### PR TITLE
feat(phase-4): MCP Server Integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -632,6 +632,7 @@ dependencies = [
  "lsp-types",
  "rmcp",
  "rstest",
+ "schemars",
  "serde",
  "serde_json",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,9 @@ serde_json = "1.0"
 thiserror = "2.0"
 anyhow = "1.0"
 
+# Schema generation
+schemars = "1.1"
+
 # CLI
 clap = { version = "4.5", features = ["derive", "env"] }
 

--- a/crates/mcpls-core/Cargo.toml
+++ b/crates/mcpls-core/Cargo.toml
@@ -16,6 +16,7 @@ lsp-types.workspace = true
 tokio.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+schemars.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
 async-trait.workspace = true

--- a/crates/mcpls-core/src/mcp/mod.rs
+++ b/crates/mcpls-core/src/mcp/mod.rs
@@ -4,9 +4,11 @@
 //! to AI agents.
 
 mod handlers;
+mod server;
 mod tools;
 
 pub use handlers::{ToolHandler, ToolHandlers};
+pub use server::McplsServer;
 pub use tools::{
     CompletionsParams, DefinitionParams, DiagnosticsParams, DocumentSymbolsParams,
     FormatDocumentParams, HoverParams, ReferencesParams, RenameParams,

--- a/crates/mcpls-core/src/mcp/tools.rs
+++ b/crates/mcpls-core/src/mcp/tools.rs
@@ -1,9 +1,10 @@
 //! MCP tool parameter definitions.
 
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 /// Parameters for the `get_hover` tool.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct HoverParams {
     /// Absolute path to the file.
     pub file_path: String,
@@ -14,7 +15,7 @@ pub struct HoverParams {
 }
 
 /// Parameters for the `get_definition` tool.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct DefinitionParams {
     /// Absolute path to the file.
     pub file_path: String,
@@ -25,7 +26,7 @@ pub struct DefinitionParams {
 }
 
 /// Parameters for the `get_references` tool.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct ReferencesParams {
     /// Absolute path to the file.
     pub file_path: String,
@@ -39,14 +40,14 @@ pub struct ReferencesParams {
 }
 
 /// Parameters for the `get_diagnostics` tool.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct DiagnosticsParams {
     /// Absolute path to the file.
     pub file_path: String,
 }
 
 /// Parameters for the `rename_symbol` tool.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct RenameParams {
     /// Absolute path to the file.
     pub file_path: String,
@@ -59,7 +60,7 @@ pub struct RenameParams {
 }
 
 /// Parameters for the `get_completions` tool.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct CompletionsParams {
     /// Absolute path to the file.
     pub file_path: String,
@@ -72,14 +73,14 @@ pub struct CompletionsParams {
 }
 
 /// Parameters for the `get_document_symbols` tool.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct DocumentSymbolsParams {
     /// Absolute path to the file.
     pub file_path: String,
 }
 
 /// Parameters for the `format_document` tool.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct FormatDocumentParams {
     /// Absolute path to the file.
     pub file_path: String,


### PR DESCRIPTION
## Summary

Phase 4 implementation - MCP Server Integration with rmcp 0.12.0 for the mcpls MCP-to-LSP bridge.

### Features
- **rmcp Integration**: Full MCP server using rmcp 0.12.0 SDK
- **8 MCP Tools**: hover, definition, references, diagnostics, rename, completions, symbols, format
- **stdio Transport**: MCP protocol over stdin/stdout for Claude Code integration
- **Protocol V_2024_11_05**: Current MCP protocol version

### Technical Details
- `McplsServer` struct with `#[tool_router]` macro
- 8 tool methods with `#[tool]` attributes
- `ServerHandler` trait with `#[tool_handler]` macro
- `JsonSchema` derive for all parameter structs (schemars 1.1)
- Proper lock scoping for `Arc<Mutex<Translator>>`

### Testing
- 54 tests pass (9 new for server.rs)
- 80.95% coverage on server.rs
- All pre-commit checks pass (fmt, clippy, nextest, deny)

### Review Summary
- ✅ Performance Review: APPROVED (B+, 87/100)
- ✅ Security Review: APPROVED (LOW risk)
- ✅ Testing Review: APPROVED
- ✅ Code Review: APPROVED

## Test plan
- [x] `cargo +nightly fmt --check` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo nextest run` passes (54 tests)
- [x] `cargo deny check` passes