### PR TITLE
fix(lsp): prevent infinite loop on EOF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1] - 2025-12-27
+
+Patch release with bug fix and documentation improvements.
+
+### Fixed
+
+- **Infinite loop on EOF** — Fixed infinite warning loop when LSP server terminates or stdin reaches EOF. Now returns `ServerTerminated` error cleanly instead of flooding logs with "Malformed header" warnings.
+
+### Added
+
+- **Prerequisites section in README** — Added rust-analyzer installation instructions with multiple methods (rustup, Homebrew, package managers). Includes important note about "LSP server process terminated unexpectedly" error when language server is missing.
+
 ## [0.2.0] - 2025-12-27
 
 Enhanced LSP features release with 5 new MCP tools for advanced code intelligence.
@@ -276,6 +288,7 @@ Add to `~/.claude/mcp.json`:
 - Workspace auto-discovery
 - LSP server auto-detection and installation
 
-[Unreleased]: https://github.com/bug-ops/mcpls/compare/v0.2.0...HEAD
+[Unreleased]: https://github.com/bug-ops/mcpls/compare/v0.2.1...HEAD
+[0.2.1]: https://github.com/bug-ops/mcpls/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/bug-ops/mcpls/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/bug-ops/mcpls/releases/tag/v0.1.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -737,7 +737,7 @@ dependencies = [
 
 [[package]]
 name = "mcpls"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -752,7 +752,7 @@ dependencies = [
 
 [[package]]
 name = "mcpls-core"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 rust-version = "1.85"
 authors = ["Andrei G. <k05h31@gmail.com>"]
@@ -23,7 +23,7 @@ clap = "4.5"
 dirs = "6.0"
 futures = "0.3"
 lsp-types = "0.97"
-mcpls-core = { path = "crates/mcpls-core", version = "0.2.0" }
+mcpls-core = { path = "crates/mcpls-core", version = "0.2.1" }
 predicates = "3.1"
 rmcp = "0.12"
 rstest = "0.26"

--- a/README.md
+++ b/README.md
@@ -24,7 +24,26 @@ AI coding assistants are remarkably capable, but they're working blind. They see
 - **Safe refactoring** — Rename symbols with confidence, workspace-wide
 
 > [!TIP]
-> Zero configuration for Rust projects. Just install and go — rust-analyzer works out of the box.
+> Zero configuration for Rust projects. Just install mcpls and a language server — ready to go.
+
+## Prerequisites
+
+For Rust projects, install rust-analyzer:
+
+```bash
+# Via rustup (recommended)
+rustup component add rust-analyzer
+
+# Or via Homebrew (macOS)
+brew install rust-analyzer
+
+# Or via package manager (Linux)
+# Ubuntu/Debian: sudo apt install rust-analyzer
+# Arch: sudo pacman -S rust-analyzer
+```
+
+> [!IMPORTANT]
+> mcpls requires a language server to be installed. Without rust-analyzer, you'll see "LSP server process terminated unexpectedly" errors.
 
 ## Installation
 

--- a/crates/mcpls-core/src/lsp/transport.rs
+++ b/crates/mcpls-core/src/lsp/transport.rs
@@ -118,6 +118,11 @@ impl LspTransport {
             line.clear();
             self.stdout.read_line(&mut line).await?;
 
+            // EOF - stream closed
+            if line.is_empty() {
+                return Err(Error::ServerTerminated);
+            }
+
             if line == "\r\n" || line == "\n" {
                 break;
             }


### PR DESCRIPTION
## Summary

Fixes infinite warning loop when running `mcpls` manually without proper MCP input.

## Problem

When stdin reaches EOF, `read_line` returns an empty string `""`. The header parsing loop only checked for `"\r\n"` or `"\n"` to break, so empty string caused:

```
WARN mcpls_core::lsp::transport: Malformed header:
WARN mcpls_core::lsp::transport: Malformed header:
WARN mcpls_core::lsp::transport: Malformed header:
... (infinite)
```

## Solution

Added EOF check before header parsing:

```rust
if line.is_empty() {
    return Err(Error::ServerTerminated);
}
```

## Test plan

- [x] `cargo nextest run` — 105 tests pass
- [x] `cargo clippy` — no warnings