### PR TITLE
chore(release): prepare v0.2.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,10 +31,10 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@nightly
         with:
           components: rustfmt
-      - run: cargo fmt --all -- --check
+      - run: cargo +nightly fmt --all -- --check
 
   clippy:
     name: Clippy
@@ -70,7 +70,8 @@ jobs:
         with:
           toolchain: ${{ matrix.rust }}
       - uses: Swatinem/rust-cache@v2
-      - run: cargo test --all-features
+      - uses: taiki-e/install-action@nextest
+      - run: cargo nextest run --all-features
 
   docs:
     name: Documentation
@@ -109,5 +110,6 @@ jobs:
       - run: cargo llvm-cov --all-features --lcov --output-path lcov.info
       - uses: codecov/codecov-action@v5
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: lcov.info
           fail_ci_if_error: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.2] - 2025-12-27
+
+Patch release with critical bug fixes for LSP server process management.
+
+### Fixed
+
+- **LSP child process lifetime** — Fixed critical bug where the LSP server process (rust-analyzer) was killed immediately after initialization. The `tokio::process::Child` handle was not being stored, causing `kill_on_drop` to terminate the process. Now the server process stays alive for the lifetime of the MCP session.
+
+- **Absolute workspace path** — Fixed workspace path resolution to use absolute paths with canonicalization. Previously, when no workspace roots were configured, a relative path `"."` was used which resulted in invalid `file://.` URI that rust-analyzer couldn't handle.
+
+### Added
+
+- **Codecov badge** — Added code coverage badge to README with Codecov integration.
+
+### Changed
+
+- **CI workflow** — Fixed codecov upload by adding token for protected branches.
+- **Test runner** — Switched from `cargo test` to `cargo nextest run` in CI and documentation for faster test execution.
+
 ## [0.2.1] - 2025-12-27
 
 Patch release with bug fix and documentation improvements.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,6 +11,7 @@ This project follows the [Rust Code of Conduct](https://www.rust-lang.org/polici
 ### Prerequisites
 
 - Rust 1.85+ (Edition 2024)
+- [cargo-nextest](https://nexte.st/) for running tests: `cargo install cargo-nextest`
 - A language server for testing (e.g., rust-analyzer)
 
 ### Setting Up Development Environment
@@ -28,12 +29,12 @@ This project follows the [Rust Code of Conduct](https://www.rust-lang.org/polici
 
 3. Run tests:
    ```bash
-   cargo test
+   cargo nextest run
    ```
 
 4. Run clippy:
    ```bash
-   cargo clippy --all-targets --all-features
+   cargo clippy --all-targets --all-features -- -D warnings
    ```
 
 ## Development Workflow
@@ -70,9 +71,9 @@ docs(readme): add pyright configuration example
 
 1. Create a feature branch from `main`
 2. Make your changes with clear, focused commits
-3. Ensure all tests pass: `cargo test`
-4. Ensure clippy is happy: `cargo clippy --all-targets`
-5. Ensure code is formatted: `cargo fmt --check`
+3. Ensure all tests pass: `cargo nextest run`
+4. Ensure clippy is happy: `cargo clippy --all-targets --all-features -- -D warnings`
+5. Ensure code is formatted: `cargo +nightly fmt --check`
 6. Update documentation if needed
 7. Submit a pull request
 
@@ -82,7 +83,7 @@ docs(readme): add pyright configuration example
 - [ ] Documentation updated
 - [ ] CHANGELOG.md updated (for user-facing changes)
 - [ ] No clippy warnings
-- [ ] Code formatted with `cargo fmt`
+- [ ] Code formatted with `cargo +nightly fmt`
 
 ## Project Structure
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -737,7 +737,7 @@ dependencies = [
 
 [[package]]
 name = "mcpls"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -752,7 +752,7 @@ dependencies = [
 
 [[package]]
 name = "mcpls-core"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.2.1"
+version = "0.2.2"
 edition = "2024"
 rust-version = "1.85"
 authors = ["Andrei G. <k05h31@gmail.com>"]
@@ -23,7 +23,7 @@ clap = "4.5"
 dirs = "6.0"
 futures = "0.3"
 lsp-types = "0.97"
-mcpls-core = { path = "crates/mcpls-core", version = "0.2.1" }
+mcpls-core = { path = "crates/mcpls-core", version = "0.2.2" }
 predicates = "3.1"
 rmcp = "0.12"
 rstest = "0.26"


### PR DESCRIPTION
## Summary

Prepare release v0.2.2 with critical bug fixes for LSP server process management.

## Changes since v0.2.1

### Fixed

- **LSP child process lifetime** (#17) — Fixed critical bug where the LSP server process was killed immediately after initialization
- **Absolute workspace path** (#16) — Fixed workspace path resolution to use absolute paths with canonicalization

### Added

- **Codecov badge** — Added code coverage badge to README

## Checklist

- [x] Version bumped to 0.2.2
- [x] CHANGELOG.md updated
- [x] All tests pass
- [x] Clippy clean