### PR TITLE
test(core): improve test coverage from 74.34% to 77.51%

### DIFF
--- a/crates/mcpls-cli/src/args.rs
+++ b/crates/mcpls-cli/src/args.rs
@@ -52,8 +52,112 @@ mod tests {
     }
 
     #[test]
+    fn test_config_short_flag() {
+        let args = Args::parse_from(["mcpls", "-c", "/path/to/config.toml"]);
+        assert_eq!(
+            args.config,
+            Some(PathBuf::from("/path/to/config.toml")),
+            "Short flag -c should work for config"
+        );
+    }
+
+    #[test]
     fn test_log_level_arg() {
         let args = Args::parse_from(["mcpls", "--log-level", "debug"]);
         assert_eq!(args.log_level, "debug");
+    }
+
+    #[test]
+    fn test_log_level_short_flag() {
+        let args = Args::parse_from(["mcpls", "-l", "trace"]);
+        assert_eq!(
+            args.log_level, "trace",
+            "Short flag -l should work for log-level"
+        );
+    }
+
+    #[test]
+    fn test_log_level_all_valid_values() {
+        let valid_levels = ["trace", "debug", "info", "warn", "error"];
+
+        for level in &valid_levels {
+            let args = Args::parse_from(["mcpls", "--log-level", level]);
+            assert_eq!(
+                args.log_level, *level,
+                "Log level {level} should be accepted"
+            );
+        }
+    }
+
+    #[test]
+    fn test_log_json_flag() {
+        let args = Args::parse_from(["mcpls", "--log-json"]);
+        assert!(args.log_json, "Flag --log-json should enable JSON logging");
+        assert_eq!(
+            args.log_level, "info",
+            "Default log level should still be info"
+        );
+    }
+
+    #[test]
+    fn test_log_json_default_false() {
+        let args = Args::parse_from(["mcpls"]);
+        assert!(!args.log_json, "JSON logging should be disabled by default");
+    }
+
+    #[test]
+    fn test_all_args_combined() {
+        let args = Args::parse_from([
+            "mcpls",
+            "--config",
+            "/custom/config.toml",
+            "--log-level",
+            "debug",
+            "--log-json",
+        ]);
+
+        assert_eq!(args.config, Some(PathBuf::from("/custom/config.toml")));
+        assert_eq!(args.log_level, "debug");
+        assert!(args.log_json);
+    }
+
+    #[test]
+    fn test_config_with_relative_path() {
+        let args = Args::parse_from(["mcpls", "--config", "./mcpls.toml"]);
+        assert_eq!(args.config, Some(PathBuf::from("./mcpls.toml")));
+    }
+
+    #[test]
+    fn test_config_with_home_path() {
+        let args = Args::parse_from(["mcpls", "--config", "~/.config/mcpls/mcpls.toml"]);
+        assert_eq!(
+            args.config,
+            Some(PathBuf::from("~/.config/mcpls/mcpls.toml"))
+        );
+    }
+
+    #[test]
+    fn test_log_level_case_sensitive() {
+        let args = Args::parse_from(["mcpls", "--log-level", "DEBUG"]);
+        assert_eq!(
+            args.log_level, "DEBUG",
+            "Log level should preserve case (validation happens later)"
+        );
+    }
+
+    #[test]
+    fn test_args_with_mixed_short_long_flags() {
+        let args = Args::parse_from([
+            "mcpls",
+            "-c",
+            "/path/to/config.toml",
+            "-l",
+            "warn",
+            "--log-json",
+        ]);
+
+        assert_eq!(args.config, Some(PathBuf::from("/path/to/config.toml")));
+        assert_eq!(args.log_level, "warn");
+        assert!(args.log_json);
     }
 }

--- a/crates/mcpls-cli/src/logging.rs
+++ b/crates/mcpls-cli/src/logging.rs
@@ -31,3 +31,119 @@ pub fn init(level: &str) -> Result<()> {
 
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_init_with_valid_trace_level() {
+        let result = init("trace");
+        assert!(
+            result.is_ok(),
+            "Should initialize successfully with trace level"
+        );
+    }
+
+    #[test]
+    fn test_init_with_valid_debug_level() {
+        let result = init("debug");
+        assert!(
+            result.is_ok(),
+            "Should initialize successfully with debug level"
+        );
+    }
+
+    #[test]
+    fn test_init_with_valid_info_level() {
+        let result = init("info");
+        assert!(
+            result.is_ok(),
+            "Should initialize successfully with info level"
+        );
+    }
+
+    #[test]
+    fn test_init_with_valid_warn_level() {
+        let result = init("warn");
+        assert!(
+            result.is_ok(),
+            "Should initialize successfully with warn level"
+        );
+    }
+
+    #[test]
+    fn test_init_with_valid_error_level() {
+        let result = init("error");
+        assert!(
+            result.is_ok(),
+            "Should initialize successfully with error level"
+        );
+    }
+
+    #[test]
+    fn test_init_with_invalid_level_falls_back_to_info() {
+        let result = init("invalid_log_level");
+        assert!(
+            result.is_ok(),
+            "Should fall back to info level for invalid input"
+        );
+    }
+
+    #[test]
+    fn test_init_with_empty_string_falls_back_to_info() {
+        let result = init("");
+        assert!(
+            result.is_ok(),
+            "Should fall back to info level for empty string"
+        );
+    }
+
+    #[test]
+    fn test_init_with_crate_specific_filter() {
+        let result = init("mcpls=debug,info");
+        assert!(
+            result.is_ok(),
+            "Should support crate-specific filter syntax"
+        );
+    }
+
+    #[test]
+    fn test_init_with_module_specific_filter() {
+        let result = init("mcpls::logging=trace");
+        assert!(
+            result.is_ok(),
+            "Should support module-specific filter syntax"
+        );
+    }
+
+    #[test]
+    fn test_init_idempotent() {
+        let result1 = init("debug");
+        assert!(result1.is_ok(), "First initialization should succeed");
+
+        let result2 = init("info");
+        assert!(
+            result2.is_ok(),
+            "Second initialization should succeed (ignored)"
+        );
+    }
+
+    #[test]
+    fn test_init_with_uppercase_level() {
+        let result = init("DEBUG");
+        assert!(
+            result.is_ok(),
+            "Should handle uppercase log levels (fallback to info if not recognized)"
+        );
+    }
+
+    #[test]
+    fn test_init_with_numeric_level() {
+        let result = init("3");
+        assert!(
+            result.is_ok(),
+            "Should handle numeric levels or fall back to info"
+        );
+    }
+}

--- a/crates/mcpls-cli/tests/cli_integration.rs
+++ b/crates/mcpls-cli/tests/cli_integration.rs
@@ -1,0 +1,125 @@
+//! Integration tests for the mcpls CLI binary.
+
+#![allow(clippy::unwrap_used)]
+#![allow(deprecated)]
+
+use std::fs;
+use std::process::Command;
+
+use assert_cmd::prelude::*;
+use predicates::prelude::*;
+use tempfile::TempDir;
+
+#[test]
+fn test_help_flag() {
+    let mut cmd = Command::cargo_bin("mcpls").unwrap();
+
+    cmd.arg("--help")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("--config"));
+}
+
+#[test]
+fn test_version_flag() {
+    let mut cmd = Command::cargo_bin("mcpls").unwrap();
+
+    cmd.arg("--version")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(env!("CARGO_PKG_VERSION")));
+}
+
+#[test]
+fn test_version_short_flag() {
+    let mut cmd = Command::cargo_bin("mcpls").unwrap();
+
+    cmd.arg("-V")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(env!("CARGO_PKG_VERSION")));
+}
+
+#[test]
+fn test_help_short_flag() {
+    let mut cmd = Command::cargo_bin("mcpls").unwrap();
+
+    cmd.arg("-h")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("--config"));
+}
+
+#[test]
+fn test_invalid_flag() {
+    let mut cmd = Command::cargo_bin("mcpls").unwrap();
+
+    cmd.arg("--invalid-flag")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("unexpected argument"));
+}
+
+#[test]
+fn test_config_file_not_found() {
+    let mut cmd = Command::cargo_bin("mcpls").unwrap();
+
+    cmd.arg("--config")
+        .arg("/nonexistent/path/to/config.toml")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("failed to load config"));
+}
+
+#[test]
+fn test_config_with_invalid_toml() {
+    let temp_dir = TempDir::new().unwrap();
+    let config_path = temp_dir.path().join("invalid.toml");
+
+    fs::write(&config_path, "this is not valid TOML {{{{").unwrap();
+
+    let mut cmd = Command::cargo_bin("mcpls").unwrap();
+
+    cmd.arg("--config")
+        .arg(&config_path)
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("failed to load config"));
+}
+
+#[test]
+fn test_config_short_flag() {
+    let mut cmd = Command::cargo_bin("mcpls").unwrap();
+
+    cmd.arg("-c")
+        .arg("/nonexistent/config.toml")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("failed to load config"));
+}
+
+#[test]
+fn test_config_with_empty_file() {
+    let temp_dir = TempDir::new().unwrap();
+    let config_path = temp_dir.path().join("empty.toml");
+
+    fs::write(&config_path, "").unwrap();
+
+    let mut cmd = Command::cargo_bin("mcpls").unwrap();
+
+    cmd.arg("--config").arg(&config_path).assert().failure();
+}
+
+#[test]
+fn test_config_file_with_spaces_in_path() {
+    let temp_dir = TempDir::new().unwrap();
+    let subdir = temp_dir.path().join("path with spaces");
+    fs::create_dir(&subdir).unwrap();
+    let config_path = subdir.join("config.toml");
+
+    fs::write(&config_path, "invalid content").unwrap();
+
+    let mut cmd = Command::cargo_bin("mcpls").unwrap();
+
+    cmd.arg("--config").arg(&config_path).assert().failure();
+}


### PR DESCRIPTION
## Summary

- Added **78 new tests** across 7 core modules
- Improved overall test coverage from **74.34%** to **77.51%** (+3.17%)
- Total test count increased from 157 to 235

### Coverage Improvements by Module

| Module | Before | After | Change |
|--------|--------|-------|--------|
| bridge/state.rs | 74.93% | 92.57% | +17.64% |
| lib.rs | 36.62% | 67.15% | +30.53% |
| lsp/lifecycle.rs | 6.70% | 50.49% | +43.79% |
| config/mod.rs | - | ~60% | New tests |
| config/server.rs | - | ~40% | New tests |
| lsp/client.rs | - | ~70% | New tests |
| lsp/transport.rs | - | ~45% | New tests |

### Test Categories Added

- **Document Tracking** (19 tests): Resource limits, language detection, Unicode content, concurrent access
- **Configuration** (16 tests): Config loading, defaults, validation, edge cases
- **Workspace Roots** (12 tests): Path resolution, relative/absolute paths, Unicode
- **LSP Lifecycle** (13 tests): ServerState transitions, initialization configs
- **LSP Client** (10 tests): Clone behavior, error handling, concurrent operations
- **LSP Transport** (8 tests): Header parsing edge cases, malformed input

### Code Changes

- Fixed `WorkspaceConfig::default()` to properly call `default_position_encodings()`
- Added `Eq` derive to `DocumentState` for test assertions
- Added `#[allow(clippy::redundant_clone)]` for test-specific clones

## Test plan

- [x] All 235 tests pass (`cargo nextest run`)
- [x] Clippy clean (`cargo clippy --all-targets --all-features -- -D warnings`)
- [x] Format check passes (`cargo +nightly fmt --check`)