### PR TITLE
feat(mcp): add status tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Shorter tool descriptions** — Condensed MCP tool descriptions for better compatibility with AI agent context windows
+
 ## [0.3.0] - 2025-12-28
 
 Major feature release adding LSP notification handling and 3 new MCP tools for real-time diagnostics and server monitoring.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `get_server_status` — New MCP tool showing registered LSP servers and their status (ready/initializing/etc.), with document counts per language
+
 ### Changed
 
 - **Shorter tool descriptions** — Condensed MCP tool descriptions for better compatibility with AI agent context windows

--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ Claude: [get_references] Found 4 matches:
 
 | Tool | What it does |
 |------|--------------|
+| `get_server_status` | Show registered LSP servers and their status |
 | `get_server_logs` | Debug LSP issues with internal log messages |
 | `get_server_messages` | User-facing messages from the language server |
 

--- a/crates/mcpls-core/src/bridge/state.rs
+++ b/crates/mcpls-core/src/bridge/state.rs
@@ -96,6 +96,12 @@ impl DocumentTracker {
         self.documents.is_empty()
     }
 
+    /// Get all tracked documents.
+    #[must_use]
+    pub const fn documents(&self) -> &HashMap<PathBuf, DocumentState> {
+        &self.documents
+    }
+
     /// Open a document and track its state.
     ///
     /// Returns the document URI for use in LSP requests.
@@ -640,5 +646,41 @@ mod tests {
         let over_size_content = "x".repeat(101);
         let result = tracker.open(PathBuf::from("/test/over.rs"), over_size_content);
         assert!(matches!(result, Err(Error::FileSizeLimitExceeded { .. })));
+    }
+
+    #[test]
+    fn test_documents_accessor_returns_empty_map_for_new_tracker() {
+        let tracker = DocumentTracker::new();
+        let docs = tracker.documents();
+        assert!(docs.is_empty());
+    }
+
+    #[test]
+    fn test_documents_accessor_returns_all_open_documents() {
+        let mut tracker = DocumentTracker::new();
+        let path1 = PathBuf::from("/test/file1.rs");
+        let path2 = PathBuf::from("/test/file2.rs");
+
+        tracker.open(path1.clone(), "content1".to_string()).unwrap();
+        tracker.open(path2.clone(), "content2".to_string()).unwrap();
+
+        let docs = tracker.documents();
+        assert_eq!(docs.len(), 2);
+        assert!(docs.contains_key(&path1));
+        assert!(docs.contains_key(&path2));
+    }
+
+    #[test]
+    fn test_documents_accessor_reflects_document_state() {
+        let mut tracker = DocumentTracker::new();
+        let path = PathBuf::from("/test/file.rs");
+
+        tracker.open(path.clone(), "initial".to_string()).unwrap();
+        tracker.update(&path, "updated".to_string());
+
+        let docs = tracker.documents();
+        let state = docs.get(&path).unwrap();
+        assert_eq!(state.content, "updated");
+        assert_eq!(state.version, 2);
     }
 }

--- a/crates/mcpls-core/src/bridge/translator.rs
+++ b/crates/mcpls-core/src/bridge/translator.rs
@@ -422,6 +422,8 @@ pub struct ServerStatusResult {
     pub servers: Vec<LspServerStatus>,
     /// Total number of servers.
     pub total_servers: usize,
+    /// Total number of tracked documents across all servers.
+    pub document_count: usize,
 }
 
 /// Maximum allowed position value for validation.
@@ -1483,9 +1485,11 @@ impl Translator {
         }
 
         let total_servers = servers.len();
+        let document_count = self.document_tracker.documents().len();
         Ok(ServerStatusResult {
             servers,
             total_servers,
+            document_count,
         })
     }
 }
@@ -2794,6 +2798,7 @@ mod tests {
         let result = ServerStatusResult {
             servers: vec![server1, server2],
             total_servers: 2,
+            document_count: 0,
         };
 
         assert_eq!(result.servers.len(), 2);
@@ -2807,6 +2812,7 @@ mod tests {
         let result = ServerStatusResult {
             servers: vec![],
             total_servers: 0,
+            document_count: 0,
         };
 
         let json = serde_json::to_string(&result).unwrap();
@@ -2825,6 +2831,7 @@ mod tests {
         let result = ServerStatusResult {
             servers: vec![server],
             total_servers: 1,
+            document_count: 3,
         };
 
         let json = serde_json::to_string(&result).unwrap();
@@ -2835,10 +2842,11 @@ mod tests {
 
     #[test]
     fn test_server_status_result_json_deserialization() {
-        let json = r#"{"servers":[{"language_id":"go","status":"uninitialized","command":"gopls","document_count":0}],"total_servers":1}"#;
+        let json = r#"{"servers":[{"language_id":"go","status":"uninitialized","command":"gopls","document_count":0}],"total_servers":1,"document_count":0}"#;
         let result: ServerStatusResult = serde_json::from_str(json).unwrap();
 
         assert_eq!(result.total_servers, 1);
+        assert_eq!(result.document_count, 0);
         assert_eq!(result.servers.len(), 1);
         assert_eq!(result.servers[0].language_id, "go");
         assert_eq!(result.servers[0].status, "uninitialized");

--- a/crates/mcpls-core/src/lsp/lifecycle.rs
+++ b/crates/mcpls-core/src/lsp/lifecycle.rs
@@ -53,6 +53,19 @@ impl ServerState {
     }
 }
 
+impl std::fmt::Display for ServerState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s = match self {
+            Self::Uninitialized => "uninitialized",
+            Self::Initializing => "initializing",
+            Self::Ready => "ready",
+            Self::ShuttingDown => "shutting_down",
+            Self::Shutdown => "shutdown",
+        };
+        write!(f, "{s}")
+    }
+}
+
 /// Configuration for LSP server initialization.
 #[derive(Debug, Clone)]
 pub struct ServerInitConfig {
@@ -347,6 +360,31 @@ mod tests {
         let state = ServerState::Ready;
         let debug_str = format!("{state:?}");
         assert!(debug_str.contains("Ready"));
+    }
+
+    #[test]
+    fn test_server_state_display_ready() {
+        assert_eq!(format!("{}", ServerState::Ready), "ready");
+    }
+
+    #[test]
+    fn test_server_state_display_initializing() {
+        assert_eq!(format!("{}", ServerState::Initializing), "initializing");
+    }
+
+    #[test]
+    fn test_server_state_display_uninitialized() {
+        assert_eq!(format!("{}", ServerState::Uninitialized), "uninitialized");
+    }
+
+    #[test]
+    fn test_server_state_display_shutting_down() {
+        assert_eq!(format!("{}", ServerState::ShuttingDown), "shutting_down");
+    }
+
+    #[test]
+    fn test_server_state_display_shutdown() {
+        assert_eq!(format!("{}", ServerState::Shutdown), "shutdown");
     }
 
     #[test]

--- a/crates/mcpls-core/src/mcp/server.rs
+++ b/crates/mcpls-core/src/mcp/server.rs
@@ -40,7 +40,7 @@ impl McplsServer {
 
     /// Get hover information at a position in a file.
     #[tool(
-        description = "Get hover information (type, documentation) at a position in a file. Returns type signatures, documentation comments, and inferred types for the symbol under cursor. Use this to understand what a variable, function, or type represents without navigating to its definition."
+        description = "Type and documentation info at position. Returns signatures, docs, and inferred types for symbols."
     )]
     async fn get_hover(
         &self,
@@ -64,7 +64,7 @@ impl McplsServer {
 
     /// Get the definition location of a symbol.
     #[tool(
-        description = "Get the definition location of a symbol at the specified position. Returns file path, line, and character where the symbol (function, variable, type, etc.) is defined. Use this to navigate from a symbol usage to its original declaration or implementation."
+        description = "Definition location of symbol at position. Returns file path, line, and character where declared."
     )]
     async fn get_definition(
         &self,
@@ -90,7 +90,7 @@ impl McplsServer {
 
     /// Find all references to a symbol.
     #[tool(
-        description = "Find all references to a symbol at the specified position. Returns a list of all locations (file, line, character) where the symbol is used across the workspace. Use this to understand how widely a function/variable/type is used before refactoring, or to find all call sites of a function."
+        description = "All references to symbol at position. Returns locations across workspace where symbol is used."
     )]
     async fn get_references(
         &self,
@@ -117,7 +117,7 @@ impl McplsServer {
 
     /// Get diagnostics for a file.
     #[tool(
-        description = "Get diagnostics (errors, warnings) for a file. Triggers language server analysis and returns compilation errors, warnings, hints, and other issues with severity, message, and location. Use this to check code for problems before running or after making changes."
+        description = "Diagnostics for a file. Returns errors, warnings, and hints with severity and location."
     )]
     async fn get_diagnostics(
         &self,
@@ -137,7 +137,7 @@ impl McplsServer {
 
     /// Rename a symbol across the workspace.
     #[tool(
-        description = "Rename a symbol across the workspace. Returns a list of text edits to apply across all files where the symbol is used. This is a safe refactoring operation that updates the symbol name consistently in declarations, usages, imports, and documentation. Use this instead of find-and-replace for reliable renaming."
+        description = "Rename symbol across workspace. Returns text edits for all files where symbol is used."
     )]
     async fn rename_symbol(
         &self,
@@ -164,7 +164,7 @@ impl McplsServer {
 
     /// Get code completion suggestions.
     #[tool(
-        description = "Get code completion suggestions at a position in a file. Returns available completions including methods, functions, variables, types, keywords, and snippets with their documentation and type information. Use after typing a dot, colon, or partial identifier to see what can be inserted."
+        description = "Completion suggestions at position. Returns methods, functions, variables, types, and snippets."
     )]
     async fn get_completions(
         &self,
@@ -191,7 +191,7 @@ impl McplsServer {
 
     /// Get all symbols in a document.
     #[tool(
-        description = "Get all symbols (functions, classes, variables) in a document. Returns a hierarchical outline of the file including functions, methods, classes, structs, enums, constants, and their locations. Use this to understand file structure, navigate to specific symbols, or get an overview of what a file contains."
+        description = "Symbols in a file. Returns hierarchical outline with functions, classes, structs, and locations."
     )]
     async fn get_document_symbols(
         &self,
@@ -211,7 +211,7 @@ impl McplsServer {
 
     /// Format a document according to language server rules.
     #[tool(
-        description = "Format a document according to the language server's formatting rules. Returns a list of text edits to apply for proper indentation, spacing, and style. The formatting follows language-specific conventions (rustfmt for Rust, prettier for JS/TS, etc.). Use this to automatically fix code style issues."
+        description = "Format document with language-specific rules. Returns text edits for indentation, spacing, and style."
     )]
     async fn format_document(
         &self,
@@ -237,7 +237,7 @@ impl McplsServer {
 
     /// Search for symbols across the workspace.
     #[tool(
-        description = "Search for symbols across the entire workspace by name or pattern. Supports partial matching and fuzzy search to find functions, types, constants, etc. by name without knowing their exact location. Use this when you know the name of something but not which file it's in, or to discover related symbols."
+        description = "Search workspace symbols by name. Supports partial matching and fuzzy search."
     )]
     async fn workspace_symbol_search(
         &self,
@@ -263,7 +263,7 @@ impl McplsServer {
 
     /// Get code actions for a range.
     #[tool(
-        description = "Get available code actions (quick fixes, refactorings) for a range in a file. Returns suggested fixes for diagnostics, refactoring options (extract function, inline variable), and source actions (organize imports, generate code). Each action includes edits to apply. Use this to get IDE-style automated fixes and refactorings."
+        description = "Code actions for range. Returns quick fixes, refactorings, and source actions with edits."
     )]
     async fn get_code_actions(
         &self,
@@ -299,7 +299,7 @@ impl McplsServer {
 
     /// Prepare call hierarchy at a position.
     #[tool(
-        description = "Prepare call hierarchy at a position, returns callable items. This is the first step for analyzing function call relationships. Returns a call hierarchy item that can be passed to get_incoming_calls or get_outgoing_calls. Use this on a function to start exploring its callers or callees."
+        description = "Prepare call hierarchy at position. Returns callable items for incoming/outgoing call analysis."
     )]
     async fn prepare_call_hierarchy(
         &self,
@@ -325,7 +325,7 @@ impl McplsServer {
 
     /// Get incoming calls (callers).
     #[tool(
-        description = "Get functions that call the specified item (callers). Takes a call hierarchy item from prepare_call_hierarchy and returns all functions/methods that call it. Use this to trace backwards through the call graph and understand how a function is invoked and from where."
+        description = "Functions calling the specified item. Takes call hierarchy item, returns all callers."
     )]
     async fn get_incoming_calls(
         &self,
@@ -345,7 +345,7 @@ impl McplsServer {
 
     /// Get outgoing calls (callees).
     #[tool(
-        description = "Get functions called by the specified item (callees). Takes a call hierarchy item from prepare_call_hierarchy and returns all functions/methods it calls. Use this to trace forward through the call graph and understand what dependencies a function has."
+        description = "Functions called by the specified item. Takes call hierarchy item, returns all callees."
     )]
     async fn get_outgoing_calls(
         &self,
@@ -365,7 +365,7 @@ impl McplsServer {
 
     /// Get cached diagnostics for a file.
     #[tool(
-        description = "Get cached diagnostics for a file from LSP server notifications. Returns diagnostics that were pushed by the language server (rather than requested on-demand). This is faster than get_diagnostics as it uses cached data. Use this to quickly check recent errors/warnings without triggering new analysis."
+        description = "Cached diagnostics from server notifications. Faster than get_diagnostics, no new analysis."
     )]
     async fn get_cached_diagnostics(
         &self,
@@ -385,7 +385,7 @@ impl McplsServer {
 
     /// Get recent LSP server log messages.
     #[tool(
-        description = "Get recent LSP server log messages with optional level filtering. Returns internal log messages from the language server for debugging LSP issues. Filter by level (error, warning, info, debug) to focus on relevant messages. Use this to diagnose why the language server might not be working correctly."
+        description = "Recent server log messages. Filter by level (error, warning, info, debug) for debugging."
     )]
     async fn get_server_logs(
         &self,
@@ -405,7 +405,7 @@ impl McplsServer {
 
     /// Get recent LSP server messages.
     #[tool(
-        description = "Get recent LSP server messages (showMessage notifications). Returns user-facing messages from the language server like prompts, warnings, and status updates that would normally appear in IDE popups. Use this to see important messages the language server wanted to communicate."
+        description = "Recent server messages (showMessage notifications). User-facing prompts and status updates."
     )]
     async fn get_server_messages(
         &self,

--- a/crates/mcpls-core/src/mcp/tools.rs
+++ b/crates/mcpls-core/src/mcp/tools.rs
@@ -249,3 +249,70 @@ pub struct ServerMessagesParams {
 const fn default_message_limit() -> usize {
     20
 }
+
+/// Parameters for the `get_server_status` tool.
+#[derive(Debug, Clone, Default, Serialize, JsonSchema)]
+#[schemars(description = "Parameters for getting the current status of all LSP servers.")]
+pub struct ServerStatusParams {}
+
+impl<'de> Deserialize<'de> for ServerStatusParams {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        // Accept both null and {} as valid empty params
+        let value = Option::<serde_json::Value>::deserialize(deserializer)?;
+        match value {
+            None | Some(serde_json::Value::Object(_) | serde_json::Value::Null) => {
+                Ok(Self {})
+            }
+            Some(_) => Err(serde::de::Error::custom(
+                "expected null or object for ServerStatusParams",
+            )),
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn server_status_params_can_be_created() {
+        let _params = ServerStatusParams {};
+    }
+
+    #[test]
+    fn server_status_params_serializes_to_empty_object() {
+        let params = ServerStatusParams {};
+        let json = serde_json::to_string(&params).unwrap();
+        assert_eq!(json, "{}");
+    }
+
+    #[test]
+    fn server_status_params_deserializes_from_empty_object() {
+        let params: ServerStatusParams = serde_json::from_str("{}").unwrap();
+        let _ = params;
+    }
+
+    #[test]
+    fn server_status_params_deserializes_from_null() {
+        let params: ServerStatusParams = serde_json::from_str("null").unwrap();
+        let _ = params;
+    }
+
+    #[test]
+    fn server_status_params_implements_debug() {
+        let params = ServerStatusParams {};
+        let debug_str = format!("{:?}", params);
+        assert!(debug_str.contains("ServerStatusParams"));
+    }
+
+    #[test]
+    fn server_status_params_implements_clone() {
+        let params = ServerStatusParams {};
+        let cloned = params.clone();
+        let _ = cloned;
+    }
+}

--- a/docs/user-guide/tools-reference.md
+++ b/docs/user-guide/tools-reference.md
@@ -1,6 +1,6 @@
 # MCP Tools Reference
 
-Complete reference for all 16 MCP tools provided by mcpls.
+Complete reference for all 17 MCP tools provided by mcpls.
 
 ## Overview
 
@@ -46,6 +46,7 @@ mcpls exposes semantic code intelligence from Language Server Protocol (LSP) ser
 
 | Tool | Description |
 |------|-------------|
+| [get_server_status](#get_server_status) | Get registered LSP servers and their status |
 | [get_server_logs](#get_server_logs) | Get LSP server log messages |
 | [get_server_messages](#get_server_messages) | Get LSP server show messages |
 
@@ -810,6 +811,76 @@ Get diagnostics from LSP server push notifications (cached).
 - Returns diagnostics pushed by LSP server via `textDocument/publishDiagnostics`
 - More efficient than `get_diagnostics` as it uses cached data
 - May be empty if file hasn't been analyzed yet
+
+---
+
+## get_server_status
+
+Get the status of all registered LSP servers.
+
+### Parameters
+
+```json
+{}
+```
+
+No parameters required.
+
+### Returns
+
+```json
+{
+  "servers": [
+    {
+      "language_id": "rust",
+      "status": "ready",
+      "command": "rust-analyzer",
+      "document_count": 5
+    },
+    {
+      "language_id": "python",
+      "status": "initializing",
+      "command": "pyright-langserver",
+      "document_count": 0
+    }
+  ],
+  "total_servers": 2,
+  "document_count": 5
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `servers` | array | List of registered LSP servers |
+| `servers[].language_id` | string | Language identifier (rust, python, etc.) |
+| `servers[].status` | string | Server state: ready, initializing, uninitialized, shutting_down, shutdown |
+| `servers[].command` | string | Server command (e.g., rust-analyzer) |
+| `servers[].document_count` | integer | Number of open documents for this language |
+| `total_servers` | integer | Total number of registered servers |
+| `document_count` | integer | Total documents across all servers |
+
+### Example Use Cases
+
+**Check server health:**
+```
+User: Which language servers are running?
+Claude: [Uses get_server_status] 2 servers registered:
+        - rust: ready (rust-analyzer, 5 documents)
+        - python: initializing (pyright-langserver)
+```
+
+**Debug initialization:**
+```
+User: Why isn't completion working for Python files?
+Claude: [Uses get_server_status] The Python server is still initializing.
+        Wait a moment for it to become ready.
+```
+
+### Notes
+
+- Returns empty `servers` array if no LSP servers are configured
+- Status values are always lowercase strings
+- Document count reflects currently open/tracked documents
 
 ---
 


### PR DESCRIPTION
## Description

Add `get_server_status` MCP tool that shows which LSP servers are registered and their current status. Returns JSON with server list (language_id, status, command, document_count), total server count, and total document count.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Related Issues

N/A

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guide
- [x] My code follows the project's coding style
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass
- [x] I have updated the documentation accordingly
- [x] I have updated the CHANGELOG.md (for user-facing changes)

## Additional Notes

Adds accessors for `LspClient::state()`, `LspClient::config()`, and DocumentTracker::documents()` to support status reporting. The handler is async due to `ServerState` being behind `Arc<Mutex<_>>`.
