### PR TITLE
Bump version to 0.3.1 and update documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.3.1] - 2026-01-24
 
 ### Added
+
+**Custom Language Extension Mapping** (3-phase implementation, fixes #33):
+- Configurable custom file extension-to-language ID mappings in `mcpls.toml`
+- Auto-config creation on first run with 30 sensible default language mappings (Rust, Python, TypeScript, Go, C/C++, Java, and 24 others)
+- Extension map automatically built from configuration and integrated through server initialization pipeline
+- Graceful fallback to `plaintext` language for unknown file extensions
+- Builder pattern for Translator initialization: `Translator::new().with_extensions(HashMap)`
+- Comprehensive test coverage with 4 new integration tests (317 total tests)
+- Platform-specific config paths: Linux/macOS `~/.config/mcpls/`, macOS alternative `~/Library/Application Support/`, Windows `%APPDATA%\mcpls\`
+- Default language extensions table in configuration documentation showing all 30 built-in mappings
 
 **Graceful LSP Server Degradation** (5-phase implementation, fixes #32):
 - System now continues operating even when some LSP servers fail to initialize
@@ -33,27 +43,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - No servers available: return `NoServersAvailable` error with clear message
 
 **Testing**:
-- 38 new tests covering all graceful degradation scenarios (337 total tests, up from 299)
-- Tests for empty configs, single failures, multiple failures, and edge cases
+- 38 new tests covering all graceful degradation scenarios + 4 new tests for extension mapping (317 total tests, up from 275)
+- Tests for empty configs, single failures, multiple failures, edge cases, and extension mapping scenarios
 - Tests for logging behavior and error message formatting
-- Integration tests for complete serve() function degradation
+- Integration tests for complete serve() function degradation and extension map initialization
 
-**Examples**:
-- Python developer without Rust: Server returns clear error message instead of crashing
-- Partial setup: If only some configured servers fail, system continues with available ones
-- Custom config: Users can configure only the language servers they need
+**Documentation Updates**:
+- Configuration documentation with extension mapping table and 30 built-in language mappings
+- Updated README with custom extension configuration examples
+- Added language_extensions section to TOML configuration reference
 
 ### Changed
 
+- **Language detection API** — Breaking change: `detect_language()` now requires explicit `HashMap<String, String>` parameter instead of `Option`. This enables proper extension mapping support.
+- **Error message clarity** — SEC-01: Removed redundant "No LSP servers available" prefix from error messages to reduce information disclosure
 - **Shorter tool descriptions** — Condensed MCP tool descriptions for better compatibility with AI agent context windows
 - **LSP server initialization** — Switched from fail-fast to graceful degradation strategy
 - **Error handling** — More descriptive error messages showing which servers failed and why
 - **Logging** — Added warning-level logs for partial success scenarios
-- **Documentation** — Updated lib.rs crate documentation with graceful degradation overview
+- **Documentation** — Updated lib.rs crate documentation with graceful degradation and extension mapping overview
 
 ### Fixed
 
 - **Documentation link** — Disambiguated `error` module link in crate docs (was causing `rustdoc::broken-intra-doc-links` warning)
+- **Test isolation** — Fixed test isolation issue in `test_load_does_not_overwrite_existing_config` by properly saving and restoring working directory, resolving llvm-cov coverage job failures
 
 ## [0.3.0] - 2025-12-28
 
@@ -399,7 +412,8 @@ Add to `~/.claude/mcp.json`:
 - Workspace auto-discovery
 - LSP server auto-detection and installation
 
-[Unreleased]: https://github.com/bug-ops/mcpls/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/bug-ops/mcpls/compare/v0.3.1...HEAD
+[0.3.1]: https://github.com/bug-ops/mcpls/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/bug-ops/mcpls/compare/v0.2.2...v0.3.0
 [0.2.2]: https://github.com/bug-ops/mcpls/compare/v0.2.1...v0.2.2
 [0.2.1]: https://github.com/bug-ops/mcpls/compare/v0.2.0...v0.2.1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.3.0"
+version = "0.3.1"
 edition = "2024"
 rust-version = "1.85"
 authors = ["Andrei G. <k05h31@gmail.com>"]
@@ -24,7 +24,7 @@ clap = "4.5"
 dirs = "6.0"
 futures = "0.3"
 lsp-types = "0.97"
-mcpls-core = { path = "crates/mcpls-core", version = "0.3.0" }
+mcpls-core = { path = "crates/mcpls-core", version = "0.3.1" }
 predicates = "3.1"
 rmcp = "0.13"
 rstest = "0.26"

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Add mcpls to your MCP configuration (`~/.claude/claude_desktop_config.json`):
 
 ### 2. Configure language servers (optional)
 
-For languages beyond Rust, create a configuration file:
+For languages beyond Rust, create a configuration file. mcpls auto-creates a default config with 30 language mappings on first run.
 
 **Linux/macOS:**
 ```bash
@@ -114,6 +114,11 @@ language_id = "typescript"
 command = "typescript-language-server"
 args = ["--stdio"]
 file_patterns = ["**/*.ts", "**/*.tsx"]
+
+[language_extensions]
+# Custom file extension mappings (optional)
+# Example: map .nushell files to nushell language
+# nushell = ["nushell", ".nushell", ".nu"]
 EOF
 ```
 
@@ -124,7 +129,7 @@ mkdir -p ~/Library/Application\ Support/mcpls
 ```
 
 > [!NOTE]
-> macOS users: `dirs::config_dir()` returns `~/Library/Application Support/` by default. Use that path if `~/.config/mcpls/` doesn't work.
+> macOS users: Configuration is stored in `~/Library/Application Support/mcpls/` by default. You can also use `~/.config/mcpls/` or set `$MCPLS_CONFIG` to a custom path.
 
 ### 3. Experience the difference
 
@@ -217,10 +222,15 @@ checkOnSave.command = "clippy"
 
 [lsp_servers.env]
 RUST_BACKTRACE = "1"
+
+[language_extensions]
+# Custom extension mappings (optional)
+# Format: extension_without_dot = ["language_id", ".ext1", ".ext2"]
+nushell = ["nushell", ".nu", ".nushell"]
 ```
 
 > [!NOTE]
-> See [Configuration Reference](docs/user-guide/configuration.md) for all options.
+> See [Configuration Reference](docs/user-guide/configuration.md) for all options including the 30 built-in language extension mappings.
 
 ## Supported Language Servers
 
@@ -234,6 +244,11 @@ mcpls works with any LSP 3.17 compliant server. Battle-tested with:
 | Go | gopls | Modules and workspaces |
 | C/C++ | clangd | compile_commands.json |
 | Java | jdtls | Maven/Gradle projects |
+| Nushell | nushell-lsp | Custom extension mapping |
+| And 24+ others | Any LSP 3.17 server | See [Configuration Reference](docs/user-guide/configuration.md) for full list |
+
+> [!TIP]
+> By default, mcpls includes 30 language-to-extension mappings. To add custom mappings (e.g., `.nu` → nushell), edit the `language_extensions` section in your config.
 
 ## Architecture
 

--- a/crates/mcpls-cli/README.md
+++ b/crates/mcpls-cli/README.md
@@ -28,13 +28,14 @@ mcpls --config ./mcpls.toml     # Custom config
 
 > [!NOTE]
 > Configuration auto-discovery order: `$MCPLS_CONFIG` → `./mcpls.toml` → platform config dir
+> Auto-creates default config with 30 language mappings on first run.
 
-Create `mcpls.toml` in the appropriate location:
+Create or edit `mcpls.toml` in the appropriate location:
 - **Linux/macOS:** `~/.config/mcpls/mcpls.toml`
 - **macOS (alternative):** `~/Library/Application Support/mcpls/mcpls.toml`
 - **Windows:** `%APPDATA%\mcpls\mcpls.toml`
 
-See the main [README](../../README.md) for configuration examples.
+See the main [README](../../README.md) for configuration examples and custom extension mapping.
 
 ## Options
 

--- a/crates/mcpls-core/README.md
+++ b/crates/mcpls-core/README.md
@@ -14,7 +14,8 @@ mcpls-core bridges MCP and LSP protocols, transforming AI tool calls into langua
 - **Position encoding** — Handles MCP's 1-based positions ↔ LSP's 0-based coordinates
 - **LSP lifecycle** — Manages language server processes (spawn, initialize, shutdown)
 - **Document tracking** — Lazy-loads files, maintains synchronization state
-- **Configuration** — Parses TOML configs, discovers LSP servers
+- **Configuration** — Parses TOML configs, discovers LSP servers, manages language extension mappings
+- **Custom extension mapping** — Configurable file extension-to-language ID mappings with sensible defaults
 - **Graceful degradation** — Continues with available servers, even if some fail to initialize
 
 > [!NOTE]
@@ -24,7 +25,7 @@ mcpls-core bridges MCP and LSP protocols, transforming AI tool calls into langua
 
 ```toml
 [dependencies]
-mcpls-core = "0.3"
+mcpls-core = "0.3.1"
 ```
 
 ## Architecture


### PR DESCRIPTION
## Summary
- Bump version to 0.3.1 (Cargo.toml workspace)
- Consolidate CHANGELOG with unified v0.3.1 entry
- Update README with custom language extension examples
- Update crate READMEs with extension support notes