### PR TITLE
feat(config): include all predefined LSP servers in default configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.3] - 2026-02-04
+
+### Changed
+
+- **Default configuration** — Include all 6 predefined LSP servers in `ServerConfig::default()` instead of just rust-analyzer. Servers included: rust-analyzer, pyright, typescript, gopls, clangd, zls. Heuristics ensure servers only spawn when project markers exist.
+
 ## [0.3.2] - 2026-02-03
 
 ### Added
@@ -432,7 +438,9 @@ Add to `~/.claude/mcp.json`:
 - Workspace auto-discovery
 - LSP server auto-detection and installation
 
-[Unreleased]: https://github.com/bug-ops/mcpls/compare/v0.3.1...HEAD
+[Unreleased]: https://github.com/bug-ops/mcpls/compare/v0.3.3...HEAD
+[0.3.3]: https://github.com/bug-ops/mcpls/compare/v0.3.2...v0.3.3
+[0.3.2]: https://github.com/bug-ops/mcpls/compare/v0.3.1...v0.3.2
 [0.3.1]: https://github.com/bug-ops/mcpls/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/bug-ops/mcpls/compare/v0.2.2...v0.3.0
 [0.2.2]: https://github.com/bug-ops/mcpls/compare/v0.2.1...v0.2.2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -737,7 +737,7 @@ dependencies = [
 
 [[package]]
 name = "mcpls"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -752,7 +752,7 @@ dependencies = [
 
 [[package]]
 name = "mcpls-core"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.3.2"
+version = "0.3.3"
 edition = "2024"
 rust-version = "1.85"
 authors = ["Andrei G. <k05h31@gmail.com>"]
@@ -24,7 +24,7 @@ clap = "4.5"
 dirs = "6.0"
 futures = "0.3"
 lsp-types = "0.97"
-mcpls-core = { path = "crates/mcpls-core", version = "0.3.2" }
+mcpls-core = { path = "crates/mcpls-core", version = "0.3.3" }
 predicates = "3.1"
 rmcp = "0.14"
 rstest = "0.26"

--- a/crates/mcpls-core/src/config/mod.rs
+++ b/crates/mcpls-core/src/config/mod.rs
@@ -355,7 +355,14 @@ impl Default for ServerConfig {
     fn default() -> Self {
         Self {
             workspace: WorkspaceConfig::default(),
-            lsp_servers: vec![LspServerConfig::rust_analyzer()],
+            lsp_servers: vec![
+                LspServerConfig::rust_analyzer(),
+                LspServerConfig::pyright(),
+                LspServerConfig::typescript(),
+                LspServerConfig::gopls(),
+                LspServerConfig::clangd(),
+                LspServerConfig::zls(),
+            ],
         }
     }
 }
@@ -372,8 +379,13 @@ mod tests {
     #[test]
     fn test_default_config() {
         let config = ServerConfig::default();
-        assert_eq!(config.lsp_servers.len(), 1);
+        assert_eq!(config.lsp_servers.len(), 6);
         assert_eq!(config.lsp_servers[0].language_id, "rust");
+        assert_eq!(config.lsp_servers[1].language_id, "python");
+        assert_eq!(config.lsp_servers[2].language_id, "typescript");
+        assert_eq!(config.lsp_servers[3].language_id, "go");
+        assert_eq!(config.lsp_servers[4].language_id, "cpp");
+        assert_eq!(config.lsp_servers[5].language_id, "zig");
         assert_eq!(config.workspace.position_encodings, vec!["utf-8", "utf-16"]);
     }
 
@@ -693,7 +705,7 @@ mod tests {
 
         let loaded_config = ServerConfig::load_from(&config_path).unwrap();
         assert_eq!(loaded_config.workspace.language_extensions.len(), 30);
-        assert_eq!(loaded_config.lsp_servers.len(), 1);
+        assert_eq!(loaded_config.lsp_servers.len(), 6);
         assert_eq!(loaded_config.lsp_servers[0].language_id, "rust");
     }
 
@@ -702,7 +714,7 @@ mod tests {
         // When called directly, default() should return config with all language extensions
         let config = ServerConfig::default();
         assert_eq!(config.workspace.language_extensions.len(), 30);
-        assert_eq!(config.lsp_servers.len(), 1);
+        assert_eq!(config.lsp_servers.len(), 6);
         assert_eq!(config.lsp_servers[0].language_id, "rust");
     }
 


### PR DESCRIPTION
## Summary

- Expand `ServerConfig::default()` to include all 6 predefined LSP servers instead of just rust-analyzer
- Servers included: rust-analyzer, pyright, typescript, gopls, clangd, zls

## Motivation

Previously, only rust-analyzer was in the default config. Users had to manually configure other LSP servers even though the codebase already had heuristics defined for them. This change enables zero-configuration usage for common languages.

## Changes

- Updated `impl Default for ServerConfig` to include all 6 servers
- Updated 3 tests to expect 6 servers with correct language_id ordering

## Behavior

- Heuristics ensure servers only spawn when project markers exist (e.g., pyright only spawns if `pyproject.toml`, `setup.py`, etc. are present)
- Graceful degradation if server binary is not installed

## Test plan

- [x] `cargo nextest run` - 294 passed
- [x] `cargo clippy --all-targets --all-features -- -D warnings` - passed
- [x] `cargo +nightly fmt --check` - passed