### PR TITLE
docs: address Copilot review comments from PR #50

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **Default configuration** — Include all 6 predefined LSP servers in `ServerConfig::default()` instead of just rust-analyzer. Servers included: rust-analyzer, pyright, typescript, gopls, clangd, zls. Heuristics ensure servers only spawn when project markers exist.
+- **BREAKING: `LspServerConfig::should_spawn` signature** — Method now accepts `max_depth: Option<usize>` parameter for recursive search depth control.
 
 ## [0.3.2] - 2026-02-03
 

--- a/crates/mcpls-core/src/config/server.rs
+++ b/crates/mcpls-core/src/config/server.rs
@@ -39,7 +39,11 @@ const EXCLUDED_DIRECTORIES: &[&str] = &[
 #[serde(deny_unknown_fields)]
 pub struct ServerHeuristics {
     /// Files or directories that indicate this server is applicable.
-    /// The server will spawn if ANY of these markers exist in the workspace root.
+    ///
+    /// The server will spawn if ANY of these markers exist anywhere in the workspace tree
+    /// (searched recursively up to `heuristics_max_depth`). Well-known directories like
+    /// `node_modules`, `target`, `.git` are excluded from the search.
+    ///
     /// If empty, the server will always attempt to spawn.
     #[serde(default)]
     pub project_markers: Vec<String>,


### PR DESCRIPTION
## Summary

Address Copilot code review comments from PR #50 that were missed before merge.

- Update `project_markers` documentation to describe recursive search semantics instead of "workspace root"
- Document breaking change in `should_spawn` signature in CHANGELOG

## Context

Copilot review: https://github.com/bug-ops/mcpls/pull/50#pullrequestreview-2651693515