### PR TITLE
release: v0.3.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.5] - 2026-03-17
+
+### Changed
+
+- Version bump to 0.3.5
+
 ## [0.3.4] - 2026-02-22
 
 ### Changed
@@ -456,7 +462,8 @@ Add to `~/.claude/mcp.json`:
 - Workspace auto-discovery
 - LSP server auto-detection and installation
 
-[Unreleased]: https://github.com/bug-ops/mcpls/compare/v0.3.4...HEAD
+[Unreleased]: https://github.com/bug-ops/mcpls/compare/v0.3.5...HEAD
+[0.3.5]: https://github.com/bug-ops/mcpls/compare/v0.3.4...v0.3.5
 [0.3.4]: https://github.com/bug-ops/mcpls/compare/v0.3.3...v0.3.4
 [0.3.3]: https://github.com/bug-ops/mcpls/compare/v0.3.2...v0.3.3
 [0.3.2]: https://github.com/bug-ops/mcpls/compare/v0.3.1...v0.3.2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -820,7 +820,7 @@ dependencies = [
 
 [[package]]
 name = "mcpls"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -835,7 +835,7 @@ dependencies = [
 
 [[package]]
 name = "mcpls-core"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.3.4"
+version = "0.3.5"
 edition = "2024"
 rust-version = "1.85"
 authors = ["Andrei G. <k05h31@gmail.com>"]
@@ -25,7 +25,7 @@ dirs = "6.0"
 futures = "0.3"
 ignore = "0.4"
 lsp-types = "0.97"
-mcpls-core = { path = "crates/mcpls-core", version = "0.3.4" }
+mcpls-core = { path = "crates/mcpls-core", version = "0.3.5" }
 predicates = "3.1"
 rmcp = "1.1"
 rstest = "0.26"

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # mcpls
 
-[![Crates.io](https://img.shields.io/crates/v/mcpls)](https://crates.io/crates/mcpls)
-[![docs.rs](https://img.shields.io/docsrs/mcpls-core)](https://docs.rs/mcpls-core)
+[![Crates.io](https://img.shields.io/crates/v/mcpls?label=mcpls)](https://crates.io/crates/mcpls)
+[![docs.rs](https://img.shields.io/docsrs/mcpls-core?label=mcpls-core)](https://docs.rs/mcpls-core)
 [![CI](https://img.shields.io/github/actions/workflow/status/bug-ops/mcpls/ci.yml?branch=main)](https://github.com/bug-ops/mcpls/actions)
 [![codecov](https://codecov.io/gh/bug-ops/mcpls/graph/badge.svg?token=FQEDLNF2GS)](https://codecov.io/gh/bug-ops/mcpls)
 [![MSRV](https://img.shields.io/badge/MSRV-1.85-blue)](https://blog.rust-lang.org/2025/02/20/Rust-1.85.0.html)


### PR DESCRIPTION
## Summary

- Bump version from 0.3.4 to 0.3.5
- Update CHANGELOG.md with release notes and version section
- Refresh README and documentation links
- All CI checks passing

## Checklist

- [x] Version updated in all manifests (Cargo.toml, workspace)
- [x] CHANGELOG.md has release section with date (2026-03-17)
- [x] README badges updated
- [x] All tests passing (333/333)
- [x] Pre-release checks complete

## After Merge

Create release tag with:
```bash
git tag v0.3.5
git push origin v0.3.5
```