### PR TITLE
Fix lsp_servers[].file_patterns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+
+- **C/C++ file pattern language detection** - When `lsp_servers[].file_patterns` include simple extensions such as `**/*.c` or `**/*.h`, mcpls now derives extension-to-language mappings from those patterns and overlays them onto the workspace extension map. This changes the default behavior for matching C/C++ files to prefer the configured LSP server language instead of falling back to built-in mappings or `plaintext`.
 
 ## [0.3.5] - 2026-03-17
 

--- a/crates/mcpls-core/src/bridge/translator.rs
+++ b/crates/mcpls-core/src/bridge/translator.rs
@@ -2776,7 +2776,7 @@ mod tests {
             lsp_servers: vec![],
         };
 
-        let extension_map = config.workspace.build_extension_map();
+        let extension_map = config.build_effective_extension_map();
         assert_eq!(extension_map.get("nu"), Some(&"nushell".to_string()));
         assert_eq!(extension_map.get("rs"), Some(&"rust".to_string()));
 

--- a/crates/mcpls-core/src/config/mod.rs
+++ b/crates/mcpls-core/src/config/mod.rs
@@ -126,7 +126,7 @@ fn extract_extension_from_pattern(pattern: &str) -> Option<String> {
         return None;
     }
 
-    let (_, ext) = pattern.rsplit_once('.')?;
+    let (_, ext) = basename.rsplit_once('.')?;
     if ext.is_empty() {
         return None;
     }

--- a/crates/mcpls-core/src/config/mod.rs
+++ b/crates/mcpls-core/src/config/mod.rs
@@ -121,6 +121,11 @@ impl WorkspaceConfig {
 /// Supports common patterns such as `**/*.rs` and `*.h`.
 /// Returns `None` for patterns without a simple trailing extension.
 fn extract_extension_from_pattern(pattern: &str) -> Option<String> {
+    let basename = pattern.rsplit('/').next().unwrap_or(pattern);
+    if basename.starts_with('.') {
+        return None;
+    }
+
     let (_, ext) = pattern.rsplit_once('.')?;
     if ext.is_empty() {
         return None;
@@ -694,6 +699,29 @@ mod tests {
         assert_eq!(map.get("cxx"), Some(&"cpp".to_string()));
         assert_eq!(map.get("nu"), Some(&"nushell".to_string()));
         assert_eq!(map.get("unknown"), None);
+    }
+
+    #[test]
+    fn test_extract_extension_from_pattern_empty_string() {
+        assert_eq!(extract_extension_from_pattern(""), None);
+    }
+
+    #[test]
+    fn test_extract_extension_from_pattern_without_dot() {
+        assert_eq!(extract_extension_from_pattern("**/*"), None);
+    }
+
+    #[test]
+    fn test_extract_extension_from_pattern_dotfile() {
+        assert_eq!(extract_extension_from_pattern(".gitignore"), None);
+    }
+
+    #[test]
+    fn test_extract_extension_from_pattern_multi_dot_extension() {
+        assert_eq!(
+            extract_extension_from_pattern("foo.tar.gz"),
+            Some("gz".to_string())
+        );
     }
 
     #[test]

--- a/crates/mcpls-core/src/config/mod.rs
+++ b/crates/mcpls-core/src/config/mod.rs
@@ -116,6 +116,27 @@ impl WorkspaceConfig {
     }
 }
 
+/// Extract a file extension from a glob-like file pattern.
+///
+/// Supports common patterns such as `**/*.rs` and `*.h`.
+/// Returns `None` for patterns without a simple trailing extension.
+fn extract_extension_from_pattern(pattern: &str) -> Option<String> {
+    let (_, ext) = pattern.rsplit_once('.')?;
+    if ext.is_empty() {
+        return None;
+    }
+
+    // Keep this conservative: only accept plain extension-like tokens.
+    if ext
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
+    {
+        Some(ext.to_string())
+    } else {
+        None
+    }
+}
+
 fn default_position_encodings() -> Vec<String> {
     vec!["utf-8".to_string(), "utf-16".to_string()]
 }
@@ -258,6 +279,25 @@ fn default_language_extensions() -> Vec<LanguageExtensionMapping> {
 }
 
 impl ServerConfig {
+    /// Build the effective extension map used for language detection.
+    ///
+    /// Starts with workspace mappings and overlays mappings inferred from
+    /// configured LSP server `file_patterns`.
+    #[must_use]
+    pub fn build_effective_extension_map(&self) -> HashMap<String, String> {
+        let mut map = self.workspace.build_extension_map();
+
+        for server in &self.lsp_servers {
+            for pattern in &server.file_patterns {
+                if let Some(ext) = extract_extension_from_pattern(pattern) {
+                    map.insert(ext, server.language_id.clone());
+                }
+            }
+        }
+
+        map
+    }
+
     /// Load configuration from the default path.
     ///
     /// Default paths checked in order:
@@ -654,6 +694,48 @@ mod tests {
         assert_eq!(map.get("cxx"), Some(&"cpp".to_string()));
         assert_eq!(map.get("nu"), Some(&"nushell".to_string()));
         assert_eq!(map.get("unknown"), None);
+    }
+
+    #[test]
+    fn test_build_effective_extension_map_overrides_with_file_patterns() {
+        let config = ServerConfig {
+            workspace: WorkspaceConfig::default(),
+            lsp_servers: vec![LspServerConfig {
+                language_id: "cpp".to_string(),
+                command: "clangd".to_string(),
+                args: vec![],
+                env: HashMap::new(),
+                file_patterns: vec!["**/*.c".to_string(), "**/*.h".to_string()],
+                initialization_options: None,
+                timeout_seconds: 30,
+                heuristics: None,
+            }],
+        };
+
+        let map = config.build_effective_extension_map();
+        assert_eq!(map.get("c"), Some(&"cpp".to_string()));
+        assert_eq!(map.get("h"), Some(&"cpp".to_string()));
+    }
+
+    #[test]
+    fn test_build_effective_extension_map_ignores_complex_patterns_without_extension() {
+        let config = ServerConfig {
+            workspace: WorkspaceConfig::default(),
+            lsp_servers: vec![LspServerConfig {
+                language_id: "cpp".to_string(),
+                command: "clangd".to_string(),
+                args: vec![],
+                env: HashMap::new(),
+                file_patterns: vec!["**/*".to_string(), "**/*.{h,hpp}".to_string()],
+                initialization_options: None,
+                timeout_seconds: 30,
+                heuristics: None,
+            }],
+        };
+
+        let map = config.build_effective_extension_map();
+        // Default C/C++ mappings remain unchanged when patterns cannot be parsed.
+        assert_eq!(map.get("h"), Some(&"c".to_string()));
     }
 
     #[test]

--- a/crates/mcpls-core/src/lib.rs
+++ b/crates/mcpls-core/src/lib.rs
@@ -111,7 +111,7 @@ pub async fn serve(config: ServerConfig) -> Result<(), Error> {
     info!("Starting MCPLS server...");
 
     let workspace_roots = resolve_workspace_roots(&config.workspace.roots);
-    let extension_map = config.workspace.build_extension_map();
+    let extension_map = config.build_effective_extension_map();
     let max_depth = Some(config.workspace.heuristics_max_depth);
 
     let mut translator = Translator::new().with_extensions(extension_map);


### PR DESCRIPTION
## Description

This change fixes language detection when files are matched via lsp_servers[].file_patterns (for example **/*.h, **/*.c). serve() now uses an effective extension map that merges workspace extension mappings with extensions inferred from each LSP server’s file_patterns, so C/C++ headers and sources can resolve to the configured server language instead of falling back to plaintext (or wrong defaults).

### Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

N/a

## Checklist

- [ ] I have read the CONTRIBUTING guide
- [x] My code follows the project's coding style
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass
- [ ] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md (for user-facing changes)

## Additional Notes

- Added ServerConfig::build_effective_extension_map() and wired it into serve().
- Added tests for:
    - file-pattern-derived extension overrides (.c/.h -> cpp)
    - ignoring complex patterns that do not provide a simple extension
- Verified locally with: cargo test -p mcpls-core --lib (310 passed, 0 failed).


