### PR TITLE
fix(labeler): use pull_request_target event for fork compatibility

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,7 +1,7 @@
 name: PR Labeler
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened]
 
 permissions:


### PR DESCRIPTION
## Problem
The PR Labeler workflow failed for PR #72 because it used the `pull_request` event trigger, which restricts token permissions for fork-based PRs to read-only. This caused the labeler action to fail with "Resource not accessible by integration" error.

## Solution
Changed the workflow trigger from `pull_request` to `pull_request_target`. This runs the workflow in the base repository context, granting proper write access to the token regardless of whether the PR originates from a fork.

## Changes
- `.github/workflows/labeler.yml`: Changed event trigger from `pull_request` to `pull_request_target`

## Testing
- All local checks pass: format, clippy, tests
- No breaking changes