### PR TITLE
fix: integration tests NoServerForLanguage + clippy.toml msrv sync

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -1,5 +1,5 @@
 # Clippy configuration
 # See: https://doc.rust-lang.org/clippy/configuration.html
 
-msrv = "1.85"
+msrv = "1.88"
 cognitive-complexity-threshold = 25

--- a/crates/mcpls-core/src/bridge/translator.rs
+++ b/crates/mcpls-core/src/bridge/translator.rs
@@ -441,10 +441,10 @@ impl Translator {
 
         // Check if path is within any workspace root
         for root in &self.workspace_roots {
-            if let Ok(canonical_root) = root.canonicalize() {
-                if canonical.starts_with(&canonical_root) {
-                    return Ok(canonical);
-                }
+            if let Ok(canonical_root) = root.canonicalize()
+                && canonical.starts_with(&canonical_root)
+            {
+                return Ok(canonical);
             }
         }
 
@@ -995,15 +995,14 @@ impl Translator {
         }
 
         // Validate kind filter
-        if let Some(ref kind) = kind_filter {
-            if !VALID_SYMBOL_KINDS
+        if let Some(ref kind) = kind_filter
+            && !VALID_SYMBOL_KINDS
                 .iter()
                 .any(|k| k.eq_ignore_ascii_case(kind))
-            {
-                return Err(Error::InvalidToolParams(format!(
-                    "Invalid kind_filter: '{kind}'. Valid values: {VALID_SYMBOL_KINDS:?}"
-                )));
-            }
+        {
+            return Err(Error::InvalidToolParams(format!(
+                "Invalid kind_filter: '{kind}'. Valid values: {VALID_SYMBOL_KINDS:?}"
+            )));
         }
 
         // Workspace search requires at least one LSP client
@@ -1075,15 +1074,14 @@ impl Translator {
         ];
 
         // Validate kind filter
-        if let Some(ref kind) = kind_filter {
-            if !VALID_ACTION_KINDS
+        if let Some(ref kind) = kind_filter
+            && !VALID_ACTION_KINDS
                 .iter()
                 .any(|k| k.eq_ignore_ascii_case(kind))
-            {
-                return Err(Error::InvalidToolParams(format!(
-                    "Invalid kind_filter: '{kind}'. Valid values: {VALID_ACTION_KINDS:?}"
-                )));
-            }
+        {
+            return Err(Error::InvalidToolParams(format!(
+                "Invalid kind_filter: '{kind}'. Valid values: {VALID_ACTION_KINDS:?}"
+            )));
         }
 
         // Validate range

--- a/crates/mcpls-core/src/config/server.rs
+++ b/crates/mcpls-core/src/config/server.rs
@@ -118,12 +118,11 @@ impl ServerHeuristics {
             .standard_filters(false)
             .filter_entry(|entry| {
                 // Skip excluded directories entirely (prevents descending into them)
-                if entry.file_type().is_some_and(|ft| ft.is_dir()) {
-                    if let Some(name) = entry.file_name().to_str() {
-                        if EXCLUDED_DIRECTORIES.contains(&name) {
-                            return false;
-                        }
-                    }
+                if entry.file_type().is_some_and(|ft| ft.is_dir())
+                    && let Some(name) = entry.file_name().to_str()
+                    && EXCLUDED_DIRECTORIES.contains(&name)
+                {
+                    return false;
                 }
                 true
             });
@@ -132,10 +131,10 @@ impl ServerHeuristics {
             let path = entry.path();
 
             // Check if this entry matches any marker
-            if let Some(file_name) = path.file_name().and_then(|n| n.to_str()) {
-                if self.project_markers.iter().any(|m| m == file_name) {
-                    return true;
-                }
+            if let Some(file_name) = path.file_name().and_then(|n| n.to_str())
+                && self.project_markers.iter().any(|m| m == file_name)
+            {
+                return true;
             }
         }
 

--- a/crates/mcpls-core/src/lsp/client.rs
+++ b/crates/mcpls-core/src/lsp/client.rs
@@ -620,13 +620,13 @@ mod tests {
         };
 
         let sender = pending_requests.lock().await.remove(&error_response.id);
-        if let Some(sender) = sender {
-            if let Some(error) = error_response.error {
-                let _ = sender.send(Err(Error::LspServerError {
-                    code: error.code,
-                    message: error.message,
-                }));
-            }
+        if let Some(sender) = sender
+            && let Some(error) = error_response.error
+        {
+            let _ = sender.send(Err(Error::LspServerError {
+                code: error.code,
+                message: error.message,
+            }));
         }
 
         let result = response_rx.await.unwrap();
@@ -682,13 +682,13 @@ mod tests {
         };
 
         let sender = pending_requests.lock().await.remove(&error_response.id);
-        if let Some(sender) = sender {
-            if let Some(error) = error_response.error {
-                let _ = sender.send(Err(Error::LspServerError {
-                    code: error.code,
-                    message: error.message,
-                }));
-            }
+        if let Some(sender) = sender
+            && let Some(error) = error_response.error
+        {
+            let _ = sender.send(Err(Error::LspServerError {
+                code: error.code,
+                message: error.message,
+            }));
         }
 
         let result = response_rx.await.unwrap();

--- a/crates/mcpls-core/src/lsp/lifecycle.rs
+++ b/crates/mcpls-core/src/lsp/lifecycle.rs
@@ -139,7 +139,7 @@ impl ServerInitResult {
 
     /// Get the number of failures.
     #[must_use]
-    pub fn failure_count(&self) -> usize {
+    pub const fn failure_count(&self) -> usize {
         self.failures.len()
     }
 

--- a/crates/mcpls-core/src/lsp/types.rs
+++ b/crates/mcpls-core/src/lsp/types.rs
@@ -137,10 +137,10 @@ impl LspNotification {
     pub fn parse(method: &str, params: Option<serde_json::Value>) -> Self {
         match method {
             "textDocument/publishDiagnostics" => {
-                if let Some(p) = params {
-                    if let Ok(parsed) = serde_json::from_value(p) {
-                        return Self::PublishDiagnostics(parsed);
-                    }
+                if let Some(p) = params
+                    && let Ok(parsed) = serde_json::from_value(p)
+                {
+                    return Self::PublishDiagnostics(parsed);
                 }
                 Self::Other {
                     method: Cow::Owned(method.to_string()),
@@ -148,10 +148,10 @@ impl LspNotification {
                 }
             }
             "window/logMessage" => {
-                if let Some(p) = params {
-                    if let Ok(parsed) = serde_json::from_value(p) {
-                        return Self::LogMessage(parsed);
-                    }
+                if let Some(p) = params
+                    && let Ok(parsed) = serde_json::from_value(p)
+                {
+                    return Self::LogMessage(parsed);
                 }
                 Self::Other {
                     method: Cow::Owned(method.to_string()),
@@ -159,10 +159,10 @@ impl LspNotification {
                 }
             }
             "window/showMessage" => {
-                if let Some(p) = params {
-                    if let Ok(parsed) = serde_json::from_value(p) {
-                        return Self::ShowMessage(parsed);
-                    }
+                if let Some(p) = params
+                    && let Ok(parsed) = serde_json::from_value(p)
+                {
+                    return Self::ShowMessage(parsed);
                 }
                 Self::Other {
                     method: Cow::Owned(method.to_string()),

--- a/crates/mcpls-core/tests/integration/rust_analyzer_tests.rs
+++ b/crates/mcpls-core/tests/integration/rust_analyzer_tests.rs
@@ -69,7 +69,8 @@ async fn setup_rust_analyzer() -> Arc<Mutex<Translator>> {
 
     let client = server.client().clone();
 
-    let mut translator = Translator::new();
+    let extension_map = std::collections::HashMap::from([("rs".to_string(), "rust".to_string())]);
+    let mut translator = Translator::new().with_extensions(extension_map);
     translator.set_workspace_roots(vec![workspace_path]);
     translator.register_client("rust".to_string(), client);
     translator.register_server("rust".to_string(), server);


### PR DESCRIPTION
## Summary

- Fixes 12 of 19 integration tests failing with `NoServerForLanguage("plaintext")` (#106)
- Syncs `clippy.toml` msrv from `1.85` to `1.88` to match `Cargo.toml` rust-version (#107)
- Applies let-chain flattening across `bridge`, `config`, and `lsp` modules now valid under Rust 1.88

## Changes

**`clippy.toml`**: `msrv = "1.85"` → `msrv = "1.88"`

**`tests/integration/rust_analyzer_tests.rs`**: `setup_rust_analyzer()` now chains `.with_extensions({"rs" => "rust"})` on the test `Translator`. Previously `Translator::new()` produced an empty extension map, causing `detect_language()` to return `"plaintext"` for `.rs` files — the client registered under `"rust"` was never found.

**`bridge/translator.rs`, `config/server.rs`, `lsp/client.rs`, `lsp/lifecycle.rs`, `lsp/types.rs`**: flatten nested `if let` blocks into let-chains (`if let A && let B { ... }`), valid since Rust 1.88.

## Test plan

- [ ] `cargo +nightly fmt --all -- --check` passes
- [ ] `cargo clippy --all-targets --all-features --workspace -- -D warnings` passes with no MSRV mismatch warning
- [ ] `cargo nextest run --workspace --all-features --lib --bins` — 344/344 pass
- [ ] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features` passes
- [ ] Integration tests with rust-analyzer in PATH: `cargo nextest run --workspace --all-features -- --ignored integration::rust_analyzer_tests` — all 19 should pass

Closes #106
Closes #107