### PR TITLE
fix(test): add [workspace] table to rust_workspace fixture Cargo.toml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **LSP server requests** — Handle server-to-client requests such as `client/registerCapability`, fixing tsgo timeouts.
+- **Integration tests** — Add `[workspace]` table to `tests/fixtures/rust_workspace/Cargo.toml` so cargo treats the fixture as a standalone workspace; fixes 8 rust-analyzer integration tests that failed with "Failed to load workspaces." (#118)
 
 ## [0.3.6] - 2026-04-21
 

--- a/crates/mcpls-core/tests/fixtures/rust_workspace/Cargo.toml
+++ b/crates/mcpls-core/tests/fixtures/rust_workspace/Cargo.toml
@@ -4,5 +4,7 @@ version = "0.1.0"
 edition = "2024"
 rust-version = "1.85"
 
+[workspace]
+
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
## Summary

- Adds an empty `[workspace]` table to `crates/mcpls-core/tests/fixtures/rust_workspace/Cargo.toml`
- Without it, cargo treats the fixture as a member of the parent workspace (`members = ["crates/*"]`), which excludes the fixture path, causing rust-analyzer to emit "Failed to load workspaces."

## Test plan

- [ ] `cargo nextest run --workspace --all-features --lib --bins` — all 345 tests pass
- [ ] `cargo nextest run --workspace --all-features --test integration_tests -- --ignored` with rust-analyzer in PATH — 8 previously failing tests should now pass

Closes #118