### PR TITLE
fix(test): replace fixed sleep with readiness poll in RA integration tests

### DIFF
--- a/crates/mcpls-core/src/lsp/client.rs
+++ b/crates/mcpls-core/src/lsp/client.rs
@@ -106,6 +106,7 @@ impl LspClient {
     /// Create client from transport (for testing or custom spawning).
     ///
     /// This method initializes the background message loop with the provided transport.
+    #[cfg(test)]
     pub(crate) fn from_transport(config: LspServerConfig, transport: LspTransport) -> Self {
         let state = Arc::new(Mutex::new(super::ServerState::Initializing));
         let request_counter = Arc::new(AtomicI64::new(1));
@@ -133,7 +134,6 @@ impl LspClient {
     ///
     /// Notifications received from the LSP server will be parsed and sent
     /// through the provided channel.
-    #[allow(dead_code)] // Used in Phase 4
     pub(crate) fn from_transport_with_notifications(
         config: LspServerConfig,
         transport: LspTransport,

--- a/crates/mcpls-core/src/lsp/lifecycle.rs
+++ b/crates/mcpls-core/src/lsp/lifecycle.rs
@@ -17,6 +17,7 @@ use lsp_types::{
     InitializedParams, PositionEncodingKind, ServerCapabilities, Uri, WorkspaceFolder,
 };
 use tokio::process::Command;
+use tokio::sync::mpsc;
 use tokio::time::Duration;
 use tracing::{debug, info};
 
@@ -24,6 +25,7 @@ use crate::config::LspServerConfig;
 use crate::error::{Error, Result, ServerSpawnFailure};
 use crate::lsp::client::LspClient;
 use crate::lsp::transport::LspTransport;
+use crate::lsp::types::LspNotification;
 
 /// State of an LSP server connection.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -167,6 +169,11 @@ pub struct LspServer {
     client: LspClient,
     capabilities: ServerCapabilities,
     position_encoding: PositionEncodingKind,
+    /// Receiver for push notifications from the LSP server.
+    ///
+    /// Extract this before registering the server to receive real-time
+    /// notifications (e.g., `textDocument/publishDiagnostics`, `$/progress`).
+    pub notification_rx: mpsc::Receiver<LspNotification>,
     /// Child process handle. Kept alive for process lifetime management.
     /// When dropped, the process is terminated via SIGKILL (`kill_on_drop`).
     _child: tokio::process::Child,
@@ -178,6 +185,7 @@ impl std::fmt::Debug for LspServer {
             .field("client", &self.client)
             .field("capabilities", &self.capabilities)
             .field("position_encoding", &self.position_encoding)
+            .field("notification_rx", &"<channel>")
             .field("_child", &"<process>")
             .finish()
     }
@@ -226,7 +234,12 @@ impl LspServer {
             .ok_or_else(|| Error::Transport("Failed to capture stdout".to_string()))?;
 
         let transport = LspTransport::new(stdin, stdout);
-        let client = LspClient::from_transport(config.server_config.clone(), transport);
+        let (notification_tx, notification_rx) = mpsc::channel(64);
+        let client = LspClient::from_transport_with_notifications(
+            config.server_config.clone(),
+            transport,
+            notification_tx,
+        );
 
         let (capabilities, position_encoding) = Self::initialize(&client, &config).await?;
 
@@ -236,6 +249,7 @@ impl LspServer {
             client,
             capabilities,
             position_encoding,
+            notification_rx,
             _child: child,
         })
     }
@@ -645,11 +659,13 @@ mod tests {
 
         let transport = LspTransport::new(mock_stdin, mock_stdout);
         let client = LspClient::from_transport(LspServerConfig::rust_analyzer(), transport);
+        let (_, mock_notification_rx) = mpsc::channel(1);
 
         let server = LspServer {
             client,
             capabilities: ServerCapabilities::default(),
             position_encoding: PositionEncodingKind::UTF8,
+            notification_rx: mock_notification_rx,
             _child: mock_child,
         };
 
@@ -731,11 +747,13 @@ mod tests {
 
         let transport1 = LspTransport::new(mock_stdin1, mock_stdout1);
         let client1 = LspClient::from_transport(LspServerConfig::rust_analyzer(), transport1);
+        let (_, mock_notification_rx1) = mpsc::channel(1);
 
         let server1 = LspServer {
             client: client1,
             capabilities: lsp_types::ServerCapabilities::default(),
             position_encoding: PositionEncodingKind::UTF8,
+            notification_rx: mock_notification_rx1,
             _child: mock_child1,
         };
 
@@ -777,11 +795,13 @@ mod tests {
 
         let transport = LspTransport::new(mock_stdin, mock_stdout);
         let client = LspClient::from_transport(LspServerConfig::rust_analyzer(), transport);
+        let (_, mock_notification_rx) = mpsc::channel(1);
 
         let server = LspServer {
             client,
             capabilities: lsp_types::ServerCapabilities::default(),
             position_encoding: PositionEncodingKind::UTF8,
+            notification_rx: mock_notification_rx,
             _child: mock_child,
         };
 
@@ -837,11 +857,13 @@ mod tests {
                 LspServerConfig::typescript()
             };
             let client = LspClient::from_transport(config.clone(), transport);
+            let (_, mock_notification_rx) = mpsc::channel(1);
 
             let server = LspServer {
                 client,
                 capabilities: lsp_types::ServerCapabilities::default(),
                 position_encoding: PositionEncodingKind::UTF8,
+                notification_rx: mock_notification_rx,
                 _child: mock_child,
             };
 
@@ -884,11 +906,13 @@ mod tests {
 
         let transport1 = LspTransport::new(mock_stdin1, mock_stdout1);
         let client1 = LspClient::from_transport(LspServerConfig::rust_analyzer(), transport1);
+        let (_, mock_notification_rx1) = mpsc::channel(1);
 
         let server1 = LspServer {
             client: client1,
             capabilities: lsp_types::ServerCapabilities::default(),
             position_encoding: PositionEncodingKind::UTF8,
+            notification_rx: mock_notification_rx1,
             _child: mock_child1,
         };
 
@@ -920,11 +944,13 @@ mod tests {
 
         let transport2 = LspTransport::new(mock_stdin2, mock_stdout2);
         let client2 = LspClient::from_transport(LspServerConfig::rust_analyzer(), transport2);
+        let (_, mock_notification_rx2) = mpsc::channel(1);
 
         let server2 = LspServer {
             client: client2,
             capabilities: lsp_types::ServerCapabilities::default(),
             position_encoding: PositionEncodingKind::UTF16,
+            notification_rx: mock_notification_rx2,
             _child: mock_child2,
         };
 

--- a/crates/mcpls-core/src/lsp/mod.rs
+++ b/crates/mcpls-core/src/lsp/mod.rs
@@ -11,4 +11,7 @@ mod types;
 pub use client::LspClient;
 pub use lifecycle::{LspServer, ServerInitConfig, ServerInitResult, ServerState};
 pub use transport::LspTransport;
-pub use types::{InboundMessage, JsonRpcNotification, JsonRpcRequest, JsonRpcResponse, RequestId};
+pub use types::{
+    InboundMessage, JsonRpcNotification, JsonRpcRequest, JsonRpcResponse, LspNotification,
+    RequestId,
+};

--- a/crates/mcpls-core/src/lsp/types.rs
+++ b/crates/mcpls-core/src/lsp/types.rs
@@ -90,18 +90,21 @@ pub enum LspNotification {
     /// textDocument/publishDiagnostics
     PublishDiagnostics(PublishDiagnosticsParams),
     /// window/logMessage
-    #[allow(dead_code)] // Used in Phase 4
     LogMessage(LogMessageParams),
     /// window/showMessage
-    #[allow(dead_code)] // Used in Phase 4
     ShowMessage(ShowMessageParams),
+    /// $/progress
+    Progress {
+        /// Progress token (string or number).
+        token: serde_json::Value,
+        /// Progress value.
+        value: serde_json::Value,
+    },
     /// Unknown or unhandled notification
     Other {
         /// Method name.
-        #[allow(dead_code)] // Used in Phase 4
         method: Cow<'static, str>,
         /// Optional parameters.
-        #[allow(dead_code)] // Used in Phase 4
         params: Option<serde_json::Value>,
     },
 }
@@ -167,6 +170,17 @@ impl LspNotification {
                 Self::Other {
                     method: Cow::Owned(method.to_string()),
                     params: None,
+                }
+            }
+            "$/progress" => {
+                if let Some(ref p) = params {
+                    let token = p.get("token").cloned().unwrap_or(Value::Null);
+                    let value = p.get("value").cloned().unwrap_or(Value::Null);
+                    return Self::Progress { token, value };
+                }
+                Self::Other {
+                    method: Cow::Owned(method.to_string()),
+                    params,
                 }
             }
             _ => Self::Other {

--- a/crates/mcpls-core/tests/integration/rust_analyzer_tests.rs
+++ b/crates/mcpls-core/tests/integration/rust_analyzer_tests.rs
@@ -11,12 +11,12 @@
 )]
 
 use std::sync::{Arc, Once};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use mcpls_core::bridge::Translator;
 use mcpls_core::config::LspServerConfig;
-use mcpls_core::lsp::{LspServer, ServerInitConfig};
-use tokio::sync::Mutex;
+use mcpls_core::lsp::{LspNotification, LspServer, ServerInitConfig};
+use tokio::sync::{Mutex, mpsc};
 use tokio::time::timeout;
 
 use crate::common::test_utils::{rust_analyzer_available, rust_workspace_path};
@@ -41,8 +41,12 @@ fn init_tracing() {
 /// 1. Spawns rust-analyzer process
 /// 2. Initializes the LSP server
 /// 3. Creates and configures a Translator
-/// 4. Returns the translator wrapped in Arc<Mutex>
-async fn setup_rust_analyzer() -> Arc<Mutex<Translator>> {
+/// 4. Returns the translator wrapped in `Arc<Mutex>` and a notification receiver
+///
+/// Extract the notification receiver before registering the server (which
+/// consumes `LspServer`), then pass it to `wait_for_indexing_ready` to block
+/// until rust-analyzer signals it has finished its first analysis pass.
+async fn setup_rust_analyzer() -> (Arc<Mutex<Translator>>, mpsc::Receiver<LspNotification>) {
     init_tracing();
     let workspace_path = rust_workspace_path();
 
@@ -63,9 +67,12 @@ async fn setup_rust_analyzer() -> Arc<Mutex<Translator>> {
         initialization_options: None,
     };
 
-    let server = LspServer::spawn(server_init_config)
+    let mut server = LspServer::spawn(server_init_config)
         .await
         .expect("Failed to spawn rust-analyzer");
+
+    // Extract before register_server consumes the LspServer.
+    let notification_rx = std::mem::replace(&mut server.notification_rx, mpsc::channel(1).1);
 
     let client = server.client().clone();
 
@@ -75,7 +82,42 @@ async fn setup_rust_analyzer() -> Arc<Mutex<Translator>> {
     translator.register_client("rust".to_string(), client);
     translator.register_server("rust".to_string(), server);
 
-    Arc::new(Mutex::new(translator))
+    (Arc::new(Mutex::new(translator)), notification_rx)
+}
+
+/// Poll the notification channel until rust-analyzer signals it has finished
+/// indexing, or the timeout elapses.
+///
+/// Readiness is defined as receiving either:
+/// - A `textDocument/publishDiagnostics` notification (primary signal), or
+/// - A `$/progress` notification with `value.kind == "end"` (secondary signal).
+///
+/// Both indicate rust-analyzer has completed at least its first analysis pass.
+async fn wait_for_indexing_ready(
+    notification_rx: &mut mpsc::Receiver<LspNotification>,
+    timeout: Duration,
+) {
+    let deadline = Instant::now() + timeout;
+    loop {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
+            tracing::warn!("Timed out waiting for rust-analyzer readiness");
+            return;
+        }
+        let msg = match tokio::time::timeout(remaining, notification_rx.recv()).await {
+            Ok(None) | Err(_) => return,
+            Ok(Some(msg)) => msg,
+        };
+        match msg {
+            LspNotification::PublishDiagnostics(_) => return,
+            LspNotification::Progress { ref value, .. }
+                if value.get("kind").and_then(|k| k.as_str()) == Some("end") =>
+            {
+                return;
+            }
+            _ => {}
+        }
+    }
 }
 
 #[tokio::test]
@@ -86,12 +128,12 @@ async fn test_hover_on_std_vec() {
         return;
     }
 
-    let translator = setup_rust_analyzer().await;
+    let (translator, mut notification_rx) = setup_rust_analyzer().await;
     let workspace_path = rust_workspace_path();
     let file_path = workspace_path.join("src/lib.rs");
 
     // Give rust-analyzer time to index the workspace
-    tokio::time::sleep(Duration::from_secs(3)).await;
+    wait_for_indexing_ready(&mut notification_rx, Duration::from_secs(30)).await;
 
     // Hover over "String" in User struct (line 20)
     // The line is: `pub name: String,`
@@ -132,11 +174,11 @@ async fn test_hover_on_u64_type() {
         return;
     }
 
-    let translator = setup_rust_analyzer().await;
+    let (translator, mut notification_rx) = setup_rust_analyzer().await;
     let workspace_path = rust_workspace_path();
     let file_path = workspace_path.join("src/lib.rs");
 
-    tokio::time::sleep(Duration::from_secs(3)).await;
+    wait_for_indexing_ready(&mut notification_rx, Duration::from_secs(30)).await;
 
     // Hover over "u64" in User struct (line 19)
     // The line is: `pub id: u64,`
@@ -173,11 +215,11 @@ async fn test_definition_user_struct() {
         return;
     }
 
-    let translator = setup_rust_analyzer().await;
+    let (translator, mut notification_rx) = setup_rust_analyzer().await;
     let workspace_path = rust_workspace_path();
     let types_file = workspace_path.join("src/types.rs");
 
-    tokio::time::sleep(Duration::from_secs(3)).await;
+    wait_for_indexing_ready(&mut notification_rx, Duration::from_secs(30)).await;
 
     // Go to definition of User in types.rs (line 9, owner: User)
     // The line is: `pub owner: User,`
@@ -218,11 +260,11 @@ async fn test_definition_across_files() {
         return;
     }
 
-    let translator = setup_rust_analyzer().await;
+    let (translator, mut notification_rx) = setup_rust_analyzer().await;
     let workspace_path = rust_workspace_path();
     let functions_file = workspace_path.join("src/functions.rs");
 
-    tokio::time::sleep(Duration::from_secs(3)).await;
+    wait_for_indexing_ready(&mut notification_rx, Duration::from_secs(30)).await;
 
     // Go to definition of Repository in functions.rs (line 3, use statement)
     // The line is: `use crate::types::Repository;`
@@ -259,11 +301,11 @@ async fn test_references_create_repo_function() {
         return;
     }
 
-    let translator = setup_rust_analyzer().await;
+    let (translator, mut notification_rx) = setup_rust_analyzer().await;
     let workspace_path = rust_workspace_path();
     let functions_file = workspace_path.join("src/functions.rs");
 
-    tokio::time::sleep(Duration::from_secs(3)).await;
+    wait_for_indexing_ready(&mut notification_rx, Duration::from_secs(30)).await;
 
     // Find references to create_repo function (line 7, function name)
     // The line is: `pub fn create_repo(name: &str) -> Repository {`
@@ -303,11 +345,11 @@ async fn test_references_user_struct() {
         return;
     }
 
-    let translator = setup_rust_analyzer().await;
+    let (translator, mut notification_rx) = setup_rust_analyzer().await;
     let workspace_path = rust_workspace_path();
     let lib_file = workspace_path.join("src/lib.rs");
 
-    tokio::time::sleep(Duration::from_secs(3)).await;
+    wait_for_indexing_ready(&mut notification_rx, Duration::from_secs(30)).await;
 
     // Find references to User struct (line 18, struct name)
     // The line is: `pub struct User {`
@@ -344,12 +386,12 @@ async fn test_diagnostics_with_error() {
         return;
     }
 
-    let translator = setup_rust_analyzer().await;
+    let (translator, mut notification_rx) = setup_rust_analyzer().await;
     let workspace_path = rust_workspace_path();
     let lib_file = workspace_path.join("src/lib.rs");
 
     // Give rust-analyzer extra time to analyze and generate diagnostics
-    tokio::time::sleep(Duration::from_secs(5)).await;
+    wait_for_indexing_ready(&mut notification_rx, Duration::from_secs(30)).await;
 
     // Get diagnostics from lib.rs (has intentional error on line 37)
     let result = timeout(
@@ -388,11 +430,11 @@ async fn test_diagnostics_no_errors() {
         return;
     }
 
-    let translator = setup_rust_analyzer().await;
+    let (translator, mut notification_rx) = setup_rust_analyzer().await;
     let workspace_path = rust_workspace_path();
     let types_file = workspace_path.join("src/types.rs");
 
-    tokio::time::sleep(Duration::from_secs(5)).await;
+    wait_for_indexing_ready(&mut notification_rx, Duration::from_secs(30)).await;
 
     // Get diagnostics from types.rs (should have no errors)
     let result = timeout(
@@ -433,11 +475,11 @@ async fn test_document_symbols() {
         return;
     }
 
-    let translator = setup_rust_analyzer().await;
+    let (translator, mut notification_rx) = setup_rust_analyzer().await;
     let workspace_path = rust_workspace_path();
     let lib_file = workspace_path.join("src/lib.rs");
 
-    tokio::time::sleep(Duration::from_secs(3)).await;
+    wait_for_indexing_ready(&mut notification_rx, Duration::from_secs(30)).await;
 
     // Get document symbols from lib.rs
     let result = timeout(
@@ -490,11 +532,11 @@ async fn test_document_symbols_types_file() {
         return;
     }
 
-    let translator = setup_rust_analyzer().await;
+    let (translator, mut notification_rx) = setup_rust_analyzer().await;
     let workspace_path = rust_workspace_path();
     let types_file = workspace_path.join("src/types.rs");
 
-    tokio::time::sleep(Duration::from_secs(3)).await;
+    wait_for_indexing_ready(&mut notification_rx, Duration::from_secs(30)).await;
 
     // Get document symbols from types.rs
     let result = timeout(
@@ -536,11 +578,11 @@ async fn test_completions_basic() {
         return;
     }
 
-    let translator = setup_rust_analyzer().await;
+    let (translator, mut notification_rx) = setup_rust_analyzer().await;
     let workspace_path = rust_workspace_path();
     let functions_file = workspace_path.join("src/functions.rs");
 
-    tokio::time::sleep(Duration::from_secs(3)).await;
+    wait_for_indexing_ready(&mut notification_rx, Duration::from_secs(30)).await;
 
     // Get completions in functions.rs
     // Position after "repo." on line 23 (repo.get_owner().name)
@@ -577,11 +619,11 @@ async fn test_format_document() {
         return;
     }
 
-    let translator = setup_rust_analyzer().await;
+    let (translator, mut notification_rx) = setup_rust_analyzer().await;
     let workspace_path = rust_workspace_path();
     let lib_file = workspace_path.join("src/lib.rs");
 
-    tokio::time::sleep(Duration::from_secs(3)).await;
+    wait_for_indexing_ready(&mut notification_rx, Duration::from_secs(30)).await;
 
     // Request document formatting
     let result = timeout(
@@ -620,7 +662,7 @@ async fn test_timeout_handling() {
         return;
     }
 
-    let translator = setup_rust_analyzer().await;
+    let (translator, _notification_rx) = setup_rust_analyzer().await;
     let workspace_path = rust_workspace_path();
     let lib_file = workspace_path.join("src/lib.rs");
 
@@ -646,9 +688,7 @@ async fn test_invalid_file_path() {
         return;
     }
 
-    let translator = setup_rust_analyzer().await;
-
-    tokio::time::sleep(Duration::from_secs(2)).await;
+    let (translator, _notification_rx) = setup_rust_analyzer().await;
 
     // Try to get hover on non-existent file
     let result = translator
@@ -669,11 +709,11 @@ async fn test_out_of_bounds_position() {
         return;
     }
 
-    let translator = setup_rust_analyzer().await;
+    let (translator, mut notification_rx) = setup_rust_analyzer().await;
     let workspace_path = rust_workspace_path();
     let lib_file = workspace_path.join("src/lib.rs");
 
-    tokio::time::sleep(Duration::from_secs(3)).await;
+    wait_for_indexing_ready(&mut notification_rx, Duration::from_secs(30)).await;
 
     // Try to get hover at an extremely large line number
     let result = timeout(
@@ -704,10 +744,10 @@ async fn test_workspace_symbol_search_basic() {
         return;
     }
 
-    let translator = setup_rust_analyzer().await;
+    let (translator, mut notification_rx) = setup_rust_analyzer().await;
 
     // Give rust-analyzer time to index the workspace
-    tokio::time::sleep(Duration::from_secs(3)).await;
+    wait_for_indexing_ready(&mut notification_rx, Duration::from_secs(30)).await;
 
     // Search for "User" struct
     let result = timeout(
@@ -750,9 +790,9 @@ async fn test_workspace_symbol_search_with_kind_filter() {
         return;
     }
 
-    let translator = setup_rust_analyzer().await;
+    let (translator, mut notification_rx) = setup_rust_analyzer().await;
 
-    tokio::time::sleep(Duration::from_secs(3)).await;
+    wait_for_indexing_ready(&mut notification_rx, Duration::from_secs(30)).await;
 
     // Search for symbols and filter by Struct kind
     let result = timeout(
@@ -789,9 +829,9 @@ async fn test_workspace_symbol_search_max_results() {
         return;
     }
 
-    let translator = setup_rust_analyzer().await;
+    let (translator, mut notification_rx) = setup_rust_analyzer().await;
 
-    tokio::time::sleep(Duration::from_secs(3)).await;
+    wait_for_indexing_ready(&mut notification_rx, Duration::from_secs(30)).await;
 
     // Search with very low limit
     let result = timeout(
@@ -823,9 +863,9 @@ async fn test_workspace_symbol_search_function() {
         return;
     }
 
-    let translator = setup_rust_analyzer().await;
+    let (translator, mut notification_rx) = setup_rust_analyzer().await;
 
-    tokio::time::sleep(Duration::from_secs(3)).await;
+    wait_for_indexing_ready(&mut notification_rx, Duration::from_secs(30)).await;
 
     // Search for function symbols
     let result = timeout(


### PR DESCRIPTION
## Summary

- Replaced all 17 fixed sleeps (3s/5s) in `rust_analyzer_tests.rs` with a `wait_for_indexing_ready()` poll helper that returns on the first `textDocument/publishDiagnostics` or `$/progress{kind:end}` notification, with a 30s hard timeout
- Switched `LspServer::spawn()` to `from_transport_with_notifications()` so push notifications flow into a dedicated `mpsc` channel exposed as `pub notification_rx` on `LspServer`
- Added `Progress` variant to `LspNotification` for `$/progress` messages
- Removed the unconditional 2s sleep in `test_invalid_file_path` (no indexing readiness needed)

## Root cause

Under parallel test execution (10+ rust-analyzer instances), CPU contention caused workspace indexing to exceed the fixed timeout, producing empty LSP responses in ~30% of runs.

## Test plan

- [x] `cargo nextest run --workspace --all-features --lib --bins` — 345/345 passed
- [x] `cargo clippy --all-targets --all-features --workspace -- -D warnings` — clean
- [x] `cargo +nightly fmt --all -- --check` — clean
- [ ] `--ignored` integration tests should now pass reliably in parallel (requires rust-analyzer in PATH)

Closes #121