### PR TITLE
fix(config): preserve React language IDs for TSX/JSX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **RUSTSEC-2026-0204** — bump transitive `crossbeam-epoch` dependency (pulled in via `ignore`) from 0.9.18 to 0.9.20 to resolve an invalid pointer dereference in `fmt::Pointer` impls for `Atomic`/`Shared`
+- **TSX/JSX diagnostics** — Preserve `typescriptreact`/`javascriptreact` language IDs when deriving mappings from TypeScript/JavaScript server `file_patterns`, fixing JSX parse errors when one server handles both plain and React extensions. (#148)
 
 ## [0.3.7] - 2026-06-23
 

--- a/crates/mcpls-core/src/bridge/translator.rs
+++ b/crates/mcpls-core/src/bridge/translator.rs
@@ -571,17 +571,36 @@ impl Translator {
     /// Get a cloned LSP client for a file path based on language detection.
     fn get_client_for_file(&self, path: &Path) -> Result<LspClient> {
         let language_id = detect_language(path, &self.extension_map);
-        self.lsp_clients.get(&language_id).cloned().ok_or_else(|| {
-            // A configured+applicable language whose server has not registered
-            // yet is still initializing (e.g. a large Unity solution loading via
-            // OmniSharp); tell the caller to wait and retry rather than implying
-            // no server is configured at all.
-            if self.expected_languages.contains(&language_id) {
-                Error::ServerInitializing(language_id)
-            } else {
-                Error::NoServerForLanguage(language_id)
-            }
-        })
+        if let Some(client) = self.lsp_clients.get(&language_id) {
+            return Ok(client.clone());
+        }
+
+        let server_language_id = Self::server_language_id_for_document(&language_id);
+        if let Some(server_language_id) = server_language_id
+            && let Some(client) = self.lsp_clients.get(server_language_id)
+        {
+            return Ok(client.clone());
+        }
+
+        // A configured+applicable language whose server has not registered
+        // yet is still initializing (e.g. a large Unity solution loading via
+        // OmniSharp); tell the caller to wait and retry rather than implying
+        // no server is configured at all.
+        if self.expected_languages.contains(&language_id)
+            || server_language_id.is_some_and(|id| self.expected_languages.contains(id))
+        {
+            Err(Error::ServerInitializing(language_id))
+        } else {
+            Err(Error::NoServerForLanguage(language_id))
+        }
+    }
+
+    fn server_language_id_for_document(language_id: &str) -> Option<&'static str> {
+        match language_id {
+            "javascriptreact" => Some("javascript"),
+            "typescriptreact" => Some("typescript"),
+            _ => None,
+        }
     }
 
     /// Parse and validate a file URI, returning the validated path.
@@ -3310,6 +3329,51 @@ mod tests {
         } else {
             panic!("Expected NoServerForLanguage(plaintext) error");
         }
+    }
+
+    #[test]
+    fn test_get_client_for_file_routes_tsx_to_typescript_server() {
+        let temp_dir = TempDir::new().unwrap();
+        let test_file = temp_dir.path().join("component.tsx");
+        fs::write(&test_file, "export const Component = () => <div />").unwrap();
+
+        let mut extension_map = HashMap::new();
+        extension_map.insert("tsx".to_string(), "typescriptreact".to_string());
+
+        let mut translator = Translator::new().with_extensions(extension_map);
+        translator.register_client(
+            "typescript".to_string(),
+            LspClient::new(crate::config::LspServerConfig::typescript()),
+        );
+
+        let client = translator.get_client_for_file(&test_file).unwrap();
+        assert_eq!(client.language_id(), "typescript");
+    }
+
+    #[test]
+    fn test_get_client_for_file_routes_jsx_to_javascript_server() {
+        let temp_dir = TempDir::new().unwrap();
+        let test_file = temp_dir.path().join("component.jsx");
+        fs::write(&test_file, "export const Component = () => <div />").unwrap();
+
+        let mut extension_map = HashMap::new();
+        extension_map.insert("jsx".to_string(), "javascriptreact".to_string());
+
+        let javascript_config = crate::config::LspServerConfig {
+            language_id: "javascript".to_string(),
+            command: "typescript-language-server".to_string(),
+            args: vec!["--stdio".to_string()],
+            env: HashMap::new(),
+            file_patterns: vec!["**/*.js".to_string(), "**/*.jsx".to_string()],
+            initialization_options: None,
+            timeout_seconds: 30,
+            heuristics: None,
+        };
+        let mut translator = Translator::new().with_extensions(extension_map);
+        translator.register_client("javascript".to_string(), LspClient::new(javascript_config));
+
+        let client = translator.get_client_for_file(&test_file).unwrap();
+        assert_eq!(client.language_id(), "javascript");
     }
 
     #[tokio::test]

--- a/crates/mcpls-core/src/bridge/translator.rs
+++ b/crates/mcpls-core/src/bridge/translator.rs
@@ -3351,6 +3351,40 @@ mod tests {
     }
 
     #[test]
+    fn test_get_client_for_file_prefers_exact_react_server() {
+        let temp_dir = TempDir::new().unwrap();
+        let test_file = temp_dir.path().join("component.tsx");
+        fs::write(&test_file, "export const Component = () => <div />").unwrap();
+
+        let mut extension_map = HashMap::new();
+        extension_map.insert("tsx".to_string(), "typescriptreact".to_string());
+
+        let typescript_react_config = crate::config::LspServerConfig {
+            language_id: "typescriptreact".to_string(),
+            command: "typescript-language-server".to_string(),
+            args: vec!["--stdio".to_string()],
+            env: HashMap::new(),
+            file_patterns: vec!["**/*.tsx".to_string()],
+            initialization_options: None,
+            timeout_seconds: 30,
+            heuristics: None,
+        };
+
+        let mut translator = Translator::new().with_extensions(extension_map);
+        translator.register_client(
+            "typescript".to_string(),
+            LspClient::new(crate::config::LspServerConfig::typescript()),
+        );
+        translator.register_client(
+            "typescriptreact".to_string(),
+            LspClient::new(typescript_react_config),
+        );
+
+        let client = translator.get_client_for_file(&test_file).unwrap();
+        assert_eq!(client.language_id(), "typescriptreact");
+    }
+
+    #[test]
     fn test_get_client_for_file_routes_jsx_to_javascript_server() {
         let temp_dir = TempDir::new().unwrap();
         let test_file = temp_dir.path().join("component.jsx");

--- a/crates/mcpls-core/src/config/mod.rs
+++ b/crates/mcpls-core/src/config/mod.rs
@@ -142,6 +142,15 @@ fn extract_extension_from_pattern(pattern: &str) -> Option<String> {
     }
 }
 
+fn language_id_for_pattern_extension(server_language_id: &str, extension: &str) -> String {
+    match (server_language_id, extension) {
+        ("javascript", "jsx") => "javascriptreact",
+        ("typescript", "tsx") => "typescriptreact",
+        _ => server_language_id,
+    }
+    .to_string()
+}
+
 fn default_position_encodings() -> Vec<String> {
     vec!["utf-8".to_string(), "utf-16".to_string()]
 }
@@ -295,7 +304,8 @@ impl ServerConfig {
         for server in &self.lsp_servers {
             for pattern in &server.file_patterns {
                 if let Some(ext) = extract_extension_from_pattern(pattern) {
-                    map.insert(ext, server.language_id.clone());
+                    let language_id = language_id_for_pattern_extension(&server.language_id, &ext);
+                    map.insert(ext, language_id);
                 }
             }
         }
@@ -743,6 +753,48 @@ mod tests {
         let map = config.build_effective_extension_map();
         assert_eq!(map.get("c"), Some(&"cpp".to_string()));
         assert_eq!(map.get("h"), Some(&"cpp".to_string()));
+    }
+
+    #[test]
+    fn test_build_effective_extension_map_derives_tsx_language_id() {
+        let config = ServerConfig {
+            workspace: WorkspaceConfig::default(),
+            lsp_servers: vec![LspServerConfig {
+                language_id: "typescript".to_string(),
+                command: "tsgo".to_string(),
+                args: vec!["--lsp".to_string(), "--stdio".to_string()],
+                env: HashMap::new(),
+                file_patterns: vec!["**/*.ts".to_string(), "**/*.tsx".to_string()],
+                initialization_options: None,
+                timeout_seconds: 30,
+                heuristics: None,
+            }],
+        };
+
+        let map = config.build_effective_extension_map();
+        assert_eq!(map.get("ts"), Some(&"typescript".to_string()));
+        assert_eq!(map.get("tsx"), Some(&"typescriptreact".to_string()));
+    }
+
+    #[test]
+    fn test_build_effective_extension_map_derives_jsx_language_id() {
+        let config = ServerConfig {
+            workspace: WorkspaceConfig::default(),
+            lsp_servers: vec![LspServerConfig {
+                language_id: "javascript".to_string(),
+                command: "typescript-language-server".to_string(),
+                args: vec!["--stdio".to_string()],
+                env: HashMap::new(),
+                file_patterns: vec!["**/*.js".to_string(), "**/*.jsx".to_string()],
+                initialization_options: None,
+                timeout_seconds: 30,
+                heuristics: None,
+            }],
+        };
+
+        let map = config.build_effective_extension_map();
+        assert_eq!(map.get("js"), Some(&"javascript".to_string()));
+        assert_eq!(map.get("jsx"), Some(&"javascriptreact".to_string()));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes #148.

This keeps React document language IDs intact for TSX/JSX files and still lets the common single TypeScript or JavaScript server configuration handle them.

- typescript + .tsx file patterns now map to typescriptreact
- javascript + .jsx file patterns now map to javascriptreact
- when no exact react LSP client is configured, typescriptreact routes to the typescript server and javascriptreact routes to the javascript server
- if an exact react server is configured, it wins over the fallback

The existing C/C++ file-pattern override behavior is unchanged.

## Validation

- cargo +nightly fmt --check
- cargo +1.95 clippy -p mcpls-core --all-targets --all-features -- -D warnings
- cargo +1.95 test -p mcpls-core
- cargo +1.95 nextest run -p mcpls-core
- cargo +1.95 test -p mcpls-core get_client_for_file
- Built a local release binary from a combined branch containing this PR plus #147, then ran a standalone MCP stdio probe against a real TSX project using tsgo. get_diagnostics returned empty diagnostics for both a TSX source file and a TSX test file, with no typescriptreact no-server error and no identifier:null protocol error.