### PR TITLE
fix(bridge): retry ServerCancelled requests and fix integration test readiness gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **ServerCancelled retry** — `LspClient::request()` now retries up to 3 times with exponential backoff (500 ms → 1 s → 2 s) when an LSP server returns error code -32802 with `data.retriggerRequest: true`, instead of propagating the error immediately to the MCP caller (#128)
+- **Integration test readiness gate** — Replaced `publishDiagnostics`-based readiness signal with hover-probe polling (3 consecutive successful hover responses required), matching the ra_e2e approach; fixes 3 of 5 integration tests that failed consistently in isolation after PR #123 (#127)
 - **LSP server requests** — Handle server-to-client requests such as `client/registerCapability`, fixing tsgo timeouts.
 - **Integration tests** — Add `[workspace]` table to `tests/fixtures/rust_workspace/Cargo.toml` so cargo treats the fixture as a standalone workspace; fixes 8 rust-analyzer integration tests that failed with "Failed to load workspaces." (#118)
 - **e2e coverage** — Add ra_e2e sub-cases for `get_signature_help`, `go_to_implementation`, `go_to_type_definition`, `get_inlay_hints` (4 LSP 3.17 tools from #124 had no coverage); add `list_resources`, `read_resource`, `subscribe_resource`, `unsubscribe_resource` to `McpClient` and ra_e2e_suite (MCP resources path was entirely untested) (#129, #130)

--- a/crates/mcpls-core/src/error.rs
+++ b/crates/mcpls-core/src/error.rs
@@ -43,6 +43,8 @@ pub enum Error {
         code: i32,
         /// Error message from the server.
         message: String,
+        /// Optional additional data from the JSON-RPC error object.
+        data: Option<serde_json::Value>,
     },
 
     /// MCP server error.
@@ -211,6 +213,7 @@ mod tests {
         let err = Error::LspServerError {
             code: -32600,
             message: "Invalid request".to_string(),
+            data: None,
         };
         assert_eq!(
             err.to_string(),

--- a/crates/mcpls-core/src/lsp/client.rs
+++ b/crates/mcpls-core/src/lsp/client.rs
@@ -22,6 +22,15 @@ use crate::lsp::types::{
 /// JSON-RPC protocol version.
 const JSONRPC_VERSION: &str = "2.0";
 
+/// LSP error code returned when the server cancels a request and wants the client to retry.
+const SERVER_CANCELLED_CODE: i32 = -32802;
+
+/// Maximum number of retry attempts for server-cancelled requests.
+const SERVER_CANCELLED_MAX_RETRIES: u32 = 3;
+
+/// Initial backoff delay for server-cancelled retries (milliseconds).
+const SERVER_CANCELLED_INITIAL_DELAY_MS: u64 = 500;
+
 /// Type alias for pending request tracking map.
 type PendingRequests = HashMap<RequestId, oneshot::Sender<Result<Value>>>;
 
@@ -174,6 +183,10 @@ impl LspClient {
 
     /// Send request and wait for response with timeout.
     ///
+    /// Automatically retries up to 3 times when the server returns error code
+    /// -32802 (`ServerCancelled`) with `data.retriggerRequest == true`, using
+    /// exponential backoff starting at 500 ms.
+    ///
     /// # Type Parameters
     ///
     /// * `P` - The type of the request parameters (must be serializable)
@@ -196,35 +209,86 @@ impl LspClient {
         P: Serialize,
         R: DeserializeOwned,
     {
-        let id = RequestId::Number(self.request_counter.fetch_add(1, Ordering::SeqCst));
         let params_value = serde_json::to_value(params)?;
+        let mut delay_ms = SERVER_CANCELLED_INITIAL_DELAY_MS;
 
-        let (response_tx, response_rx) = oneshot::channel();
+        for attempt in 0..=SERVER_CANCELLED_MAX_RETRIES {
+            if attempt > 0 {
+                debug!(
+                    "Retrying {} after ServerCancelled (attempt {}/{}), backoff={}ms",
+                    method, attempt, SERVER_CANCELLED_MAX_RETRIES, delay_ms
+                );
+                tokio::time::sleep(Duration::from_millis(delay_ms)).await;
+                delay_ms *= 2;
+            }
 
-        let request = JsonRpcRequest {
-            jsonrpc: JSONRPC_VERSION.to_string(),
-            id: id.clone(),
-            method: method.to_string(),
-            params: Some(params_value),
-        };
+            let id = RequestId::Number(self.request_counter.fetch_add(1, Ordering::SeqCst));
+            let (response_tx, response_rx) = oneshot::channel();
+            let request = JsonRpcRequest {
+                jsonrpc: JSONRPC_VERSION.to_string(),
+                id: id.clone(),
+                method: method.to_string(),
+                params: Some(params_value.clone()),
+            };
 
-        debug!("Sending request: {} (id={:?})", method, id);
+            debug!("Sending request: {} (id={:?})", method, id);
 
-        self.command_tx
-            .send(ClientCommand::SendRequest {
-                request,
-                response_tx,
-            })
-            .await
-            .map_err(|_| Error::ServerTerminated)?;
+            self.command_tx
+                .send(ClientCommand::SendRequest {
+                    request,
+                    response_tx,
+                })
+                .await
+                .map_err(|_| Error::ServerTerminated)?;
 
-        let result_value = timeout(timeout_duration, response_rx)
-            .await
-            .map_err(|_| Error::Timeout(timeout_duration.as_secs()))?
-            .map_err(|_| Error::ServerTerminated)??;
+            let outcome = timeout(timeout_duration, response_rx)
+                .await
+                .map_err(|_| Error::Timeout(timeout_duration.as_secs()))?
+                .map_err(|_| Error::ServerTerminated)?;
 
-        serde_json::from_value(result_value)
-            .map_err(|e| Error::LspProtocolError(format!("Failed to deserialize response: {e}")))
+            match outcome {
+                Ok(result_value) => {
+                    return serde_json::from_value(result_value).map_err(|e| {
+                        Error::LspProtocolError(format!("Failed to deserialize response: {e}"))
+                    });
+                }
+                Err(Error::LspServerError {
+                    code,
+                    ref message,
+                    ref data,
+                }) if code == SERVER_CANCELLED_CODE && Self::should_retrigger(data.as_ref()) => {
+                    warn!(
+                        "ServerCancelled (-32802) on '{}', will retry: {}",
+                        method, message
+                    );
+                    if attempt == SERVER_CANCELLED_MAX_RETRIES {
+                        return Err(Error::LspServerError {
+                            code,
+                            message: message.clone(),
+                            data: data.clone(),
+                        });
+                    }
+                    // continue loop for next attempt
+                }
+                Err(e) => return Err(e),
+            }
+        }
+
+        Err(Error::ServerTerminated)
+    }
+
+    /// Returns true when the error data from a `ServerCancelled` (-32802) response
+    /// indicates the server wants the client to retrigger the request.
+    ///
+    /// Per the LSP specification, `data.retriggerRequest == true` is the signal.
+    /// When `data` is absent (older servers), we default to retrying anyway because
+    /// code -32802 is exclusively used for this purpose.
+    fn should_retrigger(data: Option<&Value>) -> bool {
+        data.is_none_or(|v| {
+            v.get("retriggerRequest")
+                .and_then(Value::as_bool)
+                .unwrap_or(true)
+        })
     }
 
     /// Send notification (fire-and-forget, no response expected).
@@ -360,6 +424,7 @@ impl LspClient {
                                     let _ = sender.send(Err(Error::LspServerError {
                                         code: error.code,
                                         message: error.message,
+                                        data: error.data,
                                     }));
                                 } else if let Some(result) = response.result {
                                     let _ = sender.send(Ok(result));
@@ -630,13 +695,14 @@ mod tests {
             let _ = sender.send(Err(Error::LspServerError {
                 code: error.code,
                 message: error.message,
+                data: error.data,
             }));
         }
 
         let result = response_rx.await.unwrap();
         assert!(result.is_err(), "Should receive error");
 
-        if let Err(Error::LspServerError { code, message }) = result {
+        if let Err(Error::LspServerError { code, message, .. }) = result {
             assert_eq!(code, -32601);
             assert_eq!(message, "Method not found");
         } else {
@@ -692,13 +758,14 @@ mod tests {
             let _ = sender.send(Err(Error::LspServerError {
                 code: error.code,
                 message: error.message,
+                data: error.data,
             }));
         }
 
         let result = response_rx.await.unwrap();
         assert!(result.is_err());
 
-        if let Err(Error::LspServerError { code, message }) = result {
+        if let Err(Error::LspServerError { code, message, .. }) = result {
             assert_eq!(code, -32700);
             assert_eq!(
                 message.len(),

--- a/crates/mcpls-core/tests/integration/rust_analyzer_tests.rs
+++ b/crates/mcpls-core/tests/integration/rust_analyzer_tests.rs
@@ -10,13 +10,14 @@
     clippy::unnecessary_unwrap
 )]
 
+use std::path::Path;
 use std::sync::{Arc, Once};
 use std::time::{Duration, Instant};
 
 use mcpls_core::bridge::Translator;
 use mcpls_core::config::LspServerConfig;
-use mcpls_core::lsp::{LspNotification, LspServer, ServerInitConfig};
-use tokio::sync::{Mutex, mpsc};
+use mcpls_core::lsp::{LspServer, ServerInitConfig};
+use tokio::sync::Mutex;
 use tokio::time::timeout;
 
 use crate::common::test_utils::{rust_analyzer_available, rust_workspace_path};
@@ -41,12 +42,8 @@ fn init_tracing() {
 /// 1. Spawns rust-analyzer process
 /// 2. Initializes the LSP server
 /// 3. Creates and configures a Translator
-/// 4. Returns the translator wrapped in `Arc<Mutex>` and a notification receiver
-///
-/// Extract the notification receiver before registering the server (which
-/// consumes `LspServer`), then pass it to `wait_for_indexing_ready` to block
-/// until rust-analyzer signals it has finished its first analysis pass.
-async fn setup_rust_analyzer() -> (Arc<Mutex<Translator>>, mpsc::Receiver<LspNotification>) {
+/// 4. Returns the translator wrapped in `Arc<Mutex>`
+async fn setup_rust_analyzer() -> Arc<Mutex<Translator>> {
     init_tracing();
     let workspace_path = rust_workspace_path();
 
@@ -68,12 +65,9 @@ async fn setup_rust_analyzer() -> (Arc<Mutex<Translator>>, mpsc::Receiver<LspNot
         notification_tx: None,
     };
 
-    let mut server = LspServer::spawn(server_init_config)
+    let server = LspServer::spawn(server_init_config)
         .await
         .expect("Failed to spawn rust-analyzer");
-
-    // Extract before register_server consumes the LspServer.
-    let notification_rx = std::mem::replace(&mut server.notification_rx, mpsc::channel(1).1);
 
     let client = server.client().clone();
 
@@ -83,41 +77,60 @@ async fn setup_rust_analyzer() -> (Arc<Mutex<Translator>>, mpsc::Receiver<LspNot
     translator.register_client("rust".to_string(), client);
     translator.register_server("rust".to_string(), server);
 
-    (Arc::new(Mutex::new(translator)), notification_rx)
+    Arc::new(Mutex::new(translator))
 }
 
-/// Poll the notification channel until rust-analyzer signals it has finished
-/// indexing, or the timeout elapses.
+/// Poll hover on the `add` function until rust-analyzer returns consistent results.
 ///
-/// Readiness is defined as receiving either:
-/// - A `textDocument/publishDiagnostics` notification (primary signal), or
-/// - A `$/progress` notification with `value.kind == "end"` (secondary signal).
-///
-/// Both indicate rust-analyzer has completed at least its first analysis pass.
+/// Requires 3 consecutive successful hover responses that contain "fn add" and
+/// "i32" before declaring RA ready. This mirrors the approach in `ra_e2e.rs` and
+/// is more reliable than waiting for `publishDiagnostics`, which can arrive before
+/// type-checking is complete.
 async fn wait_for_indexing_ready(
-    notification_rx: &mut mpsc::Receiver<LspNotification>,
+    translator: &Arc<Mutex<Translator>>,
+    workspace: &Path,
     timeout: Duration,
 ) {
+    let lib_rs = workspace.join("src/lib.rs");
+    let file_path = lib_rs.to_string_lossy().to_string();
+    // `pub fn add(` is on line 51; 'a' of "add" is at column 8 (1-based).
+    let add_line: u32 = 51;
+    let add_col: u32 = 8;
+
     let deadline = Instant::now() + timeout;
+    let required_consecutive: u32 = 3;
+    let mut consecutive = 0u32;
+
     loop {
-        let remaining = deadline.saturating_duration_since(Instant::now());
-        if remaining.is_zero() {
+        if Instant::now() >= deadline {
             tracing::warn!("Timed out waiting for rust-analyzer readiness");
             return;
         }
-        let msg = match tokio::time::timeout(remaining, notification_rx.recv()).await {
-            Ok(None) | Err(_) => return,
-            Ok(Some(msg)) => msg,
-        };
-        match msg {
-            LspNotification::PublishDiagnostics(_) => return,
-            LspNotification::Progress { ref value, .. }
-                if value.get("kind").and_then(|k| k.as_str()) == Some("end") =>
-            {
-                return;
+
+        let hover_result = translator
+            .lock()
+            .await
+            .handle_hover(file_path.clone(), add_line, add_col)
+            .await;
+
+        match hover_result {
+            Ok(result) => {
+                let text = serde_json::to_string(&result).unwrap_or_default();
+                if text.contains("fn add") && text.contains("i32") {
+                    consecutive += 1;
+                    if consecutive >= required_consecutive {
+                        return;
+                    }
+                } else {
+                    consecutive = 0;
+                }
             }
-            _ => {}
+            Err(_) => {
+                consecutive = 0;
+            }
         }
+
+        tokio::time::sleep(Duration::from_millis(500)).await;
     }
 }
 
@@ -129,12 +142,12 @@ async fn test_hover_on_std_vec() {
         return;
     }
 
-    let (translator, mut notification_rx) = setup_rust_analyzer().await;
+    let translator = setup_rust_analyzer().await;
     let workspace_path = rust_workspace_path();
     let file_path = workspace_path.join("src/lib.rs");
 
     // Give rust-analyzer time to index the workspace
-    wait_for_indexing_ready(&mut notification_rx, Duration::from_secs(30)).await;
+    wait_for_indexing_ready(&translator, &rust_workspace_path(), Duration::from_secs(30)).await;
 
     // Hover over "String" in User struct (line 20)
     // The line is: `pub name: String,`
@@ -175,11 +188,11 @@ async fn test_hover_on_u64_type() {
         return;
     }
 
-    let (translator, mut notification_rx) = setup_rust_analyzer().await;
+    let translator = setup_rust_analyzer().await;
     let workspace_path = rust_workspace_path();
     let file_path = workspace_path.join("src/lib.rs");
 
-    wait_for_indexing_ready(&mut notification_rx, Duration::from_secs(30)).await;
+    wait_for_indexing_ready(&translator, &rust_workspace_path(), Duration::from_secs(30)).await;
 
     // Hover over "u64" in User struct (line 19)
     // The line is: `pub id: u64,`
@@ -216,11 +229,11 @@ async fn test_definition_user_struct() {
         return;
     }
 
-    let (translator, mut notification_rx) = setup_rust_analyzer().await;
+    let translator = setup_rust_analyzer().await;
     let workspace_path = rust_workspace_path();
     let types_file = workspace_path.join("src/types.rs");
 
-    wait_for_indexing_ready(&mut notification_rx, Duration::from_secs(30)).await;
+    wait_for_indexing_ready(&translator, &rust_workspace_path(), Duration::from_secs(30)).await;
 
     // Go to definition of User in types.rs (line 9, owner: User)
     // The line is: `pub owner: User,`
@@ -261,11 +274,11 @@ async fn test_definition_across_files() {
         return;
     }
 
-    let (translator, mut notification_rx) = setup_rust_analyzer().await;
+    let translator = setup_rust_analyzer().await;
     let workspace_path = rust_workspace_path();
     let functions_file = workspace_path.join("src/functions.rs");
 
-    wait_for_indexing_ready(&mut notification_rx, Duration::from_secs(30)).await;
+    wait_for_indexing_ready(&translator, &rust_workspace_path(), Duration::from_secs(30)).await;
 
     // Go to definition of Repository in functions.rs (line 3, use statement)
     // The line is: `use crate::types::Repository;`
@@ -302,11 +315,11 @@ async fn test_references_create_repo_function() {
         return;
     }
 
-    let (translator, mut notification_rx) = setup_rust_analyzer().await;
+    let translator = setup_rust_analyzer().await;
     let workspace_path = rust_workspace_path();
     let functions_file = workspace_path.join("src/functions.rs");
 
-    wait_for_indexing_ready(&mut notification_rx, Duration::from_secs(30)).await;
+    wait_for_indexing_ready(&translator, &rust_workspace_path(), Duration::from_secs(30)).await;
 
     // Find references to create_repo function (line 7, function name)
     // The line is: `pub fn create_repo(name: &str) -> Repository {`
@@ -346,11 +359,11 @@ async fn test_references_user_struct() {
         return;
     }
 
-    let (translator, mut notification_rx) = setup_rust_analyzer().await;
+    let translator = setup_rust_analyzer().await;
     let workspace_path = rust_workspace_path();
     let lib_file = workspace_path.join("src/lib.rs");
 
-    wait_for_indexing_ready(&mut notification_rx, Duration::from_secs(30)).await;
+    wait_for_indexing_ready(&translator, &rust_workspace_path(), Duration::from_secs(30)).await;
 
     // Find references to User struct (line 18, struct name)
     // The line is: `pub struct User {`
@@ -387,12 +400,12 @@ async fn test_diagnostics_with_error() {
         return;
     }
 
-    let (translator, mut notification_rx) = setup_rust_analyzer().await;
+    let translator = setup_rust_analyzer().await;
     let workspace_path = rust_workspace_path();
     let lib_file = workspace_path.join("src/lib.rs");
 
     // Give rust-analyzer extra time to analyze and generate diagnostics
-    wait_for_indexing_ready(&mut notification_rx, Duration::from_secs(30)).await;
+    wait_for_indexing_ready(&translator, &rust_workspace_path(), Duration::from_secs(30)).await;
 
     // Get diagnostics from lib.rs (has intentional error on line 37)
     let result = timeout(
@@ -431,11 +444,11 @@ async fn test_diagnostics_no_errors() {
         return;
     }
 
-    let (translator, mut notification_rx) = setup_rust_analyzer().await;
+    let translator = setup_rust_analyzer().await;
     let workspace_path = rust_workspace_path();
     let types_file = workspace_path.join("src/types.rs");
 
-    wait_for_indexing_ready(&mut notification_rx, Duration::from_secs(30)).await;
+    wait_for_indexing_ready(&translator, &rust_workspace_path(), Duration::from_secs(30)).await;
 
     // Get diagnostics from types.rs (should have no errors)
     let result = timeout(
@@ -476,11 +489,11 @@ async fn test_document_symbols() {
         return;
     }
 
-    let (translator, mut notification_rx) = setup_rust_analyzer().await;
+    let translator = setup_rust_analyzer().await;
     let workspace_path = rust_workspace_path();
     let lib_file = workspace_path.join("src/lib.rs");
 
-    wait_for_indexing_ready(&mut notification_rx, Duration::from_secs(30)).await;
+    wait_for_indexing_ready(&translator, &rust_workspace_path(), Duration::from_secs(30)).await;
 
     // Get document symbols from lib.rs
     let result = timeout(
@@ -533,11 +546,11 @@ async fn test_document_symbols_types_file() {
         return;
     }
 
-    let (translator, mut notification_rx) = setup_rust_analyzer().await;
+    let translator = setup_rust_analyzer().await;
     let workspace_path = rust_workspace_path();
     let types_file = workspace_path.join("src/types.rs");
 
-    wait_for_indexing_ready(&mut notification_rx, Duration::from_secs(30)).await;
+    wait_for_indexing_ready(&translator, &rust_workspace_path(), Duration::from_secs(30)).await;
 
     // Get document symbols from types.rs
     let result = timeout(
@@ -579,11 +592,11 @@ async fn test_completions_basic() {
         return;
     }
 
-    let (translator, mut notification_rx) = setup_rust_analyzer().await;
+    let translator = setup_rust_analyzer().await;
     let workspace_path = rust_workspace_path();
     let functions_file = workspace_path.join("src/functions.rs");
 
-    wait_for_indexing_ready(&mut notification_rx, Duration::from_secs(30)).await;
+    wait_for_indexing_ready(&translator, &rust_workspace_path(), Duration::from_secs(30)).await;
 
     // Get completions in functions.rs
     // Position after "repo." on line 23 (repo.get_owner().name)
@@ -620,11 +633,11 @@ async fn test_format_document() {
         return;
     }
 
-    let (translator, mut notification_rx) = setup_rust_analyzer().await;
+    let translator = setup_rust_analyzer().await;
     let workspace_path = rust_workspace_path();
     let lib_file = workspace_path.join("src/lib.rs");
 
-    wait_for_indexing_ready(&mut notification_rx, Duration::from_secs(30)).await;
+    wait_for_indexing_ready(&translator, &rust_workspace_path(), Duration::from_secs(30)).await;
 
     // Request document formatting
     let result = timeout(
@@ -663,7 +676,7 @@ async fn test_timeout_handling() {
         return;
     }
 
-    let (translator, _notification_rx) = setup_rust_analyzer().await;
+    let translator = setup_rust_analyzer().await;
     let workspace_path = rust_workspace_path();
     let lib_file = workspace_path.join("src/lib.rs");
 
@@ -689,7 +702,7 @@ async fn test_invalid_file_path() {
         return;
     }
 
-    let (translator, _notification_rx) = setup_rust_analyzer().await;
+    let translator = setup_rust_analyzer().await;
 
     // Try to get hover on non-existent file
     let result = translator
@@ -710,11 +723,11 @@ async fn test_out_of_bounds_position() {
         return;
     }
 
-    let (translator, mut notification_rx) = setup_rust_analyzer().await;
+    let translator = setup_rust_analyzer().await;
     let workspace_path = rust_workspace_path();
     let lib_file = workspace_path.join("src/lib.rs");
 
-    wait_for_indexing_ready(&mut notification_rx, Duration::from_secs(30)).await;
+    wait_for_indexing_ready(&translator, &rust_workspace_path(), Duration::from_secs(30)).await;
 
     // Try to get hover at an extremely large line number
     let result = timeout(
@@ -745,10 +758,10 @@ async fn test_workspace_symbol_search_basic() {
         return;
     }
 
-    let (translator, mut notification_rx) = setup_rust_analyzer().await;
+    let translator = setup_rust_analyzer().await;
 
     // Give rust-analyzer time to index the workspace
-    wait_for_indexing_ready(&mut notification_rx, Duration::from_secs(30)).await;
+    wait_for_indexing_ready(&translator, &rust_workspace_path(), Duration::from_secs(30)).await;
 
     // Search for "User" struct
     let result = timeout(
@@ -791,9 +804,9 @@ async fn test_workspace_symbol_search_with_kind_filter() {
         return;
     }
 
-    let (translator, mut notification_rx) = setup_rust_analyzer().await;
+    let translator = setup_rust_analyzer().await;
 
-    wait_for_indexing_ready(&mut notification_rx, Duration::from_secs(30)).await;
+    wait_for_indexing_ready(&translator, &rust_workspace_path(), Duration::from_secs(30)).await;
 
     // Search for symbols and filter by Struct kind
     let result = timeout(
@@ -830,9 +843,9 @@ async fn test_workspace_symbol_search_max_results() {
         return;
     }
 
-    let (translator, mut notification_rx) = setup_rust_analyzer().await;
+    let translator = setup_rust_analyzer().await;
 
-    wait_for_indexing_ready(&mut notification_rx, Duration::from_secs(30)).await;
+    wait_for_indexing_ready(&translator, &rust_workspace_path(), Duration::from_secs(30)).await;
 
     // Search with very low limit
     let result = timeout(
@@ -864,9 +877,9 @@ async fn test_workspace_symbol_search_function() {
         return;
     }
 
-    let (translator, mut notification_rx) = setup_rust_analyzer().await;
+    let translator = setup_rust_analyzer().await;
 
-    wait_for_indexing_ready(&mut notification_rx, Duration::from_secs(30)).await;
+    wait_for_indexing_ready(&translator, &rust_workspace_path(), Duration::from_secs(30)).await;
 
     // Search for function symbols
     let result = timeout(


### PR DESCRIPTION
## Summary

- **#128** — `LspClient::request()` now retries up to 3 times with exponential backoff (500 ms → 1 s → 2 s) when LSP returns error -32802 (`ServerCancelled`) with `data.retriggerRequest: true`. Added `data: Option<serde_json::Value>` to `Error::LspServerError` to propagate error payloads.
- **#127** — Replaced `publishDiagnostics`-based readiness signal in integration tests with hover-probe polling: 3 consecutive successful hover responses required before declaring RA ready. Matches the `ra_e2e` approach. Fixes 3 of 5 previously-failing tests; 2 remaining failures (`test_hover_on_u64_type`, `test_diagnostics_with_error`) are pre-existing and unrelated to this PR.

## Test plan

- [ ] 391/391 lib/bins tests pass (`cargo nextest run --workspace --all-features --lib --bins`)
- [ ] `test_hover_on_std_vec` passes in isolation
- [ ] `test_references_user_struct` passes in isolation
- [ ] `test_diagnostics_no_errors` passes in isolation
- [ ] `test_hover_on_u64_type` and `test_diagnostics_with_error` remain pre-existing failures (tracked separately)

Closes #127, closes #128