### PR TITLE
feat(lsp): non-blocking startup for slow-to-initialize servers (large OmniSharp/Unity solutions)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,10 +16,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **RFC-3986 URI codec** — `bridge::resources` module with percent-encoding via `url::Url::from_file_path`; empty-authority injection is rejected to prevent UNC-path attacks on Windows
 - **Subscription cap** — `ResourceSubscriptions` enforces a `MAX_SUBSCRIPTIONS = 1_000` limit per session to guard against memory exhaustion
 - **MCP tools** — `get_signature_help` (`textDocument/signatureHelp`), `go_to_implementation` (`textDocument/implementation`), `go_to_type_definition` (`textDocument/typeDefinition`), and `get_inlay_hints` (`textDocument/inlayHint`) tools exposing LSP 3.6/3.15/3.17 capabilities (#116)
+- **Non-blocking startup for slow LSP servers** — `serve_with` spawns LSP initialization in a background task and starts the MCP server immediately, so the MCP `initialize` handshake no longer waits for the language server to finish loading. Large solutions that take a long time to load (e.g. OmniSharp on a ~130-project Unity solution, ~86 s) no longer trip the MCP client's initialize timeout. (#172)
+- **`ServerInitializing` error** — a request for a configured language whose server is still loading returns a dedicated "still initializing, wait and retry" error instead of the misleading "no LSP server configured for language". (#172)
 
 ### Changed
 
 - **LSP API** — Breaking change: `InboundMessage` is now non-exhaustive and includes a server-request variant for LSP server-to-client JSON-RPC requests. Downstream exhaustive matches must include a wildcard arm.
+- **Error API** — Breaking change: `Error` is now `#[non_exhaustive]` and gains a `ServerInitializing(String)` variant. Downstream exhaustive matches must include a wildcard arm. (#172)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Initialize handshake timeout** — the LSP `initialize` request now honors the per-server `timeout_seconds` configuration instead of a hardcoded 30 s, so servers that need longer to load on large projects are no longer killed mid-initialization. (#172)
+
 - **ServerCancelled retry** — `LspClient::request()` now retries up to 3 times with exponential backoff (500 ms → 1 s → 2 s) when an LSP server returns error code -32802 with `data.retriggerRequest: true`, instead of propagating the error immediately to the MCP caller (#128)
 - **Integration test readiness gate** — Replaced `publishDiagnostics`-based readiness signal with hover-probe polling (3 consecutive successful hover responses required), matching the ra_e2e approach; fixes 3 of 5 integration tests that failed consistently in isolation after PR #123 (#127)
 - **LSP server requests** — Handle server-to-client requests such as `client/registerCapability`, fixing tsgo timeouts.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **Initialize handshake timeout** — the LSP `initialize` request now honors the per-server `timeout_seconds` configuration instead of a hardcoded 30 s, so servers that need longer to load on large projects are no longer killed mid-initialization. (#172)
+- **Startup `null` messages** — the LSP receive loop skips bare `null`/non-object JSON-RPC messages (emitted by OmniSharp during startup) and keeps reading, instead of treating them as a fatal protocol error that drops the connection. (#172)
 
 - **ServerCancelled retry** — `LspClient::request()` now retries up to 3 times with exponential backoff (500 ms → 1 s → 2 s) when an LSP server returns error code -32802 with `data.retriggerRequest: true`, instead of propagating the error immediately to the MCP caller (#128)
 - **Integration test readiness gate** — Replaced `publishDiagnostics`-based readiness signal with hover-probe polling (3 consecutive successful hover responses required), matching the ra_e2e approach; fixes 3 of 5 integration tests that failed consistently in isolation after PR #123 (#127)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Initialize handshake timeout** — the LSP `initialize` request now honors the per-server `timeout_seconds` configuration instead of a hardcoded 30 s, so servers that need longer to load on large projects are no longer killed mid-initialization. (#172)
 - **Startup `null` messages** — the LSP receive loop skips bare `null`/non-object JSON-RPC messages (emitted by OmniSharp during startup) and keeps reading, instead of treating them as a fatal protocol error that drops the connection. (#172)
+- **Partial-success expected languages** — the "expected languages" set is cleared once background initialization completes, so a language whose server failed to spawn (when others succeeded) falls back to `NoServerForLanguage` instead of reporting `ServerInitializing` forever. (#172)
 
 - **ServerCancelled retry** — `LspClient::request()` now retries up to 3 times with exponential backoff (500 ms → 1 s → 2 s) when an LSP server returns error code -32802 with `data.retriggerRequest: true`, instead of propagating the error immediately to the MCP caller (#128)
 - **Integration test readiness gate** — Replaced `publishDiagnostics`-based readiness signal with hover-probe polling (3 consecutive successful hover responses required), matching the ra_e2e approach; fixes 3 of 5 integration tests that failed consistently in isolation after PR #123 (#127)

--- a/crates/mcpls-core/src/bridge/translator.rs
+++ b/crates/mcpls-core/src/bridge/translator.rs
@@ -1,6 +1,6 @@
 //! MCP to LSP translation layer.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 
 use lsp_types::{
@@ -39,6 +39,10 @@ pub struct Translator {
     workspace_roots: Vec<PathBuf>,
     /// Custom file extension to language ID mappings.
     extension_map: HashMap<String, String>,
+    /// Languages that are configured + applicable but whose LSP server may not
+    /// have finished initializing yet (background init). Used to return a clear
+    /// "still initializing" error instead of "no server configured".
+    expected_languages: HashSet<String>,
 }
 
 impl Translator {
@@ -52,12 +56,24 @@ impl Translator {
             notification_cache: NotificationCache::new(),
             workspace_roots: vec![],
             extension_map: HashMap::new(),
+            expected_languages: HashSet::new(),
         }
     }
 
     /// Set the workspace roots for path validation.
     pub fn set_workspace_roots(&mut self, roots: Vec<PathBuf>) {
         self.workspace_roots = roots;
+    }
+
+    /// Mark the set of languages whose LSP servers are expected (configured +
+    /// applicable) but may still be initializing in the background.
+    pub fn set_expected_languages(&mut self, languages: HashSet<String>) {
+        self.expected_languages = languages;
+    }
+
+    /// Clear the expected-languages set (e.g. after background init failed).
+    pub fn clear_expected_languages(&mut self) {
+        self.expected_languages.clear();
     }
 
     /// Configure custom file extension mappings.
@@ -555,10 +571,17 @@ impl Translator {
     /// Get a cloned LSP client for a file path based on language detection.
     fn get_client_for_file(&self, path: &Path) -> Result<LspClient> {
         let language_id = detect_language(path, &self.extension_map);
-        self.lsp_clients
-            .get(&language_id)
-            .cloned()
-            .ok_or(Error::NoServerForLanguage(language_id))
+        self.lsp_clients.get(&language_id).cloned().ok_or_else(|| {
+            // A configured+applicable language whose server has not registered
+            // yet is still initializing (e.g. a large Unity solution loading via
+            // OmniSharp); tell the caller to wait and retry rather than implying
+            // no server is configured at all.
+            if self.expected_languages.contains(&language_id) {
+                Error::ServerInitializing(language_id)
+            } else {
+                Error::NoServerForLanguage(language_id)
+            }
+        })
     }
 
     /// Parse and validate a file URI, returning the validated path.
@@ -1135,13 +1158,17 @@ impl Translator {
             )));
         }
 
-        // Workspace search requires at least one LSP client
-        let client = self
-            .lsp_clients
-            .values()
-            .next()
-            .cloned()
-            .ok_or(Error::NoServerConfigured)?;
+        // Workspace search requires at least one LSP client. If none are
+        // registered yet but a configured server is still initializing, tell the
+        // caller to wait and retry rather than implying nothing is configured.
+        let client = self.lsp_clients.values().next().cloned().ok_or_else(|| {
+            self.expected_languages
+                .iter()
+                .next()
+                .map_or(Error::NoServerConfigured, |lang| {
+                    Error::ServerInitializing(lang.clone())
+                })
+        })?;
 
         let params = LspWorkspaceSymbolParams {
             query,
@@ -2090,6 +2117,53 @@ mod tests {
         // and a real LSP server process. The actual registration functionality is
         // tested in integration tests (see rust_analyzer_tests.rs).
         // This test verifies the data structure is properly initialized.
+    }
+
+    #[test]
+    fn test_get_client_for_file_server_initializing_when_expected() {
+        // A configured/applicable language whose LSP client has not registered
+        // yet (large solution still loading via OmniSharp) must surface
+        // ServerInitializing — "wait and retry" — not NoServerForLanguage.
+        let mut translator = Translator::new();
+        let path = PathBuf::from("/ws/Assets/Scripts/Player.cs");
+        let lang = detect_language(&path, &translator.extension_map);
+
+        let mut expected = HashSet::new();
+        expected.insert(lang.clone());
+        translator.set_expected_languages(expected);
+
+        let err = translator.get_client_for_file(&path).unwrap_err();
+        assert!(matches!(err, Error::ServerInitializing(ref l) if *l == lang));
+    }
+
+    #[test]
+    fn test_get_client_for_file_no_server_when_not_expected() {
+        // When the language is not in the expected set (no server configured for
+        // it at all), the error stays NoServerForLanguage.
+        let translator = Translator::new();
+        let path = PathBuf::from("/ws/Assets/Scripts/Player.cs");
+        let lang = detect_language(&path, &translator.extension_map);
+
+        let err = translator.get_client_for_file(&path).unwrap_err();
+        assert!(matches!(err, Error::NoServerForLanguage(ref l) if *l == lang));
+    }
+
+    #[test]
+    fn test_clear_expected_languages_reverts_to_no_server() {
+        // After initialization fails the expected set is cleared; subsequent
+        // lookups must fall back to NoServerForLanguage rather than keep
+        // implying the server is still on its way.
+        let mut translator = Translator::new();
+        let path = PathBuf::from("/ws/Assets/Scripts/Player.cs");
+        let lang = detect_language(&path, &translator.extension_map);
+
+        let mut expected = HashSet::new();
+        expected.insert(lang);
+        translator.set_expected_languages(expected);
+        translator.clear_expected_languages();
+
+        let err = translator.get_client_for_file(&path).unwrap_err();
+        assert!(matches!(err, Error::NoServerForLanguage(_)));
     }
 
     #[test]

--- a/crates/mcpls-core/src/error.rs
+++ b/crates/mcpls-core/src/error.rs
@@ -66,7 +66,7 @@ pub enum Error {
 
     /// LSP server for the language is configured but still initializing.
     #[error(
-        "LSP server for language '{0}' is still initializing (large project load in progress); wait a few seconds and retry the request"
+        "LSP server for language '{0}' is still initializing (large project load in progress); wait and retry the request (this may take a few minutes on large projects)"
     )]
     ServerInitializing(String),
 

--- a/crates/mcpls-core/src/error.rs
+++ b/crates/mcpls-core/src/error.rs
@@ -27,7 +27,12 @@ impl std::fmt::Display for ServerSpawnFailure {
 }
 
 /// The main error type for mcpls-core operations.
+///
+/// This enum is `#[non_exhaustive]`: downstream crates that match on it must
+/// include a wildcard arm. New variants (such as [`Error::ServerInitializing`])
+/// can then be added without further breaking changes.
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum Error {
     /// LSP server failed to initialize.
     #[error("LSP server initialization failed: {message}")]
@@ -58,6 +63,12 @@ pub enum Error {
     /// No LSP server configured for the given language.
     #[error("no LSP server configured for language: {0}")]
     NoServerForLanguage(String),
+
+    /// LSP server for the language is configured but still initializing.
+    #[error(
+        "LSP server for language '{0}' is still initializing (large project load in progress); wait a few seconds and retry the request"
+    )]
+    ServerInitializing(String),
 
     /// No LSP server is currently configured.
     #[error("no LSP server configured")]

--- a/crates/mcpls-core/src/lib.rs
+++ b/crates/mcpls-core/src/lib.rs
@@ -417,7 +417,13 @@ fn spawn_lsp_servers_background(
         let server_count = result.server_count();
         let notification_receivers = {
             let mut t = translator.lock().await;
-            register_servers(result, &mut t)
+            let receivers = register_servers(result, &mut t);
+            // Background initialization has completed; stop reporting "still
+            // initializing" (especially for languages whose server failed to
+            // spawn on partial success, which would otherwise return
+            // ServerInitializing forever instead of NoServerForLanguage).
+            t.clear_expected_languages();
+            receivers
         };
         info!("Proceeding with {} LSP server(s)", server_count);
 

--- a/crates/mcpls-core/src/lib.rs
+++ b/crates/mcpls-core/src/lib.rs
@@ -311,40 +311,21 @@ pub async fn serve_with(config: ServerConfig, transport: Transport) -> Result<()
         applicable_configs.len()
     );
 
-    // notification_receivers collects per-language mpsc receivers used by the pump tasks.
-    let mut notification_receivers = std::collections::HashMap::new();
+    // Mark applicable languages as "expected" so a tool call that arrives while
+    // its server is still initializing gets a clear "still initializing" error
+    // (instead of "no server configured"), telling the caller to wait and retry.
+    let expected_languages: std::collections::HashSet<String> = applicable_configs
+        .iter()
+        .map(|c| c.server_config.language_id.clone())
+        .collect();
+    translator.set_expected_languages(expected_languages);
 
-    if applicable_configs.is_empty() {
-        warn!("No applicable LSP servers configured — starting in protocol-only mode");
-    } else {
-        // Spawn all servers with graceful degradation.
-        let result = LspServer::spawn_batch(&applicable_configs).await;
-
-        // Handle the three possible outcomes.
-        if result.all_failed() {
-            return Err(Error::AllServersFailedToInit {
-                count: result.failure_count(),
-                failures: result.failures,
-            });
-        }
-
-        if result.partial_success() {
-            warn!(
-                "Partial server initialization: {} succeeded, {} failed",
-                result.server_count(),
-                result.failure_count()
-            );
-            for failure in &result.failures {
-                error!("Server initialization failed: {}", failure);
-            }
-        }
-
-        // Register servers and extract their notification receivers.
-        let server_count = result.server_count();
-        notification_receivers = register_servers(result, &mut translator);
-        info!("Proceeding with {} LSP server(s)", server_count);
-    }
-
+    // Shared state, built BEFORE LSP initialization so the MCP server can answer
+    // `initialize` immediately. LSP servers (which can take minutes to initialize
+    // on a large solution, e.g. a 130-project Unity .sln via OmniSharp) are spawned
+    // in a background task and registered into this shared translator once ready.
+    // Blocking the MCP handshake on LSP init makes slow servers exceed the client's
+    // initialize-request timeout (Claude Code: ~60s) -> "Request timed out".
     let translator = Arc::new(Mutex::new(translator));
     let subscriptions = Arc::new(ResourceSubscriptions::new());
     // Peer cell is populated after the MCP transport is established (Phase B).
@@ -352,19 +333,21 @@ pub async fn serve_with(config: ServerConfig, transport: Transport) -> Result<()
 
     // Cancellation for pump tasks: send `true` to request shutdown.
     let (cancel_tx, cancel_rx) = tokio::sync::watch::channel(false);
-    let mut pumps: JoinSet<()> = JoinSet::new();
 
-    // Phase A: start pump tasks before MCP serve so no notifications are dropped
-    // while the transport is being established.
-    for (lang, rx) in notification_receivers {
-        pumps.spawn(diagnostics_pump(
-            lang,
-            rx,
+    if applicable_configs.is_empty() {
+        warn!("No applicable LSP servers configured — starting in protocol-only mode");
+    } else {
+        info!(
+            "Spawning {} LSP server(s) in the background...",
+            applicable_configs.len()
+        );
+        spawn_lsp_servers_background(
+            applicable_configs,
             Arc::clone(&translator),
             Arc::clone(&subscriptions),
             Arc::clone(&peer_cell),
             cancel_rx.clone(),
-        ));
+        );
     }
 
     info!("Starting MCP server with rmcp...");
@@ -380,12 +363,78 @@ pub async fn serve_with(config: ServerConfig, transport: Transport) -> Result<()
         Transport::Http(cfg) => run_http(mcp_server, cfg).await,
     };
 
-    // Signal pump tasks to exit and wait for them.
+    // Signal background pump tasks to exit.
     let _ = cancel_tx.send(true);
-    while pumps.join_next().await.is_some() {}
 
     info!("MCPLS server shutting down");
     result
+}
+
+/// Spawn the applicable LSP servers in a background task and register them into
+/// the shared `translator` once ready.
+///
+/// This intentionally does NOT block the caller: `serve_with` starts the MCP
+/// server immediately so its `initialize` handshake returns before slow language
+/// servers (e.g. `OmniSharp` on a large Unity solution, which can take minutes to
+/// load) finish initializing. Tool calls that arrive before a server has
+/// registered return a `ServerInitializing` error telling the caller to wait and
+/// retry. If every server fails, the "expected languages" set is cleared so those
+/// calls fall back to a plain "no server configured" error instead.
+fn spawn_lsp_servers_background(
+    applicable_configs: Vec<ServerInitConfig>,
+    translator: Arc<Mutex<Translator>>,
+    subscriptions: Arc<ResourceSubscriptions>,
+    peer_cell: Arc<OnceCell<rmcp::Peer<rmcp::RoleServer>>>,
+    cancel_rx: tokio::sync::watch::Receiver<bool>,
+) {
+    tokio::spawn(async move {
+        let result = LspServer::spawn_batch(&applicable_configs).await;
+
+        if result.all_failed() {
+            error!(
+                "All {} configured LSP server(s) failed to initialize",
+                result.failure_count()
+            );
+            for failure in &result.failures {
+                error!("Server initialization failed: {}", failure);
+            }
+            // No server will register; stop reporting "still initializing".
+            translator.lock().await.clear_expected_languages();
+            return;
+        }
+
+        if result.partial_success() {
+            warn!(
+                "Partial server initialization: {} succeeded, {} failed",
+                result.server_count(),
+                result.failure_count()
+            );
+            for failure in &result.failures {
+                error!("Server initialization failed: {}", failure);
+            }
+        }
+
+        let server_count = result.server_count();
+        let notification_receivers = {
+            let mut t = translator.lock().await;
+            register_servers(result, &mut t)
+        };
+        info!("Proceeding with {} LSP server(s)", server_count);
+
+        // Start diagnostics pump tasks now that servers are registered.
+        let mut pumps: JoinSet<()> = JoinSet::new();
+        for (lang, rx) in notification_receivers {
+            pumps.spawn(diagnostics_pump(
+                lang,
+                rx,
+                Arc::clone(&translator),
+                Arc::clone(&subscriptions),
+                Arc::clone(&peer_cell),
+                cancel_rx.clone(),
+            ));
+        }
+        while pumps.join_next().await.is_some() {}
+    });
 }
 
 #[cfg(test)]
@@ -644,10 +693,18 @@ mod tests {
         }
 
         #[tokio::test]
-        async fn test_serve_fails_with_no_servers_available() {
+        async fn test_serve_degrades_when_all_servers_fail_to_spawn() {
             use crate::config::{LspServerConfig, WorkspaceConfig};
 
-            // Create a config with an invalid server (guaranteed to fail)
+            // A configured server whose command cannot spawn used to make serve()
+            // fail synchronously with NoServersAvailable / AllServersFailedToInit.
+            // LSP initialization now runs in a background task so the MCP
+            // `initialize` handshake is never blocked, which means the spawn
+            // failure is handled in the background instead: serve() starts the MCP
+            // server in degraded mode (mirroring `test_serve_starts_with_empty_config`)
+            // rather than failing fast. Any error it surfaces must therefore be a
+            // transport/MCP error from the closed test connection, NOT a fail-fast
+            // server-availability error.
             let config = ServerConfig {
                 workspace: WorkspaceConfig {
                     roots: vec![PathBuf::from("/tmp/test-workspace")],
@@ -667,18 +724,25 @@ mod tests {
                 }],
             };
 
-            let result = serve(config).await;
+            // serve() proceeds to run the MCP server and blocks on the stdio
+            // transport until EOF; bound it so the test can't hang if stdin stays
+            // open (e.g. under multi-threaded `cargo test`, where several serve()
+            // tests share the process stdin).
+            let outcome =
+                tokio::time::timeout(std::time::Duration::from_secs(2), serve(config)).await;
 
-            assert!(result.is_err());
-            let err = result.unwrap_err();
-
-            // The serve function should now return NoServersAvailable error
-            // because all servers failed, but has_servers() returned false
-            assert!(
-                matches!(err, Error::NoServersAvailable(_))
-                    || matches!(err, Error::AllServersFailedToInit { .. }),
-                "Expected NoServersAvailable or AllServersFailedToInit error, got: {err:?}"
-            );
+            match outcome {
+                // Still serving after the deadline => it did not fail fast. Good.
+                Err(_elapsed) => {}
+                // Transport closed cleanly. Also fine.
+                Ok(Ok(())) => {}
+                // It returned an error: it must not be a fail-fast availability error.
+                Ok(Err(err)) => assert!(
+                    !matches!(err, Error::NoServersAvailable(_))
+                        && !matches!(err, Error::AllServersFailedToInit { .. }),
+                    "serve() must not fail fast now that LSP init is backgrounded; got: {err:?}"
+                ),
+            }
         }
 
         #[tokio::test]

--- a/crates/mcpls-core/src/lsp/lifecycle.rs
+++ b/crates/mcpls-core/src/lsp/lifecycle.rs
@@ -382,8 +382,15 @@ impl LspServer {
             ..Default::default()
         };
 
+        // Use the server's configured timeout for the initialize handshake too,
+        // not a hardcoded 30s: large solutions (e.g. a 130-project Unity .sln via
+        // OmniSharp) take minutes to respond to `initialize`.
         let result: InitializeResult = client
-            .request("initialize", params, Duration::from_secs(30))
+            .request(
+                "initialize",
+                params,
+                Duration::from_secs(config.server_config.timeout_seconds),
+            )
             .await
             .map_err(|e| Error::LspInitFailed {
                 message: format!("Initialize request failed: {e}"),

--- a/crates/mcpls-core/src/lsp/transport.rs
+++ b/crates/mcpls-core/src/lsp/transport.rs
@@ -13,7 +13,7 @@ use std::collections::HashMap;
 use serde_json::Value;
 use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
 use tokio::process::{ChildStdin, ChildStdout};
-use tracing::{trace, warn};
+use tracing::{debug, trace, warn};
 
 use crate::error::{Error, Result};
 use crate::lsp::types::{InboundMessage, JsonRpcNotification, JsonRpcRequest, JsonRpcResponse};
@@ -111,7 +111,10 @@ impl LspTransport {
             // (or other non-object) JSON-RPC message. Skip it and read the next
             // framed message instead of killing the whole message loop.
             if !value.is_object() {
-                warn!("Skipping non-object LSP message: {}", value);
+                // Some servers (notably OmniSharp) emit a burst of these during
+                // startup; log at debug to avoid flooding the logs for what is a
+                // recoverable, expected condition.
+                debug!("Skipping non-object LSP message: {}", value);
                 continue;
             }
 

--- a/crates/mcpls-core/src/lsp/transport.rs
+++ b/crates/mcpls-core/src/lsp/transport.rs
@@ -84,27 +84,39 @@ impl LspTransport {
     /// - JSON parsing fails
     /// - Message format is invalid
     pub async fn receive(&mut self) -> Result<InboundMessage> {
-        let headers = self.read_headers().await?;
+        loop {
+            let headers = self.read_headers().await?;
 
-        let content_length = headers
-            .get("content-length")
-            .ok_or_else(|| Error::LspProtocolError("Missing Content-Length header".to_string()))?
-            .parse::<usize>()
-            .map_err(|e| Error::LspProtocolError(format!("Invalid Content-Length: {e}")))?;
+            let content_length = headers
+                .get("content-length")
+                .ok_or_else(|| {
+                    Error::LspProtocolError("Missing Content-Length header".to_string())
+                })?
+                .parse::<usize>()
+                .map_err(|e| Error::LspProtocolError(format!("Invalid Content-Length: {e}")))?;
 
-        if content_length > MAX_CONTENT_LENGTH {
-            return Err(Error::LspProtocolError(format!(
-                "Content-Length {content_length} exceeds maximum allowed size of {MAX_CONTENT_LENGTH} bytes"
-            )));
+            if content_length > MAX_CONTENT_LENGTH {
+                return Err(Error::LspProtocolError(format!(
+                    "Content-Length {content_length} exceeds maximum allowed size of {MAX_CONTENT_LENGTH} bytes"
+                )));
+            }
+
+            let content = self.read_content(content_length).await?;
+
+            trace!("Received LSP message: {}", content);
+
+            let value: Value = serde_json::from_str(&content)?;
+
+            // Some servers (notably OmniSharp) occasionally emit a bare `null`
+            // (or other non-object) JSON-RPC message. Skip it and read the next
+            // framed message instead of killing the whole message loop.
+            if !value.is_object() {
+                warn!("Skipping non-object LSP message: {}", value);
+                continue;
+            }
+
+            return parse_inbound_message(value);
         }
-
-        let content = self.read_content(content_length).await?;
-
-        trace!("Received LSP message: {}", content);
-
-        let value: Value = serde_json::from_str(&content)?;
-
-        parse_inbound_message(value)
     }
 
     /// Read headers until blank line.

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -234,7 +234,10 @@ Glob pattern syntax:
 **Type**: Integer
 **Default**: `30`
 
-Timeout in seconds for LSP server operations.
+Timeout in seconds for LSP server operations, including the initial `initialize`
+handshake. Servers that load a large project before answering `initialize`
+(e.g. OmniSharp on a big Unity/C# solution) need this raised - the default 30 s
+can otherwise cut the server off mid-initialization.
 
 ```toml
 [[lsp_servers]]

--- a/docs/user-guide/troubleshooting.md
+++ b/docs/user-guide/troubleshooting.md
@@ -233,7 +233,7 @@ mcpls --log-level debug
 roots = ["/Users/username/current-project"]
 ```
 
-**Note**: `timeout_seconds` also bounds the initial `initialize` handshake, so raising it (Solution 1) is what helps a server that needs minutes to load a large solution. While a configured server is still initializing, tool calls for that language return a "server is still initializing - wait a few seconds and retry" message rather than a hard "no server configured" error.
+**Note**: `timeout_seconds` also bounds the initial `initialize` handshake, so raising it (Solution 1) is what helps a server that needs minutes to load a large solution. While a configured server is still initializing, tool calls for that language return a "server is still initializing - wait and retry" message (loading a large solution may take a few minutes) rather than a hard "no server configured" error.
 
 ### "rust-analyzer indexing takes forever"
 

--- a/docs/user-guide/troubleshooting.md
+++ b/docs/user-guide/troubleshooting.md
@@ -233,6 +233,8 @@ mcpls --log-level debug
 roots = ["/Users/username/current-project"]
 ```
 
+**Note**: `timeout_seconds` also bounds the initial `initialize` handshake, so raising it (Solution 1) is what helps a server that needs minutes to load a large solution. While a configured server is still initializing, tool calls for that language return a "server is still initializing - wait a few seconds and retry" message rather than a hard "no server configured" error.
+
 ### "rust-analyzer indexing takes forever"
 
 **Problem**: Large codebase with many dependencies


### PR DESCRIPTION
## Description

Make mcpls usable with LSP servers that take a long time to initialize on large projects — e.g. **OmniSharp** on a ~130-project **Unity** solution, which needs ~86 s to respond to `initialize`. Four independent fixes, plus the API change required to surface the new "still loading" state.

The driving problem: pointing OmniSharp (Windows .NET Framework build, via Visual Studio MSBuild) at a large Unity solution surfaced four issues that together made mcpls unusable there:

1. The LSP `initialize` request used a **hardcoded 30 s timeout**, so the server was killed mid-load.
2. OmniSharp emits a burst of bare **`null` JSON-RPC messages** during startup; the receive loop treated them as a protocol error and exited, dropping the connection.
3. `serve_with` **awaited LSP initialization before starting the MCP server**, so the MCP `initialize` response was blocked for the whole LSP load. Clients (e.g. Claude Code) time out the `initialize` request at ~60 s → `MCP error -32001: Request timed out`.
4. While a configured server was still loading, requests returned **"no LSP server configured"**, which is misleading — the server is on its way.

### What changed

- **`lsp/lifecycle.rs`** — the `initialize` request uses the per-server `timeout_seconds` config instead of `Duration::from_secs(30)`.
- **`lsp/transport.rs`** — `receive()` logs and skips a `null`/non-object JSON-RPC message and keeps reading, instead of returning an error that exits the message loop.
- **`lib.rs`** — `serve_with` spawns LSP initialization in a background task and starts the MCP server immediately; servers register into the shared translator when ready, with diagnostics pumps wired on registration. An `expected_languages` set is populated from the applicable configs (and cleared if all servers fail) so the bridge can tell "still loading" from "not configured".
- **`error.rs`** — `Error` is now `#[non_exhaustive]` and gains a `ServerInitializing(String)` variant.
- **`bridge/translator.rs`** — a request for a configured-but-not-yet-registered language returns `ServerInitializing` (at both `get_client_for_file` and the workspace-symbol path), gated on `expected_languages`.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)

> Breaking: `Error` becomes `#[non_exhaustive]` with a new `ServerInitializing` variant — downstream exhaustive matches must add a wildcard arm. Marking the enum `#[non_exhaustive]` (mirroring the existing `InboundMessage` precedent) makes this the last variant addition that requires a downstream change.

## Related Issues

Fixes #172.

Related (not fixed): #109 (start the MCP layer with an *empty* config) and #156 (LSP timeout report) touch adjacent areas; both are already resolved.

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guide
- [x] My code follows the project's coding style
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass
- [x] I have updated the documentation accordingly
- [x] I have updated the CHANGELOG.md (for user-facing changes)

## Additional Notes

- Validated end-to-end against OmniSharp on a 133-project Unity solution via Claude Code: MCP `initialize` returns immediately, OmniSharp finishes loading (~86 s) in the background, `get_references` (42 refs / 7 files) and `rename_symbol` work once loaded, and requests during the load window return the new `ServerInitializing` message.
- New unit tests cover the `ServerInitializing` vs `NoServerForLanguage` branch and the `clear_expected_languages` fallback (`bridge/translator.rs`).
- Docs updated: `docs/user-guide/configuration.md` clarifies that `timeout_seconds` now bounds the `initialize` handshake; `docs/user-guide/troubleshooting.md` notes the same under the "LSP server timeout" entry and documents the new "still initializing, retry" message.
- `CHANGELOG.md` `[Unreleased]` entries reference the tracking issue (#172).
