### PR TITLE
chore(bridge): remove stale translator phase comment

### DIFF
--- a/crates/mcpls-core/src/bridge/translator.rs
+++ b/crates/mcpls-core/src/bridge/translator.rs
@@ -103,11 +103,6 @@ impl Translator {
     pub const fn notification_cache_mut(&mut self) -> &mut NotificationCache {
         &mut self.notification_cache
     }
-
-    // TODO: These methods will be implemented in Phase 3-5
-    // Initialize and shutdown are now handled by LspServer in lifecycle.rs
-
-    // Future implementation will use LspServer instead of LspClient directly
 }
 
 impl Default for Translator {


### PR DESCRIPTION
Closes #134.

What changed
- Removes the stale translator implementation phase comment.

Validation
- Included in standalone integration branch `restart-standalone-integration`.
- `cargo test -p mcpls-core` passed.
- `cargo clippy -p mcpls-core --all-targets -- -D warnings` passed.
- Real rust-analyzer smoke passed: `cargo test -p mcpls-core --test integration_tests integration::rust_analyzer_tests::test_hover_on_u64_type -- --ignored --exact --nocapture`.