### PR TITLE
test(ra): hover on u64 token position

### DIFF
--- a/crates/mcpls-core/tests/integration/rust_analyzer_tests.rs
+++ b/crates/mcpls-core/tests/integration/rust_analyzer_tests.rs
@@ -201,7 +201,7 @@ async fn test_hover_on_u64_type() {
         translator.lock().await.handle_hover(
             file_path.to_string_lossy().to_string(),
             19,
-            17, // Position on "u64"
+            13, // Position on "u64"
         ),
     )
     .await;


### PR DESCRIPTION
Closes #138.

What changed
- Fixes the rust-analyzer u64 hover smoke test column so it targets the token.

Validation
- Included in standalone integration branch `restart-standalone-integration`.
- `cargo test -p mcpls-core` passed.
- `cargo clippy -p mcpls-core --all-targets -- -D warnings` passed.
- Real rust-analyzer smoke passed: `cargo test -p mcpls-core --test integration_tests integration::rust_analyzer_tests::test_hover_on_u64_type -- --ignored --exact --nocapture`.