### PR TITLE
test(lsp): cover server-cancelled retry decisions

### DIFF
--- a/crates/mcpls-core/src/lsp/client.rs
+++ b/crates/mcpls-core/src/lsp/client.rs
@@ -617,6 +617,84 @@ mod tests {
         }
     }
 
+    #[test]
+    fn test_should_retrigger_defaults_to_true_without_data() {
+        assert!(LspClient::should_retrigger(None));
+    }
+
+    #[test]
+    fn test_should_retrigger_uses_retrigger_request_false() {
+        let data = serde_json::json!({ "retriggerRequest": false });
+        assert!(!LspClient::should_retrigger(Some(&data)));
+    }
+
+    #[test]
+    fn test_should_retrigger_uses_retrigger_request_true() {
+        let data = serde_json::json!({ "retriggerRequest": true });
+        assert!(LspClient::should_retrigger(Some(&data)));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_server_cancelled_retry_exhaustion_returns_error() {
+        let config = LspServerConfig::rust_analyzer();
+        let (command_tx, mut command_rx) = mpsc::channel(8);
+        let client = LspClient {
+            config,
+            state: Arc::new(Mutex::new(crate::lsp::ServerState::Initializing)),
+            request_counter: Arc::new(AtomicI64::new(1)),
+            command_tx,
+            receiver_task: None,
+        };
+
+        let handle = tokio::spawn(async move {
+            client
+                .request::<_, Value>(
+                    "textDocument/hover",
+                    serde_json::json!({}),
+                    Duration::from_secs(5),
+                )
+                .await
+        });
+
+        let backoffs = [
+            Duration::ZERO,
+            Duration::from_millis(500),
+            Duration::from_millis(1_000),
+            Duration::from_millis(2_000),
+        ];
+
+        for (attempt, backoff) in backoffs.into_iter().enumerate() {
+            tokio::time::advance(backoff).await;
+            let command = command_rx.recv().await.expect("request command");
+            match command {
+                ClientCommand::SendRequest { response_tx, .. } => response_tx
+                    .send(Err(Error::LspServerError {
+                        code: SERVER_CANCELLED_CODE,
+                        message: format!("cancelled attempt {attempt}"),
+                        data: Some(serde_json::json!({ "retriggerRequest": true })),
+                    }))
+                    .expect("request receiver should still be alive"),
+                ClientCommand::SendNotification { .. } | ClientCommand::Shutdown => {
+                    panic!("expected request command")
+                }
+            }
+        }
+
+        let result = handle.await.unwrap();
+        match result {
+            Err(Error::LspServerError {
+                code,
+                message,
+                data,
+            }) => {
+                assert_eq!(code, SERVER_CANCELLED_CODE);
+                assert_eq!(message, "cancelled attempt 3");
+                assert_eq!(data, Some(serde_json::json!({ "retriggerRequest": true })));
+            }
+            other => panic!("expected retry exhaustion ServerCancelled error, got {other:?}"),
+        }
+    }
+
     #[tokio::test]
     async fn test_null_response_handling() {
         use crate::lsp::types::{JsonRpcResponse, RequestId};

--- a/crates/mcpls-core/src/lsp/client.rs
+++ b/crates/mcpls-core/src/lsp/client.rs
@@ -659,21 +659,28 @@ mod tests {
         let backoffs = [
             Duration::ZERO,
             Duration::from_millis(500),
-            Duration::from_millis(1_000),
-            Duration::from_millis(2_000),
+            Duration::from_secs(1),
+            Duration::from_secs(2),
         ];
 
         for (attempt, backoff) in backoffs.into_iter().enumerate() {
             tokio::time::advance(backoff).await;
-            let command = command_rx.recv().await.expect("request command");
+            let Some(command) = command_rx.recv().await else {
+                panic!("request command");
+            };
             match command {
-                ClientCommand::SendRequest { response_tx, .. } => response_tx
-                    .send(Err(Error::LspServerError {
-                        code: SERVER_CANCELLED_CODE,
-                        message: format!("cancelled attempt {attempt}"),
-                        data: Some(serde_json::json!({ "retriggerRequest": true })),
-                    }))
-                    .expect("request receiver should still be alive"),
+                ClientCommand::SendRequest { response_tx, .. } => {
+                    assert!(
+                        response_tx
+                            .send(Err(Error::LspServerError {
+                                code: SERVER_CANCELLED_CODE,
+                                message: format!("cancelled attempt {attempt}"),
+                                data: Some(serde_json::json!({ "retriggerRequest": true })),
+                            }))
+                            .is_ok(),
+                        "request receiver should still be alive"
+                    );
+                }
                 ClientCommand::SendNotification { .. } | ClientCommand::Shutdown => {
                     panic!("expected request command")
                 }


### PR DESCRIPTION
Closes #161.

What changed
- Adds coverage for server-cancelled retry decisions and retry exhaustion.

Validation
- Included in standalone integration branch `restart-standalone-integration`.
- `cargo test -p mcpls-core` passed.
- `cargo clippy -p mcpls-core --all-targets -- -D warnings` passed.
- Real rust-analyzer smoke passed: `cargo test -p mcpls-core --test integration_tests integration::rust_analyzer_tests::test_hover_on_u64_type -- --ignored --exact --nocapture`.