### PR TITLE
feat(config): route tools to named LSP servers

### DIFF
--- a/crates/mcpls-core/src/bridge/translator.rs
+++ b/crates/mcpls-core/src/bridge/translator.rs
@@ -27,10 +27,12 @@ use crate::lsp::{LspClient, LspServer};
 /// Translator handles MCP tool calls by converting them to LSP requests.
 #[derive(Debug)]
 pub struct Translator {
-    /// LSP clients indexed by language ID.
+    /// LSP clients indexed by server key.
     lsp_clients: HashMap<String, LspClient>,
-    /// LSP servers indexed by language ID (held for lifetime management).
+    /// LSP servers indexed by server key (held for lifetime management).
     lsp_servers: HashMap<String, LspServer>,
+    /// Tool routes indexed by `(language_id, tool_handle)`.
+    tool_routes: HashMap<(String, String), String>,
     /// Document state tracker.
     document_tracker: DocumentTracker,
     /// Notification cache for LSP server notifications.
@@ -48,6 +50,7 @@ impl Translator {
         Self {
             lsp_clients: HashMap::new(),
             lsp_servers: HashMap::new(),
+            tool_routes: HashMap::new(),
             document_tracker: DocumentTracker::new(ResourceLimits::default(), HashMap::new()),
             notification_cache: NotificationCache::new(),
             workspace_roots: vec![],
@@ -72,14 +75,28 @@ impl Translator {
         self
     }
 
-    /// Register an LSP client for a language.
-    pub fn register_client(&mut self, language_id: String, client: LspClient) {
-        self.lsp_clients.insert(language_id, client);
+    /// Register an LSP client for a server key.
+    pub fn register_client(&mut self, server_key: String, client: LspClient) {
+        self.lsp_clients.insert(server_key, client);
     }
 
-    /// Register an LSP server for a language.
-    pub fn register_server(&mut self, language_id: String, server: LspServer) {
-        self.lsp_servers.insert(language_id, server);
+    /// Register an LSP server for a server key.
+    pub fn register_server(&mut self, server_key: String, server: LspServer) {
+        self.lsp_servers.insert(server_key, server);
+    }
+
+    /// Register tool routes for a language/server pair.
+    pub fn register_tool_routes<I, S>(&mut self, language_id: &str, server_key: &str, handles: I)
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        for handle in handles {
+            self.tool_routes.insert(
+                (language_id.to_string(), handle.into()),
+                server_key.to_string(),
+            );
+        }
     }
 
     /// Get the document tracker.
@@ -552,13 +569,44 @@ impl Translator {
         Err(Error::PathOutsideWorkspace(path.to_path_buf()))
     }
 
-    /// Get a cloned LSP client for a file path based on language detection.
-    fn get_client_for_file(&self, path: &Path) -> Result<LspClient> {
+    /// Get a cloned LSP client for a file path and tool based on configured routes.
+    fn get_client_for_file_and_tool(&self, path: &Path, tool: &str) -> Result<LspClient> {
         let language_id = detect_language(path, &self.extension_map);
+        let server_key = self
+            .tool_routes
+            .get(&(language_id.clone(), tool.to_string()))
+            .unwrap_or(&language_id);
         self.lsp_clients
-            .get(&language_id)
+            .get(server_key)
             .cloned()
             .ok_or(Error::NoServerForLanguage(language_id))
+    }
+
+    /// Get a cloned LSP client for workspace-scoped tools.
+    fn get_client_for_workspace_tool(&self, tool: &str) -> Result<LspClient> {
+        let mut routed_server_keys =
+            self.tool_routes
+                .iter()
+                .filter_map(|((_, handle), server_key)| {
+                    if handle == tool {
+                        Some(server_key)
+                    } else {
+                        None
+                    }
+                });
+
+        if let Some(server_key) = routed_server_keys.next()
+            && routed_server_keys.all(|other| other == server_key)
+            && let Some(client) = self.lsp_clients.get(server_key)
+        {
+            return Ok(client.clone());
+        }
+
+        self.lsp_clients
+            .values()
+            .next()
+            .cloned()
+            .ok_or(Error::NoServerConfigured)
     }
 
     /// Parse and validate a file URI, returning the validated path.
@@ -612,7 +660,7 @@ impl Translator {
     ) -> Result<HoverResult> {
         let path = PathBuf::from(&file_path);
         let validated_path = self.validate_path(&path)?;
-        let client = self.get_client_for_file(&validated_path)?;
+        let client = self.get_client_for_file_and_tool(&validated_path, "hover")?;
         let uri = self
             .document_tracker
             .ensure_open(&validated_path, &client)
@@ -660,7 +708,7 @@ impl Translator {
     ) -> Result<DefinitionResult> {
         let path = PathBuf::from(&file_path);
         let validated_path = self.validate_path(&path)?;
-        let client = self.get_client_for_file(&validated_path)?;
+        let client = self.get_client_for_file_and_tool(&validated_path, "definition")?;
         let uri = self
             .document_tracker
             .ensure_open(&validated_path, &client)
@@ -721,7 +769,7 @@ impl Translator {
     ) -> Result<ReferencesResult> {
         let path = PathBuf::from(&file_path);
         let validated_path = self.validate_path(&path)?;
-        let client = self.get_client_for_file(&validated_path)?;
+        let client = self.get_client_for_file_and_tool(&validated_path, "references")?;
         let uri = self
             .document_tracker
             .ensure_open(&validated_path, &client)
@@ -768,7 +816,7 @@ impl Translator {
     pub async fn handle_diagnostics(&mut self, file_path: String) -> Result<DiagnosticsResult> {
         let path = PathBuf::from(&file_path);
         let validated_path = self.validate_path(&path)?;
-        let client = self.get_client_for_file(&validated_path)?;
+        let client = self.get_client_for_file_and_tool(&validated_path, "diagnostics")?;
         let uri = self
             .document_tracker
             .ensure_open(&validated_path, &client)
@@ -831,7 +879,7 @@ impl Translator {
     ) -> Result<RenameResult> {
         let path = PathBuf::from(&file_path);
         let validated_path = self.validate_path(&path)?;
-        let client = self.get_client_for_file(&validated_path)?;
+        let client = self.get_client_for_file_and_tool(&validated_path, "rename")?;
         let uri = self
             .document_tracker
             .ensure_open(&validated_path, &client)
@@ -927,7 +975,7 @@ impl Translator {
     ) -> Result<CompletionsResult> {
         let path = PathBuf::from(&file_path);
         let validated_path = self.validate_path(&path)?;
-        let client = self.get_client_for_file(&validated_path)?;
+        let client = self.get_client_for_file_and_tool(&validated_path, "completions")?;
         let uri = self
             .document_tracker
             .ensure_open(&validated_path, &client)
@@ -989,7 +1037,7 @@ impl Translator {
     ) -> Result<DocumentSymbolsResult> {
         let path = PathBuf::from(&file_path);
         let validated_path = self.validate_path(&path)?;
-        let client = self.get_client_for_file(&validated_path)?;
+        let client = self.get_client_for_file_and_tool(&validated_path, "document_symbols")?;
         let uri = self
             .document_tracker
             .ensure_open(&validated_path, &client)
@@ -1039,7 +1087,7 @@ impl Translator {
     ) -> Result<FormatDocumentResult> {
         let path = PathBuf::from(&file_path);
         let validated_path = self.validate_path(&path)?;
-        let client = self.get_client_for_file(&validated_path)?;
+        let client = self.get_client_for_file_and_tool(&validated_path, "format_document")?;
         let uri = self
             .document_tracker
             .ensure_open(&validated_path, &client)
@@ -1135,13 +1183,7 @@ impl Translator {
             )));
         }
 
-        // Workspace search requires at least one LSP client
-        let client = self
-            .lsp_clients
-            .values()
-            .next()
-            .cloned()
-            .ok_or(Error::NoServerConfigured)?;
+        let client = self.get_client_for_workspace_tool("workspace_symbols")?;
 
         let params = LspWorkspaceSymbolParams {
             query,
@@ -1203,7 +1245,7 @@ impl Translator {
 
         let path = PathBuf::from(&file_path);
         let validated_path = self.validate_path(&path)?;
-        let client = self.get_client_for_file(&validated_path)?;
+        let client = self.get_client_for_file_and_tool(&validated_path, "code_actions")?;
         let uri = self
             .document_tracker
             .ensure_open(&validated_path, &client)
@@ -1293,7 +1335,8 @@ impl Translator {
 
         let path = PathBuf::from(&file_path);
         let validated_path = self.validate_path(&path)?;
-        let client = self.get_client_for_file(&validated_path)?;
+        let client =
+            self.get_client_for_file_and_tool(&validated_path, "call_hierarchy_prepare")?;
         let uri = self
             .document_tracker
             .ensure_open(&validated_path, &client)
@@ -1341,7 +1384,7 @@ impl Translator {
 
         // Parse and validate the URI
         let path = self.parse_file_uri(&lsp_item.uri)?;
-        let client = self.get_client_for_file(&path)?;
+        let client = self.get_client_for_file_and_tool(&path, "call_hierarchy_incoming")?;
 
         let params = CallHierarchyIncomingCallsParams {
             item: lsp_item,
@@ -1390,7 +1433,7 @@ impl Translator {
 
         // Parse and validate the URI
         let path = self.parse_file_uri(&lsp_item.uri)?;
-        let client = self.get_client_for_file(&path)?;
+        let client = self.get_client_for_file_and_tool(&path, "call_hierarchy_outgoing")?;
 
         let params = CallHierarchyOutgoingCallsParams {
             item: lsp_item,
@@ -1549,7 +1592,7 @@ impl Translator {
     ) -> Result<SignatureHelpResult> {
         let path = PathBuf::from(&file_path);
         let validated_path = self.validate_path(&path)?;
-        let client = self.get_client_for_file(&validated_path)?;
+        let client = self.get_client_for_file_and_tool(&validated_path, "signature_help")?;
         let uri = self
             .document_tracker
             .ensure_open(&validated_path, &client)
@@ -1622,7 +1665,7 @@ impl Translator {
     ) -> Result<LocationsResult> {
         let path = PathBuf::from(&file_path);
         let validated_path = self.validate_path(&path)?;
-        let client = self.get_client_for_file(&validated_path)?;
+        let client = self.get_client_for_file_and_tool(&validated_path, "implementation")?;
         let uri = self
             .document_tracker
             .ensure_open(&validated_path, &client)
@@ -1664,7 +1707,7 @@ impl Translator {
     ) -> Result<LocationsResult> {
         let path = PathBuf::from(&file_path);
         let validated_path = self.validate_path(&path)?;
-        let client = self.get_client_for_file(&validated_path)?;
+        let client = self.get_client_for_file_and_tool(&validated_path, "type_definition")?;
         let uri = self
             .document_tracker
             .ensure_open(&validated_path, &client)
@@ -1710,7 +1753,7 @@ impl Translator {
 
         let path = PathBuf::from(&file_path);
         let validated_path = self.validate_path(&path)?;
-        let client = self.get_client_for_file(&validated_path)?;
+        let client = self.get_client_for_file_and_tool(&validated_path, "inlay_hints")?;
         let uri = self
             .document_tracker
             .ensure_open(&validated_path, &client)
@@ -2054,10 +2097,26 @@ fn convert_code_action(action: lsp_types::CodeAction) -> CodeAction {
 mod tests {
     use std::fs;
 
+    use crate::config::LspServerConfig;
     use tempfile::TempDir;
     use url::Url;
 
     use super::*;
+
+    fn test_lsp_client(server_key: &str, language_id: &str) -> LspClient {
+        LspClient::new(LspServerConfig {
+            name: Some(server_key.to_string()),
+            language_id: language_id.to_string(),
+            command: "test-lsp".to_string(),
+            args: vec![],
+            env: HashMap::new(),
+            file_patterns: vec![],
+            initialization_options: None,
+            timeout_seconds: 30,
+            heuristics: None,
+            handles: vec![],
+        })
+    }
 
     #[test]
     fn test_translator_new() {
@@ -3197,7 +3256,7 @@ mod tests {
     }
 
     #[test]
-    fn test_get_client_for_file_uses_custom_extension() {
+    fn test_get_client_for_file_and_tool_uses_custom_extension() {
         let temp_dir = TempDir::new().unwrap();
         let test_file = temp_dir.path().join("script.nu");
         fs::write(&test_file, "echo hello").unwrap();
@@ -3207,7 +3266,7 @@ mod tests {
 
         let translator = Translator::new().with_extensions(extension_map);
 
-        let result = translator.get_client_for_file(&test_file);
+        let result = translator.get_client_for_file_and_tool(&test_file, "hover");
 
         assert!(result.is_err());
         if let Err(Error::NoServerForLanguage(lang)) = result {
@@ -3218,7 +3277,7 @@ mod tests {
     }
 
     #[test]
-    fn test_get_client_for_file_falls_back_to_default() {
+    fn test_get_client_for_file_and_tool_falls_back_to_default() {
         let temp_dir = TempDir::new().unwrap();
         let test_file = temp_dir.path().join("unknown.xyz");
         fs::write(&test_file, "content").unwrap();
@@ -3228,7 +3287,7 @@ mod tests {
 
         let translator = Translator::new().with_extensions(extension_map);
 
-        let result = translator.get_client_for_file(&test_file);
+        let result = translator.get_client_for_file_and_tool(&test_file, "hover");
 
         assert!(result.is_err());
         if let Err(Error::NoServerForLanguage(lang)) = result {
@@ -3236,6 +3295,21 @@ mod tests {
         } else {
             panic!("Expected NoServerForLanguage(plaintext) error");
         }
+    }
+
+    #[test]
+    fn test_get_client_for_workspace_tool_uses_unique_route() {
+        let mut translator = Translator::new();
+        translator.register_client("pyright".to_string(), test_lsp_client("pyright", "pyright"));
+        translator.register_client("pylsp".to_string(), test_lsp_client("pylsp", "pylsp"));
+        translator.register_tool_routes("python", "pyright", ["workspace_symbols"]);
+        translator.register_tool_routes("python", "pylsp", ["diagnostics"]);
+
+        let client = translator
+            .get_client_for_workspace_tool("workspace_symbols")
+            .unwrap();
+
+        assert_eq!(client.language_id(), "pyright");
     }
 
     #[tokio::test]

--- a/crates/mcpls-core/src/config/mod.rs
+++ b/crates/mcpls-core/src/config/mod.rs
@@ -390,10 +390,18 @@ impl ServerConfig {
 
     /// Validate the configuration.
     fn validate(&self) -> Result<()> {
+        let mut routes: HashMap<(String, &'static str), String> = HashMap::new();
+
         for server in &self.lsp_servers {
+            let server_key = server.server_key();
             if server.language_id.is_empty() {
                 return Err(Error::InvalidConfig(
                     "language_id cannot be empty".to_string(),
+                ));
+            }
+            if server_key.is_empty() {
+                return Err(Error::InvalidConfig(
+                    "server name cannot be empty".to_string(),
                 ));
             }
             if server.command.is_empty() {
@@ -401,6 +409,22 @@ impl ServerConfig {
                     "command cannot be empty for language '{}'",
                     server.language_id
                 )));
+            }
+            for handle in &server.handles {
+                if LspServerConfig::normalize_handle(handle).is_none() {
+                    return Err(Error::InvalidConfig(format!(
+                        "unknown tool handle '{handle}' for server '{server_key}'"
+                    )));
+                }
+            }
+            for handle in server.normalized_handles() {
+                let route = (server.language_id.clone(), handle);
+                if let Some(existing) = routes.insert(route, server_key.clone()) {
+                    return Err(Error::InvalidConfig(format!(
+                        "tool handle '{handle}' for language '{}' is claimed by both '{}' and '{}'",
+                        server.language_id, existing, server_key
+                    )));
+                }
             }
         }
         Ok(())
@@ -584,6 +608,62 @@ mod tests {
     }
 
     #[test]
+    fn test_load_named_servers_with_split_handles() {
+        let tmp_dir = TempDir::new().unwrap();
+        let config_path = tmp_dir.path().join("routing.toml");
+
+        let toml_content = r#"
+            [[lsp_servers]]
+            name = "pyright"
+            language_id = "python"
+            command = "pyright-langserver"
+            args = ["--stdio"]
+            handles = ["hover", "definition", "references"]
+
+            [[lsp_servers]]
+            name = "pylsp"
+            language_id = "python"
+            command = "pylsp"
+            handles = ["diagnostics", "cached_diagnostics"]
+        "#;
+
+        fs::write(&config_path, toml_content).unwrap();
+
+        let config = ServerConfig::load_from(&config_path).unwrap();
+        assert_eq!(config.lsp_servers.len(), 2);
+        assert_eq!(config.lsp_servers[0].server_key(), "pyright");
+        assert_eq!(
+            config.lsp_servers[1].normalized_handles(),
+            vec!["diagnostics", "cached_diagnostics"]
+        );
+    }
+
+    #[test]
+    fn test_duplicate_tool_routes_are_rejected() {
+        let tmp_dir = TempDir::new().unwrap();
+        let config_path = tmp_dir.path().join("routing-conflict.toml");
+
+        let toml_content = r#"
+            [[lsp_servers]]
+            name = "pyright"
+            language_id = "python"
+            command = "pyright-langserver"
+            handles = ["diagnostics"]
+
+            [[lsp_servers]]
+            name = "pylsp"
+            language_id = "python"
+            command = "pylsp"
+            handles = ["get_diagnostics"]
+        "#;
+
+        fs::write(&config_path, toml_content).unwrap();
+
+        let result = ServerConfig::load_from(&config_path);
+        assert!(matches!(result, Err(Error::InvalidConfig(msg)) if msg.contains("diagnostics")));
+    }
+
+    #[test]
     fn test_deny_unknown_fields() {
         let tmp_dir = TempDir::new().unwrap();
         let config_path = tmp_dir.path().join("unknown.toml");
@@ -729,6 +809,7 @@ mod tests {
         let config = ServerConfig {
             workspace: WorkspaceConfig::default(),
             lsp_servers: vec![LspServerConfig {
+                name: None,
                 language_id: "cpp".to_string(),
                 command: "clangd".to_string(),
                 args: vec![],
@@ -737,6 +818,7 @@ mod tests {
                 initialization_options: None,
                 timeout_seconds: 30,
                 heuristics: None,
+                handles: vec![],
             }],
         };
 
@@ -750,6 +832,7 @@ mod tests {
         let config = ServerConfig {
             workspace: WorkspaceConfig::default(),
             lsp_servers: vec![LspServerConfig {
+                name: None,
                 language_id: "cpp".to_string(),
                 command: "clangd".to_string(),
                 args: vec![],
@@ -758,6 +841,7 @@ mod tests {
                 initialization_options: None,
                 timeout_seconds: 30,
                 heuristics: None,
+                handles: vec![],
             }],
         };
 

--- a/crates/mcpls-core/src/config/server.rs
+++ b/crates/mcpls-core/src/config/server.rs
@@ -146,6 +146,12 @@ impl ServerHeuristics {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct LspServerConfig {
+    /// Stable server name used for explicit tool routing.
+    ///
+    /// Defaults to `language_id` when omitted.
+    #[serde(default)]
+    pub name: Option<String>,
+
     /// Language identifier (e.g., "rust", "python", "typescript").
     pub language_id: String,
 
@@ -176,6 +182,12 @@ pub struct LspServerConfig {
     /// If not specified, the server will always attempt to spawn.
     #[serde(default)]
     pub heuristics: Option<ServerHeuristics>,
+
+    /// Tool handles this server should receive for its language.
+    ///
+    /// Empty means all supported tools for the language.
+    #[serde(default)]
+    pub handles: Vec<String>,
 }
 
 const fn default_timeout() -> u64 {
@@ -183,6 +195,84 @@ const fn default_timeout() -> u64 {
 }
 
 impl LspServerConfig {
+    /// Server key used internally for routing and lifetime management.
+    #[must_use]
+    pub fn server_key(&self) -> String {
+        self.name
+            .as_ref()
+            .filter(|name| !name.is_empty())
+            .cloned()
+            .unwrap_or_else(|| self.language_id.clone())
+    }
+
+    /// Normalize a user-facing tool handle into the internal routing key.
+    #[must_use]
+    pub fn normalize_handle(handle: &str) -> Option<&'static str> {
+        match handle {
+            "hover" | "get_hover" => Some("hover"),
+            "definition" | "get_definition" | "go_to_definition" => Some("definition"),
+            "references" | "get_references" | "find_references" => Some("references"),
+            "diagnostics" | "get_diagnostics" => Some("diagnostics"),
+            "cached_diagnostics" | "get_cached_diagnostics" => Some("cached_diagnostics"),
+            "completions" | "get_completions" => Some("completions"),
+            "document_symbols" | "get_document_symbols" => Some("document_symbols"),
+            "workspace_symbols" | "workspace_symbol_search" => Some("workspace_symbols"),
+            "format" | "format_document" => Some("format_document"),
+            "code_actions" | "get_code_actions" => Some("code_actions"),
+            "rename" | "rename_symbol" => Some("rename"),
+            "signature_help" | "get_signature_help" => Some("signature_help"),
+            "implementation" | "go_to_implementation" => Some("implementation"),
+            "type_definition" | "go_to_type_definition" => Some("type_definition"),
+            "inlay_hints" | "get_inlay_hints" => Some("inlay_hints"),
+            "call_hierarchy_prepare" | "prepare_call_hierarchy" => Some("call_hierarchy_prepare"),
+            "call_hierarchy_incoming" | "incoming_calls" | "get_incoming_calls" => {
+                Some("call_hierarchy_incoming")
+            }
+            "call_hierarchy_outgoing" | "outgoing_calls" | "get_outgoing_calls" => {
+                Some("call_hierarchy_outgoing")
+            }
+            _ => None,
+        }
+    }
+
+    /// Normalized handles for this server.
+    #[must_use]
+    pub fn normalized_handles(&self) -> Vec<&'static str> {
+        if self.handles.is_empty() {
+            return Self::all_handles();
+        }
+
+        self.handles
+            .iter()
+            .filter_map(|handle| Self::normalize_handle(handle))
+            .collect()
+    }
+
+    /// All routeable tool handles.
+    #[must_use]
+    pub fn all_handles() -> Vec<&'static str> {
+        vec![
+            "hover",
+            "definition",
+            "references",
+            "diagnostics",
+            "cached_diagnostics",
+            "completions",
+            "document_symbols",
+            "workspace_symbols",
+            "format_document",
+            "code_actions",
+            "rename",
+            "signature_help",
+            "implementation",
+            "type_definition",
+            "inlay_hints",
+            "call_hierarchy_prepare",
+            "call_hierarchy_incoming",
+            "call_hierarchy_outgoing",
+        ]
+    }
+
     /// Check if this server should be spawned for the given workspace.
     ///
     /// Uses recursive marker search to detect nested projects.
@@ -202,6 +292,7 @@ impl LspServerConfig {
     #[must_use]
     pub fn rust_analyzer() -> Self {
         Self {
+            name: None,
             language_id: "rust".to_string(),
             command: "rust-analyzer".to_string(),
             args: vec![],
@@ -213,6 +304,7 @@ impl LspServerConfig {
                 "Cargo.toml",
                 "rust-toolchain.toml",
             ])),
+            handles: vec![],
         }
     }
 
@@ -220,6 +312,7 @@ impl LspServerConfig {
     #[must_use]
     pub fn pyright() -> Self {
         Self {
+            name: None,
             language_id: "python".to_string(),
             command: "pyright-langserver".to_string(),
             args: vec!["--stdio".to_string()],
@@ -233,6 +326,7 @@ impl LspServerConfig {
                 "requirements.txt",
                 "pyrightconfig.json",
             ])),
+            handles: vec![],
         }
     }
 
@@ -240,6 +334,7 @@ impl LspServerConfig {
     #[must_use]
     pub fn typescript() -> Self {
         Self {
+            name: None,
             language_id: "typescript".to_string(),
             command: "typescript-language-server".to_string(),
             args: vec!["--stdio".to_string()],
@@ -252,6 +347,7 @@ impl LspServerConfig {
                 "tsconfig.json",
                 "jsconfig.json",
             ])),
+            handles: vec![],
         }
     }
 
@@ -259,6 +355,7 @@ impl LspServerConfig {
     #[must_use]
     pub fn gopls() -> Self {
         Self {
+            name: None,
             language_id: "go".to_string(),
             command: "gopls".to_string(),
             args: vec!["serve".to_string()],
@@ -267,6 +364,7 @@ impl LspServerConfig {
             initialization_options: None,
             timeout_seconds: default_timeout(),
             heuristics: Some(ServerHeuristics::with_markers(["go.mod", "go.sum"])),
+            handles: vec![],
         }
     }
 
@@ -274,6 +372,7 @@ impl LspServerConfig {
     #[must_use]
     pub fn clangd() -> Self {
         Self {
+            name: None,
             language_id: "cpp".to_string(),
             command: "clangd".to_string(),
             args: vec![],
@@ -292,6 +391,7 @@ impl LspServerConfig {
                 "Makefile",
                 ".clangd",
             ])),
+            handles: vec![],
         }
     }
 
@@ -299,6 +399,7 @@ impl LspServerConfig {
     #[must_use]
     pub fn zls() -> Self {
         Self {
+            name: None,
             language_id: "zig".to_string(),
             command: "zls".to_string(),
             args: vec![],
@@ -310,6 +411,7 @@ impl LspServerConfig {
                 "build.zig",
                 "build.zig.zon",
             ])),
+            handles: vec![],
         }
     }
 }
@@ -371,6 +473,7 @@ mod tests {
         env.insert("RUST_LOG".to_string(), "debug".to_string());
 
         let config = LspServerConfig {
+            name: None,
             language_id: "custom".to_string(),
             command: "custom-lsp".to_string(),
             args: vec!["--flag".to_string()],
@@ -379,6 +482,7 @@ mod tests {
             initialization_options: Some(serde_json::json!({"key": "value"})),
             timeout_seconds: 60,
             heuristics: None,
+            handles: vec![],
         };
 
         assert_eq!(config.language_id, "custom");
@@ -477,6 +581,7 @@ mod tests {
     #[test]
     fn test_should_spawn_without_heuristics() {
         let config = LspServerConfig {
+            name: None,
             language_id: "test".to_string(),
             command: "test-lsp".to_string(),
             args: vec![],
@@ -485,6 +590,7 @@ mod tests {
             initialization_options: None,
             timeout_seconds: 30,
             heuristics: None,
+            handles: vec![],
         };
 
         let tmp = TempDir::new().unwrap();

--- a/crates/mcpls-core/src/lib.rs
+++ b/crates/mcpls-core/src/lib.rs
@@ -156,15 +156,27 @@ pub(crate) async fn diagnostics_pump(
 fn register_servers(
     mut result: lsp::ServerInitResult,
     translator: &mut bridge::Translator,
+    configs: &[lsp::ServerInitConfig],
 ) -> std::collections::HashMap<String, tokio::sync::mpsc::Receiver<lsp::LspNotification>> {
+    let configs_by_key: std::collections::HashMap<_, _> = configs
+        .iter()
+        .map(|config| (config.server_config.server_key(), &config.server_config))
+        .collect();
     let mut receivers = std::collections::HashMap::new();
-    for (lang, server) in &mut result.servers {
-        receivers.insert(lang.clone(), server.take_notification_rx());
+    for (server_key, server) in &mut result.servers {
+        receivers.insert(server_key.clone(), server.take_notification_rx());
     }
-    for (language_id, server) in result.servers {
+    for (server_key, server) in result.servers {
         let client = server.client().clone();
-        translator.register_client(language_id.clone(), client);
-        translator.register_server(language_id.clone(), server);
+        translator.register_client(server_key.clone(), client);
+        if let Some(config) = configs_by_key.get(&server_key) {
+            translator.register_tool_routes(
+                &config.language_id,
+                &server_key,
+                config.normalized_handles(),
+            );
+        }
+        translator.register_server(server_key, server);
     }
     receivers
 }
@@ -341,7 +353,7 @@ pub async fn serve_with(config: ServerConfig, transport: Transport) -> Result<()
 
         // Register servers and extract their notification receivers.
         let server_count = result.server_count();
-        notification_receivers = register_servers(result, &mut translator);
+        notification_receivers = register_servers(result, &mut translator, &applicable_configs);
         info!("Proceeding with {} LSP server(s)", server_count);
     }
 
@@ -656,6 +668,7 @@ mod tests {
                     heuristics_max_depth: 10,
                 },
                 lsp_servers: vec![LspServerConfig {
+                    name: None,
                     language_id: "rust".to_string(),
                     command: "nonexistent-command-that-will-fail-12345".to_string(),
                     args: vec![],
@@ -664,6 +677,7 @@ mod tests {
                     initialization_options: None,
                     timeout_seconds: 10,
                     heuristics: None,
+                    handles: vec![],
                 }],
             };
 

--- a/crates/mcpls-core/src/lsp/lifecycle.rs
+++ b/crates/mcpls-core/src/lsp/lifecycle.rs
@@ -99,7 +99,7 @@ pub struct ServerInitConfig {
 /// ```
 #[derive(Debug)]
 pub struct ServerInitResult {
-    /// Successfully initialized servers (`language_id` -> server).
+    /// Successfully initialized servers (`server_key` -> server).
     pub servers: HashMap<String, LspServer>,
     /// Failures that occurred during spawn attempts.
     pub failures: Vec<ServerSpawnFailure>,
@@ -154,9 +154,9 @@ impl ServerInitResult {
 
     /// Add a successful server.
     ///
-    /// If a server with the same `language_id` already exists, it will be replaced.
-    pub fn add_server(&mut self, language_id: String, server: LspServer) {
-        self.servers.insert(language_id, server);
+    /// If a server with the same key already exists, it will be replaced.
+    pub fn add_server(&mut self, server_key: String, server: LspServer) {
+        self.servers.insert(server_key, server);
     }
 
     /// Add a failure.
@@ -504,6 +504,7 @@ impl LspServer {
 
         for config in configs {
             let language_id = config.server_config.language_id.clone();
+            let server_key = config.server_config.server_key();
             let command = config.server_config.command.clone();
 
             match Self::spawn(config.clone()).await {
@@ -512,7 +513,7 @@ impl LspServer {
                         "Successfully spawned LSP server: {} ({})",
                         language_id, command
                     );
-                    result.add_server(language_id, server);
+                    result.add_server(server_key, server);
                 }
                 Err(e) => {
                     tracing::error!(
@@ -638,6 +639,7 @@ mod tests {
 
         let config = ServerInitConfig {
             server_config: LspServerConfig {
+                name: None,
                 language_id: "python".to_string(),
                 command: "pyright-langserver".to_string(),
                 args: vec!["--stdio".to_string()],
@@ -646,6 +648,7 @@ mod tests {
                 initialization_options: Some(init_opts.clone()),
                 timeout_seconds: 10,
                 heuristics: None,
+                handles: vec![],
             },
             workspace_roots: vec![PathBuf::from("/workspace")],
             initialization_options: Some(init_opts),
@@ -1064,6 +1067,7 @@ mod tests {
     async fn test_spawn_batch_single_invalid_config() {
         let configs = vec![ServerInitConfig {
             server_config: LspServerConfig {
+                name: None,
                 language_id: "rust".to_string(),
                 command: "nonexistent-command-12345".to_string(),
                 args: vec![],
@@ -1072,6 +1076,7 @@ mod tests {
                 initialization_options: None,
                 timeout_seconds: 10,
                 heuristics: None,
+                handles: vec![],
             },
             workspace_roots: vec![],
             initialization_options: None,
@@ -1097,6 +1102,7 @@ mod tests {
         let configs = vec![
             ServerInitConfig {
                 server_config: LspServerConfig {
+                    name: None,
                     language_id: "rust".to_string(),
                     command: "nonexistent-rust-analyzer".to_string(),
                     args: vec![],
@@ -1105,6 +1111,7 @@ mod tests {
                     initialization_options: None,
                     timeout_seconds: 10,
                     heuristics: None,
+                    handles: vec![],
                 },
                 workspace_roots: vec![],
                 initialization_options: None,
@@ -1112,6 +1119,7 @@ mod tests {
             },
             ServerInitConfig {
                 server_config: LspServerConfig {
+                    name: None,
                     language_id: "python".to_string(),
                     command: "nonexistent-pyright".to_string(),
                     args: vec![],
@@ -1120,6 +1128,7 @@ mod tests {
                     initialization_options: None,
                     timeout_seconds: 10,
                     heuristics: None,
+                    handles: vec![],
                 },
                 workspace_roots: vec![],
                 initialization_options: None,
@@ -1127,6 +1136,7 @@ mod tests {
             },
             ServerInitConfig {
                 server_config: LspServerConfig {
+                    name: None,
                     language_id: "typescript".to_string(),
                     command: "nonexistent-tsserver".to_string(),
                     args: vec![],
@@ -1135,6 +1145,7 @@ mod tests {
                     initialization_options: None,
                     timeout_seconds: 10,
                     heuristics: None,
+                    handles: vec![],
                 },
                 workspace_roots: vec![],
                 initialization_options: None,
@@ -1165,6 +1176,7 @@ mod tests {
         let configs = vec![
             ServerInitConfig {
                 server_config: LspServerConfig {
+                    name: None,
                     language_id: "lang1".to_string(),
                     command: "cmd1-nonexistent".to_string(),
                     args: vec![],
@@ -1173,6 +1185,7 @@ mod tests {
                     initialization_options: None,
                     timeout_seconds: 10,
                     heuristics: None,
+                    handles: vec![],
                 },
                 workspace_roots: vec![],
                 initialization_options: None,
@@ -1180,6 +1193,7 @@ mod tests {
             },
             ServerInitConfig {
                 server_config: LspServerConfig {
+                    name: None,
                     language_id: "lang2".to_string(),
                     command: "cmd2-nonexistent".to_string(),
                     args: vec![],
@@ -1188,6 +1202,7 @@ mod tests {
                     initialization_options: None,
                     timeout_seconds: 10,
                     heuristics: None,
+                    handles: vec![],
                 },
                 workspace_roots: vec![],
                 initialization_options: None,
@@ -1211,6 +1226,7 @@ mod tests {
         let configs = vec![
             ServerInitConfig {
                 server_config: LspServerConfig {
+                    name: None,
                     language_id: "test1".to_string(),
                     command: "nonexistent-test1".to_string(),
                     args: vec![],
@@ -1219,6 +1235,7 @@ mod tests {
                     initialization_options: None,
                     timeout_seconds: 10,
                     heuristics: None,
+                    handles: vec![],
                 },
                 workspace_roots: vec![],
                 initialization_options: None,
@@ -1226,6 +1243,7 @@ mod tests {
             },
             ServerInitConfig {
                 server_config: LspServerConfig {
+                    name: None,
                     language_id: "test2".to_string(),
                     command: "nonexistent-test2".to_string(),
                     args: vec![],
@@ -1234,6 +1252,7 @@ mod tests {
                     initialization_options: None,
                     timeout_seconds: 10,
                     heuristics: None,
+                    handles: vec![],
                 },
                 workspace_roots: vec![],
                 initialization_options: None,

--- a/crates/mcpls-core/tests/integration/rust_analyzer_tests.rs
+++ b/crates/mcpls-core/tests/integration/rust_analyzer_tests.rs
@@ -48,6 +48,7 @@ async fn setup_rust_analyzer() -> Arc<Mutex<Translator>> {
     let workspace_path = rust_workspace_path();
 
     let lsp_config = LspServerConfig {
+        name: None,
         language_id: "rust".to_string(),
         command: "rust-analyzer".to_string(),
         args: vec![],
@@ -56,6 +57,7 @@ async fn setup_rust_analyzer() -> Arc<Mutex<Translator>> {
         initialization_options: None,
         timeout_seconds: 30,
         heuristics: None,
+        handles: vec![],
     };
 
     let server_init_config = ServerInitConfig {


### PR DESCRIPTION
Closes #174.

What changed
- Adds explicit tool routing for named LSP servers targeting the same file extension.

Validation
- Included in standalone integration branch `restart-standalone-integration`.
- `cargo test -p mcpls-core` passed.
- `cargo clippy -p mcpls-core --all-targets -- -D warnings` passed.
- Real rust-analyzer smoke passed: `cargo test -p mcpls-core --test integration_tests integration::rust_analyzer_tests::test_hover_on_u64_type -- --ignored --exact --nocapture`.