### PR TITLE
release: v0.3.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.7] - 2026-06-23
+
 ### Added
 
 - **Streamable HTTP transport** — opt-in `transport-http` Cargo feature enables MCP 2025-11-25 Streamable HTTP transport; pass `--listen <addr>` (or set `MCPLS_LISTEN`) to bind a TCP port instead of using stdio; `--http-path` (default `/mcp`) controls the URL prefix (#122)
@@ -517,7 +519,8 @@ Add to `~/.claude/mcp.json`:
 - Workspace auto-discovery
 - LSP server auto-detection and installation
 
-[Unreleased]: https://github.com/bug-ops/mcpls/compare/v0.3.6...HEAD
+[Unreleased]: https://github.com/bug-ops/mcpls/compare/v0.3.7...HEAD
+[0.3.7]: https://github.com/bug-ops/mcpls/compare/v0.3.6...v0.3.7
 [0.3.6]: https://github.com/bug-ops/mcpls/compare/v0.3.5...v0.3.6
 [0.3.5]: https://github.com/bug-ops/mcpls/compare/v0.3.4...v0.3.5
 [0.3.4]: https://github.com/bug-ops/mcpls/compare/v0.3.3...v0.3.4

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1307,9 +1307,9 @@ checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
 
 [[package]]
 name = "rmcp"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0810a9f717d9828f475fe1f629f4c305c8464b7f496c3a854b58d29e65f4058e"
+checksum = "1d1f571c72940a19d9532fe52dbea8bc9912bf1d766c2970bb824056b86f3f59"
 dependencies = [
  "async-trait",
  "base64",
@@ -1338,9 +1338,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aefac48c364756e97f04c0401ba3231e8607882c7c1d92da0437dc16307904d"
+checksum = "1aad0035b69380782d78ea95b508327e6deaa2235909053e596eea8f27b5e1d5"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -985,7 +985,7 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "mcpls"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1000,7 +1000,7 @@ dependencies = [
 
 [[package]]
 name = "mcpls-core"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.3.6"
+version = "0.3.7"
 edition = "2024"
 rust-version = "1.88"
 authors = ["Andrei G. <k05h31@gmail.com>"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,9 +25,9 @@ dirs = "6.0"
 futures = "0.3"
 ignore = "0.4"
 lsp-types = "0.97"
-mcpls-core = { path = "crates/mcpls-core", version = "0.3.6" }
+mcpls-core = { path = "crates/mcpls-core", version = "0.3.7" }
 predicates = "3.1"
-rmcp = "1.7.0"
+rmcp = "1.8.0"
 rstest = "0.26"
 schemars = "1.2"
 serde = "1.0"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![docs.rs](https://img.shields.io/docsrs/mcpls-core?label=mcpls-core)](https://docs.rs/mcpls-core)
 [![CI](https://img.shields.io/github/actions/workflow/status/bug-ops/mcpls/ci.yml?branch=main)](https://github.com/bug-ops/mcpls/actions)
 [![codecov](https://codecov.io/gh/bug-ops/mcpls/graph/badge.svg?token=FQEDLNF2GS)](https://codecov.io/gh/bug-ops/mcpls)
-[![MSRV](https://img.shields.io/badge/MSRV-1.85-blue)](https://blog.rust-lang.org/2025/02/20/Rust-1.85.0.html)
+[![MSRV](https://img.shields.io/badge/MSRV-1.88-blue)](https://blog.rust-lang.org/2025/05/15/Rust-1.88.0.html)
 [![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue)](LICENSE-MIT)
 
 **Stop treating code as text. Give your AI agent a compiler's understanding.**
@@ -322,7 +322,7 @@ cargo nextest run        # Test
 cargo run -- --log-level debug  # Run locally
 ```
 
-**Requirements:** Rust 1.85+ (Edition 2024)
+**Requirements:** Rust 1.88+ (Edition 2024)
 
 ## Contributing
 

--- a/crates/mcpls-cli/README.md
+++ b/crates/mcpls-cli/README.md
@@ -19,9 +19,10 @@ cargo install mcpls
 ## Usage
 
 ```bash
-mcpls                           # Run with defaults
-mcpls --log-level debug         # Verbose output
-mcpls --config ./mcpls.toml     # Custom config
+mcpls                                      # stdio transport (default)
+mcpls --log-level debug                    # verbose output
+mcpls --config ./mcpls.toml               # custom config
+mcpls --listen 127.0.0.1:3000             # HTTP transport (transport-http feature)
 ```
 
 ## Configuration
@@ -39,11 +40,13 @@ See the main [README](../../README.md) for configuration examples and custom ext
 
 ## Options
 
-| Flag | Description |
-|------|-------------|
-| `-c, --config <PATH>` | Configuration file path |
-| `-l, --log-level <LEVEL>` | trace, debug, info, warn, error |
-| `--log-json` | JSON-formatted logs for tooling |
+| Flag | Env | Description |
+|------|-----|-------------|
+| `-c, --config <PATH>` | `MCPLS_CONFIG` | Configuration file path |
+| `-l, --log-level <LEVEL>` | `MCPLS_LOG` | trace, debug, info, warn, error (default: info) |
+| `--log-json` | `MCPLS_LOG_JSON` | JSON-formatted logs for tooling |
+| `--listen <ADDR>` | `MCPLS_LISTEN` | Bind address for HTTP transport (`transport-http` feature) |
+| `--http-path <PATH>` | `MCPLS_HTTP_PATH` | URL prefix for HTTP transport (default: `/mcp`) |
 
 ## Claude Code Integration
 

--- a/crates/mcpls-core/README.md
+++ b/crates/mcpls-core/README.md
@@ -13,7 +13,9 @@ mcpls-core bridges MCP and LSP protocols, transforming AI tool calls into langua
 - **Protocol translation** — Converts MCP tool calls to LSP requests and back
 - **Position encoding** — Handles MCP's 1-based positions ↔ LSP's 0-based coordinates
 - **LSP lifecycle** — Manages language server processes (spawn, initialize, shutdown)
+- **Non-blocking startup** — MCP server accepts connections immediately; LSP initialization runs in the background
 - **Document tracking** — Lazy-loads files, maintains synchronization state
+- **Diagnostics cache** — Caches push-based `publishDiagnostics` notifications for fast polling via MCP
 - **Configuration** — Parses TOML configs, discovers LSP servers, manages language extension mappings
 - **Custom extension mapping** — Configurable file extension-to-language ID mappings with sensible defaults
 - **Graceful degradation** — Continues with available servers, even if some fail to initialize
@@ -25,7 +27,7 @@ mcpls-core bridges MCP and LSP protocols, transforming AI tool calls into langua
 
 ```toml
 [dependencies]
-mcpls-core = "0.3.1"
+mcpls-core = "0.3.7"
 ```
 
 ## Architecture
@@ -49,14 +51,13 @@ flowchart LR
 ## Usage
 
 ```rust
-use mcpls_core::config::Config;
-use mcpls_core::mcp::McplsServer;
+use mcpls_core::{ServerConfig, Transport};
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    let config = Config::load()?;
-    let server = McplsServer::new(config);
-    server.run().await
+    let config = ServerConfig::load()?;
+    mcpls_core::serve_with(config, Transport::Stdio).await?;
+    Ok(())
 }
 ```
 

--- a/crates/mcpls-core/tests/e2e/mcp_client.rs
+++ b/crates/mcpls-core/tests/e2e/mcp_client.rs
@@ -279,6 +279,18 @@ impl McpClient {
             anyhow::bail!("MCP error: {error:?}");
         }
 
+        // rmcp 1.8.0+: deserialization failures return isError=true inside a successful
+        // tools/call result instead of a JSON-RPC error (PR #894).
+        if response
+            .get("result")
+            .and_then(|r| r.get("isError"))
+            .and_then(serde_json::Value::as_bool)
+            .unwrap_or(false)
+        {
+            let content = response["result"]["content"].to_string();
+            anyhow::bail!("MCP tool error (isError=true): {content}");
+        }
+
         Ok(response)
     }
 

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -317,6 +317,27 @@ export MCPLS_LOG_JSON=true
 mcpls
 ```
 
+### `MCPLS_LISTEN` (transport-http feature)
+
+Bind address for Streamable HTTP transport. When set, mcpls binds this address
+instead of using stdio.
+
+```bash
+export MCPLS_LISTEN=127.0.0.1:3000
+mcpls
+```
+
+### `MCPLS_HTTP_PATH` (transport-http feature)
+
+URL prefix the MCP service is mounted at.
+
+**Default**: `/mcp`
+
+```bash
+export MCPLS_HTTP_PATH=/api/mcp
+mcpls
+```
+
 ## Complete Examples
 
 ### Rust Project (Zero Config)
@@ -491,6 +512,10 @@ mcpls --log-level debug
 
 # Enable JSON logging
 mcpls --log-json
+
+# HTTP transport (requires transport-http feature)
+mcpls --listen 127.0.0.1:3000
+mcpls --listen 127.0.0.1:3000 --http-path /api/mcp
 
 # Show version
 mcpls --version

--- a/docs/user-guide/getting-started.md
+++ b/docs/user-guide/getting-started.md
@@ -34,7 +34,6 @@ cargo install --path crates/mcpls-cli
 
 ```bash
 mcpls --version
-# Should output: mcpls 0.1.0
 ```
 
 ## Quick Start with Claude Code
@@ -43,8 +42,8 @@ mcpls --version
 
 Add mcpls to your Claude Code MCP configuration file:
 
-**macOS/Linux**: `~/.claude/mcp.json`
-**Windows**: `%APPDATA%\Claude\mcp.json`
+**macOS/Linux**: `~/.claude/claude_desktop_config.json`
+**Windows**: `%APPDATA%\Claude\claude_desktop_config.json`
 
 ```json
 {
@@ -65,15 +64,14 @@ After adding the configuration, restart Claude Code to load mcpls.
 
 Ask Claude: "What tools are available?"
 
-You should see 8 mcpls tools:
-- get_hover
-- get_definition
-- get_references
-- get_diagnostics
-- rename_symbol
-- get_completions
-- get_document_symbols
-- format_document
+You should see 20 mcpls tools, including:
+- get_hover, get_definition, get_references, get_completions
+- get_diagnostics, get_cached_diagnostics
+- get_document_symbols, workspace_symbol_search
+- rename_symbol, format_document, get_code_actions
+- get_signature_help, go_to_implementation, go_to_type_definition, get_inlay_hints
+- prepare_call_hierarchy, get_incoming_calls, get_outgoing_calls
+- get_server_logs, get_server_messages
 
 ### 4. Try It Out
 

--- a/docs/user-guide/installation.md
+++ b/docs/user-guide/installation.md
@@ -4,7 +4,7 @@ Complete installation guide for mcpls - the universal MCP to LSP bridge.
 
 ## Prerequisites
 
-- Rust 1.85 or later (for building from source)
+- Rust 1.88 or later (for building from source)
 - At least one Language Server installed (see [Language Server Setup](#language-server-setup))
 
 ## Installation Methods
@@ -21,7 +21,6 @@ Verify installation:
 
 ```bash
 mcpls --version
-# Should output: mcpls 0.1.0
 ```
 
 ### Method 2: Pre-Built Binaries from GitHub Releases
@@ -32,10 +31,10 @@ Download pre-built binaries for your platform from [GitHub Releases](https://git
 
 ```bash
 # Download latest release
-curl -LO https://github.com/bug-ops/mcpls/releases/latest/download/mcpls-v0.1.0-linux-x86_64.tar.gz
+curl -LO https://github.com/bug-ops/mcpls/releases/latest/download/mcpls-linux-x86_64.tar.gz
 
 # Extract archive
-tar xzf mcpls-v0.1.0-linux-x86_64.tar.gz
+tar xzf mcpls-linux-x86_64.tar.gz
 
 # Move to system path
 sudo mv mcpls /usr/local/bin/
@@ -48,10 +47,10 @@ mcpls --version
 
 ```bash
 # Download latest release
-curl -LO https://github.com/bug-ops/mcpls/releases/latest/download/mcpls-v0.1.0-macos-x86_64.tar.gz
+curl -LO https://github.com/bug-ops/mcpls/releases/latest/download/mcpls-macos-x86_64.tar.gz
 
 # Extract archive
-tar xzf mcpls-v0.1.0-macos-x86_64.tar.gz
+tar xzf mcpls-macos-x86_64.tar.gz
 
 # Move to system path
 sudo mv mcpls /usr/local/bin/
@@ -64,10 +63,10 @@ mcpls --version
 
 ```bash
 # Download latest release
-curl -LO https://github.com/bug-ops/mcpls/releases/latest/download/mcpls-v0.1.0-macos-aarch64.tar.gz
+curl -LO https://github.com/bug-ops/mcpls/releases/latest/download/mcpls-macos-aarch64.tar.gz
 
 # Extract archive
-tar xzf mcpls-v0.1.0-macos-aarch64.tar.gz
+tar xzf mcpls-macos-aarch64.tar.gz
 
 # Move to system path
 sudo mv mcpls /usr/local/bin/
@@ -78,7 +77,7 @@ mcpls --version
 
 #### Windows (x86_64)
 
-1. Download `mcpls-v0.1.0-windows-x86_64.zip` from [GitHub Releases](https://github.com/bug-ops/mcpls/releases)
+1. Download `mcpls-windows-x86_64.zip` from [GitHub Releases](https://github.com/bug-ops/mcpls/releases)
 2. Extract the archive to a directory
 3. Add the directory to your PATH environment variable
 4. Open a new terminal and verify:
@@ -97,7 +96,7 @@ git clone https://github.com/bug-ops/mcpls
 cd mcpls
 
 # Build and install
-cargo install --path crates/mcpls
+cargo install --path crates/mcpls-cli
 
 # Verify installation
 mcpls --version
@@ -461,7 +460,7 @@ Expected output should be a JSON response with `"method":"initialize"` result.
 
 **Solution:**
 ```bash
-# Update Rust to 1.85+
+# Update Rust to 1.88+
 rustup update stable
 rustup default stable
 

--- a/docs/user-guide/tools-reference.md
+++ b/docs/user-guide/tools-reference.md
@@ -1,6 +1,6 @@
 # MCP Tools Reference
 
-Complete reference for all 16 MCP tools provided by mcpls.
+Complete reference for all 20 MCP tools provided by mcpls.
 
 ## Overview
 
@@ -23,7 +23,7 @@ mcpls exposes semantic code intelligence from Language Server Protocol (LSP) ser
 
 | Tool | LSP Method | Description |
 |------|------------|-------------|
-| [get_diagnostics](#get_diagnostics) | `textDocument/publishDiagnostics` | Compiler errors and warnings |
+| [get_diagnostics](#get_diagnostics) | `textDocument/diagnostic` | Pull-based compiler errors and warnings |
 | [get_cached_diagnostics](#get_cached_diagnostics) | Cached notifications | Diagnostics from server push notifications |
 | [format_document](#format_document) | `textDocument/formatting` | Document formatting |
 
@@ -41,6 +41,15 @@ mcpls exposes semantic code intelligence from Language Server Protocol (LSP) ser
 | [prepare_call_hierarchy](#prepare_call_hierarchy) | `textDocument/prepareCallHierarchy` | Prepare call hierarchy at position |
 | [get_incoming_calls](#get_incoming_calls) | `callHierarchy/incomingCalls` | Functions that call the target |
 | [get_outgoing_calls](#get_outgoing_calls) | `callHierarchy/outgoingCalls` | Functions called by the target |
+
+### Navigation Tools
+
+| Tool | LSP Method | Description |
+|------|------------|-------------|
+| [get_signature_help](#get_signature_help) | `textDocument/signatureHelp` | Parameter signatures at a call site |
+| [go_to_implementation](#go_to_implementation) | `textDocument/implementation` | Jump to trait/interface implementations |
+| [go_to_type_definition](#go_to_type_definition) | `textDocument/typeDefinition` | Jump to the type definition of a value |
+| [get_inlay_hints](#get_inlay_hints) | `textDocument/inlayHint` | Inline type and parameter hints for a range |
 
 ### Server Monitoring Tools
 
@@ -890,6 +899,180 @@ Get recent show messages from LSP servers.
 
 - Contains user-facing messages from LSP servers
 - Useful for tracking server status and important notifications
+
+---
+
+## get_signature_help
+
+Get parameter signature information at a call site.
+
+### Parameters
+
+```json
+{
+  "file_path": "/path/to/file.rs",
+  "line": 10,
+  "character": 20
+}
+```
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `file_path` | string | Yes | Absolute path to the file |
+| `line` | integer | Yes | Line number (1-based) |
+| `character` | integer | Yes | Character position (1-based, UTF-8) |
+
+### Returns
+
+Signature help with active parameter highlighted:
+
+```json
+{
+  "signatures": [
+    {
+      "label": "fn process(input: &str, timeout: u32) -> Result<Output>",
+      "documentation": "Process the input string.",
+      "parameters": [
+        { "label": "input: &str" },
+        { "label": "timeout: u32" }
+      ],
+      "activeParameter": 1
+    }
+  ],
+  "activeSignature": 0,
+  "activeParameter": 1
+}
+```
+
+### Notes
+
+- Useful when the cursor is inside a function call's argument list
+- Returns `null` if no signature information is available
+
+---
+
+## go_to_implementation
+
+Jump to all implementations of a trait, interface, or abstract method.
+
+### Parameters
+
+```json
+{
+  "file_path": "/path/to/file.rs",
+  "line": 10,
+  "character": 5
+}
+```
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `file_path` | string | Yes | Absolute path to the file |
+| `line` | integer | Yes | Line number (1-based) |
+| `character` | integer | Yes | Character position (1-based, UTF-8) |
+
+### Returns
+
+Array of locations where the symbol is implemented:
+
+```json
+[
+  {
+    "uri": "file:///src/handlers/api_handler.rs",
+    "range": {
+      "start": { "line": 12, "character": 0 },
+      "end": { "line": 12, "character": 28 }
+    }
+  }
+]
+```
+
+### Example Use Cases
+
+```
+User: Show me all implementations of the Handler trait
+Claude: [Uses go_to_implementation] Found 3 implementations:
+        - src/handlers/api_handler.rs:12
+        - src/handlers/db_handler.rs:8
+        - src/handlers/file_handler.rs:5
+```
+
+---
+
+## go_to_type_definition
+
+Jump to the type definition of the value under the cursor (e.g. follow a typedef or type alias to its definition).
+
+### Parameters
+
+```json
+{
+  "file_path": "/path/to/file.rs",
+  "line": 10,
+  "character": 5
+}
+```
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `file_path` | string | Yes | Absolute path to the file |
+| `line` | integer | Yes | Line number (1-based) |
+| `character` | integer | Yes | Character position (1-based, UTF-8) |
+
+### Returns
+
+Array of type definition locations (same shape as [get_definition](#get_definition)).
+
+### Notes
+
+- Differs from `get_definition`: navigates to the *type* of an expression, not the expression itself
+- Useful for following type aliases, `impl Trait` return types, or generic bounds
+
+---
+
+## get_inlay_hints
+
+Get inline type and parameter hints for a range in a document.
+
+### Parameters
+
+```json
+{
+  "file_path": "/path/to/file.rs",
+  "start_line": 1,
+  "end_line": 50
+}
+```
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `file_path` | string | Yes | Absolute path to the file |
+| `start_line` | integer | Yes | First line of range (1-based) |
+| `end_line` | integer | Yes | Last line of range (1-based, inclusive) |
+
+### Returns
+
+Array of inlay hints with positions and labels:
+
+```json
+[
+  {
+    "position": { "line": 5, "character": 12 },
+    "label": ": Vec<String>",
+    "kind": "type"
+  },
+  {
+    "position": { "line": 8, "character": 24 },
+    "label": "timeout:",
+    "kind": "parameter"
+  }
+]
+```
+
+### Notes
+
+- Inlay hints show inferred types, parameter names, and other implicit information
+- Request only the lines visible to the AI agent to keep response size manageable
 
 ---
 

--- a/docs/user-guide/troubleshooting.md
+++ b/docs/user-guide/troubleshooting.md
@@ -42,10 +42,10 @@ which mcpls
 
 **Solution**:
 ```bash
-# Update to Rust 1.85 or later
+# Update to Rust 1.88 or later
 rustup update stable
 rustc --version
-# Should output: rustc 1.85.0 or higher
+# Should output: rustc 1.88.0 or higher
 ```
 
 **Problem**: Missing build dependencies
@@ -83,8 +83,8 @@ cargo install --path crates/mcpls-cli
 **Checklist**:
 1. Verify mcpls is installed: `mcpls --version`
 2. Check MCP configuration file exists
-   - macOS/Linux: `~/.claude/mcp.json`
-   - Windows: `%APPDATA%\Claude\mcp.json`
+   - macOS/Linux: `~/.claude/claude_desktop_config.json`
+   - Windows: `%APPDATA%\Claude\claude_desktop_config.json`
 3. Verify JSON syntax is valid (no trailing commas)
 4. Restart Claude Code completely (quit and reopen)
 5. Check Claude Code logs for errors
@@ -689,13 +689,18 @@ inotifywait -m ~/.config/mcpls/mcpls.toml
 
 ### Network debugging
 
-If using TCP transport (future feature):
+If using HTTP transport (`--listen` flag, requires `transport-http` feature):
 ```bash
-# Monitor network traffic
-tcpdump -i lo0 -A port 8080
+# Start with HTTP transport
+mcpls --listen 127.0.0.1:3000
 
-# Test with netcat
-nc localhost 8080
+# Monitor network traffic
+tcpdump -i lo0 -A port 3000
+
+# Test MCP over HTTP with curl
+curl -X POST http://127.0.0.1:3000/mcp \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{}}}'
 ```
 
 ---


### PR DESCRIPTION
## Summary

- Bump version from 0.3.6 to 0.3.7
- Update CHANGELOG.md: finalize [Unreleased] section as [0.3.7] - 2026-06-23
- Update comparison links

## Checklist

- [x] Version updated in workspace Cargo.toml (members inherit via `version.workspace = true`)
- [x] Cargo.lock regenerated
- [x] CHANGELOG.md has release section with date
- [x] `cargo +nightly fmt --check` passed
- [x] `cargo clippy --all-targets --all-features --workspace -- -D warnings` passed
- [x] `cargo nextest run --workspace --all-features --lib --bins` passed (395/395)
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features` passed
- [ ] Ready for tagging after merge

## After merge

```bash
git tag v0.3.7 && git push origin v0.3.7
```