### PR TITLE
docs: add ty language server configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,9 +66,14 @@ rustup component add rust-analyzer
 # Or: brew install rust-analyzer (macOS)
 ```
 
-**Python (pyright):**
+**Python (pyright, built-in default):**
 ```bash
 npm install -g pyright
+```
+
+**Python ([ty](https://docs.astral.sh/ty/), with custom configuration):**
+```bash
+uv tool install ty@latest
 ```
 
 **TypeScript:**
@@ -261,7 +266,7 @@ mcpls works with any LSP 3.17 compliant server. Battle-tested with:
 | Language | Server | Notes |
 |----------|--------|-------|
 | Rust | rust-analyzer | Zero-config, built-in support |
-| Python | pyright | Full type inference |
+| Python | pyright (default), ty | Full type inference |
 | TypeScript/JS | typescript-language-server | JSX/TSX support |
 | Go | gopls | Modules and workspaces |
 | C/C++ | clangd | compile_commands.json |

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -367,6 +367,19 @@ python.analysis.typeCheckingMode = "basic"
 python.analysis.autoSearchPaths = true
 ```
 
+To use [ty](https://docs.astral.sh/ty/) instead of the default Pyright server:
+
+```toml
+[[lsp_servers]]
+language_id = "python"
+command = "ty"
+args = ["server"]
+file_patterns = ["**/*.py", "**/*.pyi"]
+
+[lsp_servers.heuristics]
+project_markers = ["pyproject.toml", "ty.toml"]
+```
+
 ### TypeScript/JavaScript Project
 
 ```toml


### PR DESCRIPTION
## Problem

Python setup only documents Pyright, so users cannot see how to run mcpls with ty.

## Root cause

The README and configuration guide only cover mcpls's built-in Python server.

## Fix

Document ty as a configured Python alternative, including its install command and `ty server` configuration.

## Validation

- `git diff --check`
- `ty server --help` with ty 0.0.56
- mcpls 0.3.7 with ty 0.0.56 returned diagnostics, document symbols, hover, and references on a Python project
