### PR TITLE
fix: bump crossbeam-epoch to 0.9.20 to resolve RUSTSEC-2026-0204

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **RUSTSEC-2026-0204** — bump transitive `crossbeam-epoch` dependency (pulled in via `ignore`) from 0.9.18 to 0.9.20 to resolve an invalid pointer dereference in `fmt::Pointer` impls for `Atomic`/`Shared`
+
 ## [0.3.7] - 2026-06-23
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -321,9 +321,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/crates/mcpls-core/src/mcp/handlers.rs
+++ b/crates/mcpls-core/src/mcp/handlers.rs
@@ -46,6 +46,6 @@ mod tests {
         let translator = Arc::new(Mutex::new(Translator::new()));
         let subscriptions = Arc::new(ResourceSubscriptions::new());
         let context = HandlerContext::new(translator, subscriptions);
-        assert!(Arc::strong_count(&context.translator) == 1);
+        assert_eq!(Arc::strong_count(&context.translator), 1);
     }
 }


### PR DESCRIPTION
## Summary
- The `ignore` crate pulls in `crossbeam-epoch` 0.9.18, which is affected by RUSTSEC-2026-0204 (invalid pointer dereference in `fmt::Pointer` impls for `Atomic`/`Shared`)
- `cargo update -p crossbeam-epoch` bumps it to 0.9.20, the patched version
- This advisory is currently failing `Security Audit` / `CI Gate` on every open PR, including dependabot PR #204

## Test plan
- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo nextest run --workspace --all-features --lib --bins` (395 passed)
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`
- [x] `cargo deny check advisories` reports `advisories ok`