### PR TITLE
fix(ci): allow CodeQL to check out fork PR head SHA

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -34,6 +34,11 @@ jobs:
           # For push/schedule: github.sha resolves to the pushed commit.
           # Safe because this job has no access to secrets.
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          # actions/checkout v7 refuses fork checkouts in pull_request_target
+          # workflows by default ("pwn request" guard). Opting in is safe here
+          # per the threat model documented above: no secrets, permissions
+          # scoped to security-events:write + contents:read only.
+          allow-unsafe-pr-checkout: true
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **CodeQL fork PR checkout** — `actions/checkout@v7` refuses to check out a fork PR's head SHA in `pull_request_target` workflows unless explicitly opted in; set `allow-unsafe-pr-checkout: true` on the CodeQL workflow's checkout step, which was failing every fork-originated PR since the checkout v6 → v7 bump. Safe here because the job carries no secrets and permissions are scoped to `security-events: write` + `contents: read` only.
+
 ### Changed
 
 - **`rmcp` 2.2.0** — Breaking change upstream: bump `rmcp` from 1.8.0 to 2.2.0 to align with the MCP 2025-11-25 spec. `rmcp::model::RawResource` and the `Annotated<RawResource>` wrapper were merged into a single flat `rmcp::model::Resource` struct; `McplsServer::list_resources` updated accordingly.


### PR DESCRIPTION
## Summary
- `actions/checkout@v7` refuses to check out a fork pull request's head SHA inside a `pull_request_target` workflow unless explicitly opted in (a new "pwn request" guard) — this has been failing CodeQL analysis on every fork-originated PR (e.g. #208) since the checkout v6 -> v7 bump
- Set `allow-unsafe-pr-checkout: true` on the CodeQL workflow's checkout step
- This is safe here: the job carries no secrets (top-level `permissions: {}`) and the analyze job's permissions are scoped to `security-events: write` + `contents: read` only, matching the threat-model comment already documented in the workflow

## Test plan
- [x] `fy lint .github/workflows/codeql.yml` — no errors (pre-existing style infos only)
- [ ] Confirm `Analyze (actions)` / `Analyze (rust)` pass once this merges and PR #208 (or another fork PR) re-runs CodeQL