### PR TITLE
fix(lsp): encode reserved chars in workspace root URIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`path_to_uri` produced invalid `file://` URIs for paths containing RFC 3986 reserved characters** — filesystem paths containing `[`, `]`, `^`, or `|` (e.g. Next.js dynamic route files like `[...slug].ts`) were embedded in LSP `file://` URIs unencoded; these characters are now percent-encoded (`%5B`, `%5D`, `%5E`, `%7C`), and `uri_to_path` decodes them back to the original path on the return trip. (#151)
 - **RUSTSEC-2026-0204** — bump transitive `crossbeam-epoch` dependency (pulled in via `ignore`) from 0.9.18 to 0.9.20 to resolve an invalid pointer dereference in `fmt::Pointer` impls for `Atomic`/`Shared`
 - **TSX/JSX diagnostics** — Preserve `typescriptreact`/`javascriptreact` language IDs when deriving mappings from TypeScript/JavaScript server `file_patterns`, fixing JSX parse errors when one server handles both plain and React extensions. (#148)
+- **Workspace root URIs** — Build `initialize` workspace folder URIs with the shared `bridge::path_to_uri` encoder instead of splicing raw paths, so a root containing `#` no longer truncates to its parent directory and roots containing `[`/`]` no longer fail initialization. (#221)
 
 ## [0.3.7] - 2026-06-23
 

--- a/crates/mcpls-core/src/bridge/mod.rs
+++ b/crates/mcpls-core/src/bridge/mod.rs
@@ -16,6 +16,7 @@ pub use notifications::{
     DiagnosticInfo, LogEntry, LogLevel, MessageType, NotificationCache, ServerMessage,
 };
 pub use resources::ResourceSubscriptions;
+pub(crate) use state::try_path_to_uri;
 pub use state::{DocumentState, DocumentTracker, path_to_uri, uri_to_path};
 pub(crate) use translator::validate_path_against_roots;
 pub use translator::{

--- a/crates/mcpls-core/src/bridge/state.rs
+++ b/crates/mcpls-core/src/bridge/state.rs
@@ -738,34 +738,38 @@ pub fn path_to_uri(path: &Path) -> Uri {
 /// where a bad value should surface as an error rather than a panic.
 #[must_use]
 pub fn try_path_to_uri(path: &Path) -> Option<Uri> {
-    let uri_string = encode_rfc3986_path_chars(&file_uri_string(path)?);
+    let uri_string = encode_rfc3986_path_chars(&file_url(path)?);
     uri_string.parse().ok()
 }
 
 #[cfg(not(windows))]
-fn file_uri_string(path: &Path) -> Option<String> {
-    Url::from_file_path(path).ok().map(Into::into)
+fn file_url(path: &Path) -> Option<Url> {
+    Url::from_file_path(path).ok()
 }
 
 #[cfg(windows)]
-fn file_uri_string(path: &Path) -> Option<String> {
+fn file_url(path: &Path) -> Option<Url> {
     match Url::from_file_path(path) {
-        Ok(file_url) => Some(file_url.into()),
-        Err(()) if path.has_root() => Some(windows_rooted_path_to_file_uri(path)),
+        Ok(file_url) => Some(file_url),
+        Err(()) if path.has_root() => windows_rooted_path_to_file_url(path),
         Err(()) => None,
     }
 }
 
 #[cfg(windows)]
-fn windows_rooted_path_to_file_uri(path: &Path) -> String {
+fn windows_rooted_path_to_file_url(path: &Path) -> Option<Url> {
     let path_str = path.to_string_lossy();
     let stripped = path_str.strip_prefix(r"\\?\").unwrap_or(&path_str);
-    format!("file:///{}", stripped.replace('\\', "/"))
+    let mut file_url = Url::parse("file:///").ok()?;
+    file_url.path_segments_mut().ok()?.clear().extend(
+        stripped
+            .split(['\\', '/'])
+            .filter(|segment| !segment.is_empty()),
+    );
+    Some(file_url)
 }
 
-fn encode_rfc3986_path_chars(uri: &str) -> String {
-    #[allow(clippy::expect_used)]
-    let url = Url::parse(uri).expect("encode called with invalid URI");
+fn encode_rfc3986_path_chars(url: &Url) -> String {
     let prefix = url[..url::Position::BeforePath].to_owned();
     let encoded = url[url::Position::BeforePath..]
         .replace('[', "%5B")
@@ -1213,6 +1217,14 @@ mod tests {
     #[test]
     fn test_try_path_to_uri_returns_none_for_relative_path() {
         assert_eq!(try_path_to_uri(Path::new("relative/file.ts")), None);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn test_try_path_to_uri_encodes_synthetic_windows_root() {
+        let uri = try_path_to_uri(Path::new("/home/user/#work %23")).unwrap();
+
+        assert_eq!(uri.as_str(), "file:///home/user/%23work%20%2523");
     }
 
     #[test]

--- a/crates/mcpls-core/src/bridge/state.rs
+++ b/crates/mcpls-core/src/bridge/state.rs
@@ -727,25 +727,32 @@ impl Decision {
 /// not occur for valid absolute paths.
 #[must_use]
 pub fn path_to_uri(path: &Path) -> Uri {
-    let uri_string = file_uri_string(path);
-    let uri_string = encode_rfc3986_path_chars(&uri_string);
     #[allow(clippy::expect_used)]
-    uri_string.parse().expect("failed to create URI from path")
+    try_path_to_uri(path).expect("failed to create URI from path")
+}
+
+/// Convert a file path to a URI, returning `None` if the path cannot be
+/// represented as a `file://` URI.
+///
+/// Prefer this over [`path_to_uri`] on paths that come from configuration,
+/// where a bad value should surface as an error rather than a panic.
+#[must_use]
+pub fn try_path_to_uri(path: &Path) -> Option<Uri> {
+    let uri_string = encode_rfc3986_path_chars(&file_uri_string(path)?);
+    uri_string.parse().ok()
 }
 
 #[cfg(not(windows))]
-fn file_uri_string(path: &Path) -> String {
-    #[allow(clippy::expect_used)]
-    let file_url = Url::from_file_path(path).expect("failed to create file URI from path");
-    file_url.into()
+fn file_uri_string(path: &Path) -> Option<String> {
+    Url::from_file_path(path).ok().map(Into::into)
 }
 
 #[cfg(windows)]
-fn file_uri_string(path: &Path) -> String {
+fn file_uri_string(path: &Path) -> Option<String> {
     match Url::from_file_path(path) {
-        Ok(file_url) => file_url.into(),
-        Err(()) if path.has_root() => windows_rooted_path_to_file_uri(path),
-        Err(()) => panic!("failed to create file URI from path"),
+        Ok(file_url) => Some(file_url.into()),
+        Err(()) if path.has_root() => Some(windows_rooted_path_to_file_uri(path)),
+        Err(()) => None,
     }
 }
 
@@ -1201,6 +1208,11 @@ mod tests {
             Some(path),
             "encoded file URI should round-trip to the original path"
         );
+    }
+
+    #[test]
+    fn test_try_path_to_uri_returns_none_for_relative_path() {
+        assert_eq!(try_path_to_uri(Path::new("relative/file.ts")), None);
     }
 
     #[test]

--- a/crates/mcpls-core/src/lsp/lifecycle.rs
+++ b/crates/mcpls-core/src/lsp/lifecycle.rs
@@ -8,19 +8,19 @@
 //! 5. Graceful shutdown sequence
 
 use std::collections::HashMap;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::Stdio;
-use std::str::FromStr;
 
 use lsp_types::{
     ClientCapabilities, ClientInfo, GeneralClientCapabilities, InitializeParams, InitializeResult,
-    InitializedParams, PositionEncodingKind, ServerCapabilities, Uri, WorkspaceFolder,
+    InitializedParams, PositionEncodingKind, ServerCapabilities, WorkspaceFolder,
 };
 use tokio::process::Command;
 use tokio::sync::mpsc;
 use tokio::time::Duration;
 use tracing::{debug, info};
 
+use crate::bridge::try_path_to_uri;
 use crate::config::{LspServerConfig, ServerId};
 use crate::error::{Error, Result, ServerSpawnFailure};
 use crate::lsp::client::LspClient;
@@ -284,31 +284,7 @@ impl LspServer {
         let workspace_folders: Vec<WorkspaceFolder> = config
             .workspace_roots
             .iter()
-            .map(|root| {
-                let path_str = root.to_str().ok_or_else(|| {
-                    let root_display = root.display();
-                    Error::InvalidUri(format!("Invalid UTF-8 in path: {root_display}"))
-                })?;
-                let uri_str = if cfg!(windows) {
-                    // Strip \\?\ extended-path prefix that canonicalize() adds on Windows.
-                    let stripped = path_str.strip_prefix(r"\\?\").unwrap_or(path_str);
-                    format!("file:///{}", stripped.replace('\\', "/"))
-                } else {
-                    format!("file://{path_str}")
-                };
-                let uri = Uri::from_str(&uri_str).map_err(|_| {
-                    let root_display = root.display();
-                    Error::InvalidUri(format!("Invalid workspace root: {root_display}"))
-                })?;
-                Ok(WorkspaceFolder {
-                    uri,
-                    name: root
-                        .file_name()
-                        .and_then(|n| n.to_str())
-                        .unwrap_or("workspace")
-                        .to_string(),
-                })
-            })
+            .map(|root| workspace_folder(root))
             .collect::<Result<Vec<_>>>()?;
 
         let params = InitializeParams {
@@ -543,6 +519,26 @@ impl LspServer {
     }
 }
 
+/// Build the `workspace/workspaceFolders` entry for one configured root.
+///
+/// Reserved characters have to be percent-encoded here: an unencoded `#`
+/// would truncate the path into a URI fragment, and `[` / `]` are rejected
+/// outright by `Uri`.
+fn workspace_folder(root: &Path) -> Result<WorkspaceFolder> {
+    let uri = try_path_to_uri(root).ok_or_else(|| {
+        let root_display = root.display();
+        Error::InvalidUri(format!("Invalid workspace root: {root_display}"))
+    })?;
+    Ok(WorkspaceFolder {
+        uri,
+        name: root
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or("workspace")
+            .to_string(),
+    })
+}
+
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod tests {
@@ -564,6 +560,52 @@ mod tests {
     fn test_server_state_initializing() {
         assert!(!ServerState::Initializing.is_ready());
         assert!(!ServerState::Initializing.can_accept_requests());
+    }
+
+    #[test]
+    fn test_workspace_folder_encodes_fragment_char() {
+        // An unencoded `#` parses as a fragment, silently handing the server
+        // the parent directory as its root.
+        #[cfg(windows)]
+        let (root, expected) = (
+            Path::new(r"C:\home\me\dev\#work"),
+            "file:///C:/home/me/dev/%23work",
+        );
+        #[cfg(not(windows))]
+        let (root, expected) = (
+            Path::new("/home/me/dev/#work"),
+            "file:///home/me/dev/%23work",
+        );
+
+        let folder = workspace_folder(root).unwrap();
+
+        assert_eq!(folder.uri.as_str(), expected);
+        assert_eq!(folder.name, "#work");
+    }
+
+    #[test]
+    fn test_workspace_folder_encodes_bracket_chars() {
+        #[cfg(windows)]
+        let (root, expected) = (
+            Path::new(r"C:\home\me\dev\[env]"),
+            "file:///C:/home/me/dev/%5Benv%5D",
+        );
+        #[cfg(not(windows))]
+        let (root, expected) = (
+            Path::new("/home/me/dev/[env]"),
+            "file:///home/me/dev/%5Benv%5D",
+        );
+
+        let folder = workspace_folder(root).unwrap();
+
+        assert_eq!(folder.uri.as_str(), expected);
+        assert_eq!(folder.name, "[env]");
+    }
+
+    #[test]
+    fn test_workspace_folder_rejects_relative_root() {
+        let err = workspace_folder(Path::new("relative/root")).unwrap_err();
+        assert!(matches!(err, Error::InvalidUri(_)), "got {err:?}");
     }
 
     #[test]


### PR DESCRIPTION
Closes #221.

## Problem

`initialize` built workspace folder URIs by splicing raw paths, so a workspace root containing reserved characters was sent wrong or rejected:

- `#` parsed cleanly but truncated. `/home/me/dev/#work` became path `/home/me/dev/` with fragment `work`, so the server silently received the parent directory as its root.
- `[` and `]` were rejected by `Uri::from_str`, failing initialization with `Invalid workspace root`.

## Root cause

`lsp/lifecycle.rs` predates `bridge::path_to_uri` (#151) and never used it, so it carried its own `format!("file://{path_str}")` plus a duplicate copy of the Windows `\\?\` stripping the shared helper already does.

## Fix

Route the mapping through the shared encoder. `path_to_uri` panics and this call site returns `Result`, so `try_path_to_uri` becomes the fallible core and `path_to_uri` a thin wrapper over it; the new helper is crate-internal. The per-root mapping moves into `workspace_folder` so it is testable without a live LSP client.

Incidental: the `Invalid UTF-8 in path` branch is gone, since `Url::from_file_path` takes a `&Path`. Non-UTF-8 roots now work instead of erroring.

## Validation

- `cargo +nightly fmt --check`, `cargo +1.95 clippy --all-targets --all-features -- -D warnings`
- `cargo +1.95 nextest run` — 412 passed, 33 skipped
- `cargo +1.95 check -p mcpls-core --target x86_64-pc-windows-msvc --all-targets --all-features`, since #151 hit Windows-only breakage. New tests use `C:\...` roots on Windows and `/...` elsewhere, matching `state.rs`.
- The three new `workspace_folder` tests fail against the pre-fix logic with the predicted symptom: `left: "file:///home/me/dev/#work"`, `right: "file:///home/me/dev/%23work"`.
