### PR TITLE
fix: hover test off-by-one positions and diagnostics replay on subscribe

### DIFF
--- a/crates/mcpls-core/src/lib.rs
+++ b/crates/mcpls-core/src/lib.rs
@@ -118,9 +118,6 @@ pub(crate) async fn diagnostics_pump(
                         let Some(path) = bridge::uri_to_path(&p.uri) else { continue };
                         let Ok(mcp_uri) = make_uri(&path) else { continue };
 
-                        // TODO(critic-S3): on subscribe, replay cached diagnostics once
-                        // so clients that subscribe after the first PublishDiagnostics
-                        // do not have to wait for the next LSP push.
                         if !subs.contains(&mcp_uri).await {
                             continue;
                         }

--- a/crates/mcpls-core/src/mcp/server.rs
+++ b/crates/mcpls-core/src/mcp/server.rs
@@ -679,10 +679,14 @@ impl ServerHandler for McplsServer {
         };
 
         if has_cached_diagnostics {
-            let _ = context
+            let uri = request.uri.clone();
+            if let Err(e) = context
                 .peer
                 .notify_resource_updated(ResourceUpdatedNotificationParam::new(request.uri))
-                .await;
+                .await
+            {
+                tracing::warn!("Failed to replay cached diagnostics for {uri}: {e}");
+            }
         }
 
         Ok(())

--- a/crates/mcpls-core/src/mcp/server.rs
+++ b/crates/mcpls-core/src/mcp/server.rs
@@ -657,6 +657,14 @@ impl ServerHandler for McplsServer {
         let validated_path = validate_path_against_roots(&path, &self.context.workspace_roots)
             .map_err(|e| McpError::invalid_params(e.to_string(), None))?;
 
+        // Track and reply under the canonical resource URI, not the client's raw
+        // `request.uri`: `diagnostics_pump` derives `mcp_uri` from the canonical LSP
+        // path (see below), so a subscription keyed by a non-canonical but equivalent
+        // URI (symlink, macOS /var vs /private/var, ...) would never match its
+        // `subs.contains` check and silently stop receiving pushes.
+        let canonical_uri =
+            make_uri(&validated_path).map_err(|e| McpError::invalid_params(e.to_string(), None))?;
+
         // Record the subscription *before* checking the cache. This closes the race where
         // a PublishDiagnostics notification lands between the cache check and the
         // subscription being recorded: if diagnostics arrive before this point, the check
@@ -665,7 +673,7 @@ impl ServerHandler for McplsServer {
         // update through the normal push path.
         self.context
             .subscriptions
-            .subscribe(request.uri.clone())
+            .subscribe(canonical_uri.clone())
             .await
             .map_err(|e| McpError::invalid_params(e, None))?;
 
@@ -677,15 +685,15 @@ impl ServerHandler for McplsServer {
             cache.get_diagnostics(lsp_uri.as_str()).is_some()
         };
 
-        if has_cached_diagnostics {
-            let uri = request.uri.clone();
-            if let Err(e) = context
+        if has_cached_diagnostics
+            && let Err(e) = context
                 .peer
-                .notify_resource_updated(ResourceUpdatedNotificationParam::new(request.uri))
+                .notify_resource_updated(ResourceUpdatedNotificationParam::new(
+                    canonical_uri.clone(),
+                ))
                 .await
-            {
-                tracing::warn!("Failed to replay cached diagnostics for {uri}: {e}");
-            }
+        {
+            tracing::warn!("Failed to replay cached diagnostics for {canonical_uri}: {e}");
         }
 
         Ok(())
@@ -697,8 +705,18 @@ impl ServerHandler for McplsServer {
         _context: rmcp::service::RequestContext<RoleServer>,
     ) -> Result<(), McpError> {
         // Parse the URI for consistency with subscribe validation.
-        parse_uri(&request.uri).map_err(|e| McpError::invalid_params(e.to_string(), None))?;
-        self.context.subscriptions.unsubscribe(&request.uri).await;
+        let path =
+            parse_uri(&request.uri).map_err(|e| McpError::invalid_params(e.to_string(), None))?;
+
+        // Remove under the same canonical URI `subscribe` recorded under. Best-effort
+        // fall back to the raw URI if canonicalization fails (e.g. the file was
+        // deleted since subscribing) so unsubscribing a stale entry never errors.
+        let key = validate_path_against_roots(&path, &self.context.workspace_roots)
+            .ok()
+            .and_then(|validated_path| make_uri(&validated_path).ok())
+            .unwrap_or_else(|| request.uri.clone());
+
+        self.context.subscriptions.unsubscribe(&key).await;
         Ok(())
     }
 

--- a/crates/mcpls-core/src/mcp/server.rs
+++ b/crates/mcpls-core/src/mcp/server.rs
@@ -9,8 +9,8 @@ use std::sync::Arc;
 use rmcp::handler::server::wrapper::Parameters;
 use rmcp::model::{
     Implementation, ListResourcesResult, ReadResourceRequestParams, ReadResourceResult, Resource,
-    ResourceContents, ServerCapabilities, ServerInfo, SubscribeRequestParams,
-    UnsubscribeRequestParams,
+    ResourceContents, ResourceUpdatedNotificationParam, ServerCapabilities, ServerInfo,
+    SubscribeRequestParams, UnsubscribeRequestParams,
 };
 use rmcp::{ErrorData as McpError, RoleServer, ServerHandler, tool, tool_handler, tool_router};
 use tokio::sync::Mutex;
@@ -639,10 +639,14 @@ impl ServerHandler for McplsServer {
         )]))
     }
 
+    /// When cached diagnostics exist, the replay notification is flushed to the client
+    /// before this call returns its own response; this is legal per JSON-RPC/MCP, which
+    /// permits notifications to interleave with in-flight requests, so a conformant
+    /// client must demultiplex by request `id` rather than assume response-before-notification ordering.
     async fn subscribe(
         &self,
         request: SubscribeRequestParams,
-        _context: rmcp::service::RequestContext<RoleServer>,
+        context: rmcp::service::RequestContext<RoleServer>,
     ) -> Result<(), McpError> {
         let path =
             parse_uri(&request.uri).map_err(|e| McpError::invalid_params(e.to_string(), None))?;
@@ -653,15 +657,33 @@ impl ServerHandler for McplsServer {
         validate_path_against_roots(&path, &self.context.workspace_roots)
             .map_err(|e| McpError::invalid_params(e.to_string(), None))?;
 
-        // TODO(S3): If diagnostics are already cached for this URI, emit a synthetic
-        // notify_resource_updated so clients subscribing after initial workspace indexing
-        // don't have to wait for the next LSP push. Requires peer access from HandlerContext.
-        // Track as follow-up issue.
+        // Record the subscription *before* checking the cache. This closes the race where
+        // a PublishDiagnostics notification lands between the cache check and the
+        // subscription being recorded: if diagnostics arrive before this point, the check
+        // below catches them; if they arrive after, `diagnostics_pump`'s own
+        // `subs.contains` check already sees this URI as subscribed and delivers the
+        // update through the normal push path.
         self.context
             .subscriptions
-            .subscribe(request.uri)
+            .subscribe(request.uri.clone())
             .await
             .map_err(|e| McpError::invalid_params(e, None))?;
+
+        let has_cached_diagnostics = {
+            let translator = self.context.translator.lock().await;
+            let lsp_uri = crate::bridge::path_to_uri(&path);
+            translator
+                .notification_cache()
+                .get_diagnostics(lsp_uri.as_str())
+                .is_some()
+        };
+
+        if has_cached_diagnostics {
+            let _ = context
+                .peer
+                .notify_resource_updated(ResourceUpdatedNotificationParam::new(request.uri))
+                .await;
+        }
 
         Ok(())
     }

--- a/crates/mcpls-core/src/mcp/server.rs
+++ b/crates/mcpls-core/src/mcp/server.rs
@@ -654,7 +654,7 @@ impl ServerHandler for McplsServer {
         // Enforce workspace-root containment (same invariant as every LSP tool).
         // Validated against a lock-free snapshot of workspace_roots so subscribing
         // never waits on the translator lock (see `read_resource`).
-        validate_path_against_roots(&path, &self.context.workspace_roots)
+        let validated_path = validate_path_against_roots(&path, &self.context.workspace_roots)
             .map_err(|e| McpError::invalid_params(e.to_string(), None))?;
 
         // Record the subscription *before* checking the cache. This closes the race where
@@ -669,13 +669,12 @@ impl ServerHandler for McplsServer {
             .await
             .map_err(|e| McpError::invalid_params(e, None))?;
 
+        // Build the URI from the canonicalized path, matching `read_resource` and
+        // what `diagnostics_pump` stores from LSP notifications.
+        let lsp_uri = crate::bridge::path_to_uri(&validated_path);
         let has_cached_diagnostics = {
-            let translator = self.context.translator.lock().await;
-            let lsp_uri = crate::bridge::path_to_uri(&path);
-            translator
-                .notification_cache()
-                .get_diagnostics(lsp_uri.as_str())
-                .is_some()
+            let cache = self.context.notification_cache.lock().await;
+            cache.get_diagnostics(lsp_uri.as_str()).is_some()
         };
 
         if has_cached_diagnostics {

--- a/crates/mcpls-core/tests/e2e/mcp_client.rs
+++ b/crates/mcpls-core/tests/e2e/mcp_client.rs
@@ -29,6 +29,9 @@ pub struct McpClient {
     stdin: ChildStdin,
     stdout: BufReader<ChildStdout>,
     request_id: i64,
+    /// Server-pushed notifications (no matching request `id`) collected while
+    /// waiting for a request/response round-trip. Drained via `take_notifications`.
+    pending_notifications: Vec<Value>,
 }
 
 impl McpClient {
@@ -103,7 +106,19 @@ impl McpClient {
             stdin,
             stdout: BufReader::new(stdout),
             request_id: 0,
+            pending_notifications: Vec::new(),
         })
+    }
+
+    /// Drain and return server-pushed notifications collected so far (e.g.
+    /// `notifications/resources/updated`).
+    ///
+    /// Notifications have no JSON-RPC `id` and may arrive interleaved with
+    /// request/response traffic on the same stdout stream; `send_request` queues
+    /// them here instead of misinterpreting them as the response it is waiting for.
+    #[allow(dead_code)]
+    pub fn take_notifications(&mut self) -> Vec<Value> {
+        std::mem::take(&mut self.pending_notifications)
     }
 
     /// Send MCP initialize request.
@@ -256,6 +271,10 @@ impl McpClient {
 
     /// Send a raw JSON-RPC request and return the response.
     ///
+    /// The server may push notifications (e.g. `notifications/resources/updated`)
+    /// on the same stdout stream before writing the response; those are queued into
+    /// `pending_notifications` rather than being mistaken for the response.
+    ///
     /// # Errors
     ///
     /// Returns an error if:
@@ -267,13 +286,22 @@ impl McpClient {
         writeln!(self.stdin, "{request_str}")?;
         self.stdin.flush()?;
 
-        let mut line = String::new();
-        self.stdout
-            .read_line(&mut line)
-            .context("failed to read response from mcpls")?;
+        let expected_id = request.get("id").cloned();
 
-        let response: Value =
-            serde_json::from_str(&line).context("failed to parse JSON-RPC response")?;
+        let response = loop {
+            let mut line = String::new();
+            self.stdout
+                .read_line(&mut line)
+                .context("failed to read response from mcpls")?;
+
+            let value: Value =
+                serde_json::from_str(&line).context("failed to parse JSON-RPC message")?;
+
+            if value.get("id") == expected_id.as_ref() {
+                break value;
+            }
+            self.pending_notifications.push(value);
+        };
 
         if let Some(error) = response.get("error") {
             anyhow::bail!("MCP error: {error:?}");

--- a/crates/mcpls-core/tests/fixtures/rust_workspace/extras/untouched.rs
+++ b/crates/mcpls-core/tests/fixtures/rust_workspace/extras/untouched.rs
@@ -1,0 +1,7 @@
+/// This file is intentionally never opened by any MCP tool call in the e2e suite,
+/// and is NOT part of the crate's module tree — it lives in `extras/` and is copied
+/// into the staged workspace's src/ directory to exist on disk (subscribe() requires
+/// the path to exist) without rust-analyzer ever running diagnostics on it.
+pub fn never_diagnosed() -> i32 {
+    42
+}

--- a/crates/mcpls-core/tests/integration/rust_analyzer_tests.rs
+++ b/crates/mcpls-core/tests/integration/rust_analyzer_tests.rs
@@ -201,7 +201,7 @@ async fn test_hover_on_u64_type() {
         translator.lock().await.handle_hover(
             file_path.to_string_lossy().to_string(),
             19,
-            17, // Position on "u64"
+            13, // Position on "u64"
         ),
     )
     .await;
@@ -242,7 +242,7 @@ async fn test_definition_user_struct() {
         translator.lock().await.handle_definition(
             types_file.to_string_lossy().to_string(),
             9,
-            20, // Position on "User"
+            16, // Position on "User"
         ),
     )
     .await;
@@ -605,7 +605,7 @@ async fn test_completions_basic() {
         translator.lock().await.handle_completions(
             functions_file.to_string_lossy().to_string(),
             23,
-            10, // Position after "repo."
+            11, // Position after "repo."
             None,
         ),
     )
@@ -614,14 +614,17 @@ async fn test_completions_basic() {
     assert!(result.is_ok(), "Should not timeout");
     let completions_result = result.unwrap();
 
-    // Completions might not always be available depending on timing
-    if completions_result.is_ok() {
-        let completions_json = completions_result.unwrap();
+    // Completions might not always be available depending on timing, so only assert
+    // on content when the call actually succeeded.
+    if let Ok(completions_json) = completions_result {
         let completions_str = serde_json::to_string(&completions_json).unwrap();
-
-        // If we got completions, they should include Repository fields/methods
-        // This is a soft check since completion can be timing-sensitive
-        println!("Completions: {}", completions_str);
+        assert!(
+            completions_str.contains("get_owner")
+                || completions_str.contains("name")
+                || completions_str.contains("stars"),
+            "Completions should include Repository fields/methods, got: {}",
+            completions_str
+        );
     }
 }
 

--- a/crates/mcpls-core/tests/ra_e2e.rs
+++ b/crates/mcpls-core/tests/ra_e2e.rs
@@ -98,6 +98,13 @@ fn stage_workspace() -> TempDir {
     let fmt_dst = tmp.path().join("src/bad_format.rs");
     fs::copy(&fmt_src, &fmt_dst).expect("failed to copy bad_format.rs");
 
+    // Copy untouched.rs into src/ — NOT added to lib.rs and never opened by any
+    // sub-case, so rust-analyzer never runs diagnostics on it (unlike bad_format.rs,
+    // which gets diagnosed as a detached file once opened via format_document).
+    let untouched_src = fixture_dir.join("extras/untouched.rs");
+    let untouched_dst = tmp.path().join("src/untouched.rs");
+    fs::copy(&untouched_src, &untouched_dst).expect("failed to copy untouched.rs");
+
     tmp
 }
 
@@ -908,11 +915,11 @@ fn sc_get_server_logs(client: &mut McpClient, _workspace: &Path) -> Result<(), S
     Ok(())
 }
 
-/// Resolve the `lsp-diagnostics` URI for `lib.rs` by querying `resources/list`.
+/// Resolve a resource URI ending with `suffix` by querying `resources/list`.
 ///
 /// Avoids drift from `make_uri`'s encoding rules on macOS `/private/var/...`
 /// canonicalised paths or Windows UNC.
-fn lib_rs_uri(client: &mut McpClient) -> Result<String, String> {
+fn resource_uri_ending_with(client: &mut McpClient, suffix: &str) -> Result<String, String> {
     let resp = client
         .list_resources()
         .map_err(|e| format!("list_resources: {e}"))?;
@@ -922,9 +929,14 @@ fn lib_rs_uri(client: &mut McpClient) -> Result<String, String> {
     resources
         .iter()
         .filter_map(|r| r["uri"].as_str())
-        .find(|u| u.ends_with("/src/lib.rs"))
+        .find(|u| u.ends_with(suffix))
         .map(str::to_owned)
-        .ok_or_else(|| format!("no lib.rs URI in resources list: {resources:?}"))
+        .ok_or_else(|| format!("no URI ending with '{suffix}' in resources list: {resources:?}"))
+}
+
+/// Resolve the `lsp-diagnostics` URI for `lib.rs` by querying `resources/list`.
+fn lib_rs_uri(client: &mut McpClient) -> Result<String, String> {
+    resource_uri_ending_with(client, "/src/lib.rs")
 }
 
 /// Tool 17: `get_signature_help` — signature of `add` inside its call site.
@@ -1242,7 +1254,11 @@ fn sc_read_resource(client: &mut McpClient, _workspace: &Path) -> Result<(), Str
     Ok(())
 }
 
-/// Resource sub-case 3: subscribe and unsubscribe lib.rs resource.
+/// Resource sub-case 3: subscribing to lib.rs replays its already-cached diagnostics
+/// immediately (issue #131), then subscribe/unsubscribe still round-trip cleanly.
+///
+/// Precondition: `sc_get_cached_diagnostics` has already run, so lib.rs has an entry
+/// in the push-diagnostics cache — this sub-case must remain after it in the registry.
 fn sc_subscribe_unsubscribe_resource(
     client: &mut McpClient,
     _workspace: &Path,
@@ -1262,6 +1278,21 @@ fn sc_subscribe_unsubscribe_resource(
         ));
     }
 
+    // #131: diagnostics are already cached for lib.rs (sc_get_cached_diagnostics ran
+    // earlier), so subscribe must replay them immediately via a
+    // notifications/resources/updated push instead of waiting for the next LSP update.
+    let replayed = client
+        .take_notifications()
+        .into_iter()
+        .any(|n| n["method"] == "notifications/resources/updated" && n["params"]["uri"] == uri);
+    if !replayed {
+        return Err(
+            "subscribe: expected an immediate notifications/resources/updated replay for \
+             lib.rs (diagnostics already cached), got none"
+                .to_owned(),
+        );
+    }
+
     let unsub_resp = client
         .unsubscribe_resource(&uri)
         .map_err(|e| format!("unsubscribe call failed: {e}"))?;
@@ -1276,6 +1307,59 @@ fn sc_subscribe_unsubscribe_resource(
 
     // TODO(critic): add negative case with "file:///tmp/x.rs" (wrong scheme) once error envelope shape confirmed
     // TODO(critic): assert idempotent unsubscribe — second unsubscribe of same URI returns Ok
+
+    Ok(())
+}
+
+/// Resource sub-case 4 (negative): subscribing to a resource with no cached diagnostics
+/// yet must not produce a spurious `notifications/resources/updated` push (issue #131).
+///
+/// `untouched.rs` is never opened by any sub-case and not part of the crate's module
+/// tree, so rust-analyzer never runs diagnostics on it — unlike `bad_format.rs`, which
+/// modern rust-analyzer diagnoses as a detached file once `sc_format_document` opens
+/// it via `didOpen`, even outside the module tree. Its URI is derived from lib.rs's
+/// (same directory, sibling filename) rather than via `resources/list`, since
+/// `untouched.rs` is never opened and therefore never appears there.
+fn sc_subscribe_no_replay_without_cached_diagnostics(
+    client: &mut McpClient,
+    _workspace: &Path,
+) -> Result<(), String> {
+    let lib_uri = lib_rs_uri(client)?;
+    let uri = lib_uri.replace("lib.rs", "untouched.rs");
+    if uri == lib_uri {
+        return Err(format!("failed to derive sibling URI from {lib_uri}"));
+    }
+
+    // Drain any notifications left over from earlier sub-cases before subscribing,
+    // so this check only observes what subscribe() itself produces.
+    client.take_notifications();
+
+    let sub_resp = client
+        .subscribe_resource(&uri)
+        .map_err(|e| format!("subscribe call failed: {e}"))?;
+    if sub_resp.get("error").is_some() {
+        return Err(format!("subscribe returned error: {sub_resp}"));
+    }
+    if sub_resp.get("result").is_none() {
+        return Err(format!(
+            "subscribe: no 'result' field in response: {sub_resp}"
+        ));
+    }
+
+    let spurious = client
+        .take_notifications()
+        .into_iter()
+        .any(|n| n["method"] == "notifications/resources/updated" && n["params"]["uri"] == uri);
+    if spurious {
+        return Err(format!(
+            "subscribe: got an unexpected notifications/resources/updated replay for \
+             {uri} which has no cached diagnostics"
+        ));
+    }
+
+    client
+        .unsubscribe_resource(&uri)
+        .map_err(|e| format!("unsubscribe call failed: {e}"))?;
 
     Ok(())
 }
@@ -1364,6 +1448,7 @@ fn ra_e2e_suite() {
         sub_case!(sc_list_resources),
         sub_case!(sc_read_resource),
         sub_case!(sc_subscribe_unsubscribe_resource),
+        sub_case!(sc_subscribe_no_replay_without_cached_diagnostics),
     ];
 
     let filter = std::env::var("MCPLS_RA_FILTER").ok();


### PR DESCRIPTION
## Summary

- Fixes #138 — `test_hover_on_u64_type` (and two related test cases found during review: `test_definition_user_struct`, `test_completions_basic`) passed column positions past their target tokens, so rust-analyzer returned null/empty results. `test_completions_basic` also had a print-only success branch that asserted nothing.
- Fixes #131 — `subscribe()` now replays cached diagnostics immediately when a client subscribes to a URI that already has diagnostics cached, instead of waiting for the next LSP push. The subscription is recorded before the cache check to close a race with the diagnostics pump.

## Test plan

- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features --workspace -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --lib --bins` (415/415)
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`
- [x] `cargo test --test ra_e2e ra_e2e_suite -- --ignored` against real rust-analyzer (24/24), including new positive/negative subscribe-replay coverage
- [x] Fixed integration tests individually verified against real rust-analyzer