### PR TITLE
fix(mcpls-core): escalate on repeat shutdown signal during cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **Repeat `SIGTERM`/`SIGINT` during shutdown cleanup can now force-quit a stuck cleanup** — previously, a signal arriving while `shutdown()` was mid `shutdown_servers`/LSP-init cleanup had no listener to catch it and was silently discarded, making that window uninterruptible short of `SIGKILL`. `shutdown()` now re-registers its own signal handler for the duration of cleanup, so a repeat signal there triggers an immediate exit.
+- **Repeat `SIGTERM`/`SIGINT` during shutdown cleanup can now force-quit a stuck cleanup** — previously, a signal arriving while `shutdown()` was mid `shutdown_servers`/LSP-init cleanup had no listener to catch it and was silently discarded, making that window uninterruptible short of `SIGKILL`. `shutdown()` now re-registers its own signal handler for the duration of cleanup, so a repeat signal there triggers an immediate exit. (#350)
 - **Explicit relative `workspace.roots` no longer fail LSP initialization with `Invalid workspace root`** — configured roots are now made absolute and canonical before `ServerInitConfig` is built, while the URI layer continues to reject any relative path that reaches it. Roots loaded from a TOML file resolve against that file's directory, making committed `--config`/`MCPLS_CONFIG` files independent of launcher cwd; relative roots on caller-built `ServerConfig`s resolve against process cwd. A missing relative root now fails early with a clear invalid-configuration error instead of becoming an invalid `file://` URI. Absolute roots and the empty-roots cwd fallback retain their existing behavior. (#345)
 
 ## [0.3.9] - 2026-08-05

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Repeat `SIGTERM`/`SIGINT` during shutdown cleanup can now force-quit a stuck cleanup** — previously, a signal arriving while `shutdown()` was mid `shutdown_servers`/LSP-init cleanup had no listener to catch it and was silently discarded, making that window uninterruptible short of `SIGKILL`. `shutdown()` now re-registers its own signal handler for the duration of cleanup, so a repeat signal there triggers an immediate exit.
 - **Explicit relative `workspace.roots` no longer fail LSP initialization with `Invalid workspace root`** — configured roots are now made absolute and canonical before `ServerInitConfig` is built, while the URI layer continues to reject any relative path that reaches it. Roots loaded from a TOML file resolve against that file's directory, making committed `--config`/`MCPLS_CONFIG` files independent of launcher cwd; relative roots on caller-built `ServerConfig`s resolve against process cwd. A missing relative root now fails early with a clear invalid-configuration error instead of becoming an invalid `file://` URI. Absolute roots and the empty-roots cwd fallback retain their existing behavior. (#345)
 
 ## [0.3.9] - 2026-08-05

--- a/crates/mcpls-core/src/lib.rs
+++ b/crates/mcpls-core/src/lib.rs
@@ -701,6 +701,30 @@ async fn await_lsp_init_handle(mut handle: JoinHandle<()>, timeout: Duration) {
     }
 }
 
+/// Aborts the wrapped [`JoinHandle`] when dropped, including on an unwind out
+/// of the enclosing scope — unlike a bare `.abort()` call placed at the end
+/// of a function body, which is skipped if that scope is left early (a
+/// panic, or a future `?` added above it).
+struct AbortOnDrop<'a, T>(&'a JoinHandle<T>);
+
+impl<T> Drop for AbortOnDrop<'_, T> {
+    fn drop(&mut self) {
+        self.0.abort();
+    }
+}
+
+/// Whether a shutdown signal caught during [`shutdown`]'s cleanup window
+/// should force an immediate `std::process::exit`, given how many such
+/// signals (including this one) have been received so far.
+///
+/// Extracted as a pure function, rather than inlined into the loop that
+/// calls it, so the threshold is unit-testable without actually invoking
+/// `std::process::exit` — which would tear down the test process itself
+/// under `cargo nextest` before any assertion could run.
+const fn should_escalate(repeat_signals: u32) -> bool {
+    repeat_signals >= 1
+}
+
 /// Post-transport shutdown sequence, run once the transport future
 /// (`run_stdio`/`run_http`) returns — whether that's because of a
 /// `SIGTERM`/`SIGINT`, stdio EOF, or (for HTTP) its own graceful shutdown.
@@ -714,12 +738,70 @@ async fn await_lsp_init_handle(mut handle: JoinHandle<()>, timeout: Duration) {
 /// finish draining before `serve_with` returns. Extracted from
 /// [`serve_with`] so this sequence is exercised directly in tests without
 /// needing a full stdio/HTTP transport round trip.
+///
+/// # Signal handling during cleanup (#329)
+///
+/// The OS-level `SIGTERM`/`SIGINT` handler installed by [`ShutdownSignal::new`]
+/// stays installed for the rest of the process's life once registered —
+/// `tokio::signal` never uninstalls it, regardless of how many [`ShutdownSignal`]
+/// values are constructed or dropped. So dropping the instance built in
+/// `serve_with` and moved into `run_stdio`/`run_http` (which happens as soon
+/// as that transport function returns, right before this function runs)
+/// does *not* reopen a window where a repeat signal could hit the OS's
+/// default disposition. What it does instead: with no live [`ShutdownSignal`]
+/// subscribed, a signal delivered during `shutdown_servers`/
+/// `await_lsp_init_handle` (bounded by [`Translator::shutdown_servers`]'s own
+/// per-server timeout and [`LSP_INIT_TASK_SHUTDOWN_TIMEOUT`], ~15s worst
+/// case) is recorded and then silently discarded — there is no receiver to
+/// broadcast it to. Before this fix, that made cleanup **uninterruptible**:
+/// an operator's repeat `Ctrl-C`/`SIGTERM` during that window was a no-op
+/// short of `SIGKILL`.
+///
+/// This function re-registers a fresh `ShutdownSignal` first thing to give
+/// cleanup a listener again, restoring the ability to force-quit a stuck
+/// cleanup on request. A brief gap remains between the old registration's
+/// last live receiver dropping and this one subscribing, in which a signal
+/// can still be discarded the same way as before the fix — see the
+/// escalation behavior below for how that's bounded.
+///
+/// A signal caught here means "the operator wants out": the first one during
+/// cleanup ([`should_escalate`]) is logged and forces an immediate
+/// `std::process::exit(1)`, since the graceful default (waiting out
+/// `shutdown_servers`'s bounded timeouts) already had its chance before the
+/// operator intervened. This is deliberately not lenient — because a signal
+/// in the re-registration gap above is silently dropped rather than
+/// counted, requiring a second repeat before acting would let an unlucky
+/// operator's second press go unnoticed too. `exit(1)` skips unwinding, so
+/// it forfeits `Drop` (`kill_on_drop` on any still-running LSP child)
+/// exactly like the pre-existing panic/abort gap documented on
+/// [`Translator::shutdown_servers`]'s "Limitations" section — an explicit
+/// trade the operator is asking for, not a case this fix silently
+/// regresses.
 async fn shutdown(
     cancel_tx: &tokio::sync::watch::Sender<bool>,
     translator: &Translator,
     lsp_init_handle: Option<JoinHandle<()>>,
 ) {
     let _ = cancel_tx.send(true);
+
+    let mut cleanup_signal = ShutdownSignal::new();
+    let force_exit_on_signal = tokio::spawn(async move {
+        let mut repeat_signals = 0u32;
+        loop {
+            cleanup_signal.recv().await;
+            repeat_signals += 1;
+            if should_escalate(repeat_signals) {
+                error!("shutdown signal received during cleanup, forcing immediate exit");
+                std::process::exit(1);
+            }
+        }
+    });
+    // Aborts `force_exit_on_signal` on every exit from this scope, including
+    // an unwind out of `shutdown_servers().await` below (debug builds only;
+    // release uses `panic = "abort"`) — otherwise that path would merely
+    // detach the task instead of stopping it, unlike the equivalent
+    // abort-on-timeout handling in `await_lsp_init_handle`.
+    let _abort_force_exit_on_signal = AbortOnDrop(&force_exit_on_signal);
 
     info!("Shutting down LSP servers...");
     translator.shutdown_servers().await;

--- a/crates/mcpls-core/src/transport.rs
+++ b/crates/mcpls-core/src/transport.rs
@@ -727,6 +727,11 @@ mod tests {
     /// would kill this test's own process for real rather than fail an
     /// assertion — see the #329 regression-test handoff for why a test
     /// triggering `std::process::exit(1)` isn't attempted here.
+    ///
+    /// Unix-only: `SIGTERM` and the external `kill` binary this test relies
+    /// on don't exist on Windows, where `ShutdownSignal` listens for
+    /// Ctrl-C instead (see the struct's `#[cfg(windows)]` arm above).
+    #[cfg(unix)]
     #[tokio::test]
     async fn test_fresh_shutdown_signal_still_receives_sigterm_after_prior_instance_dropped() {
         let earlier = super::ShutdownSignal::new();

--- a/crates/mcpls-core/src/transport.rs
+++ b/crates/mcpls-core/src/transport.rs
@@ -180,6 +180,19 @@ use rmcp::transport::streamable_http_server::session::{
 /// across the gap between construction in `serve_with` and the first await
 /// inside the transport — a fresh registration per call would risk losing a
 /// signal delivered in between.
+///
+/// This instance is dropped as soon as the transport function it was moved
+/// into returns — but that does *not* deregister the OS-level handler:
+/// `tokio::signal` installs it once per process and never uninstalls it, no
+/// matter how many `ShutdownSignal`s are constructed or dropped. What
+/// dropping the last live instance actually does is remove the only
+/// receiver a delivered signal could be broadcast to, so until a new one
+/// subscribes, a signal is recorded and then silently discarded rather than
+/// observed by anything — making that stretch of code uninterruptible
+/// rather than unsafe. [`crate::shutdown`] (the post-transport cleanup run
+/// immediately after) registers a *second* `ShutdownSignal` of its own so a
+/// repeat signal during cleanup has a receiver again and can force an exit;
+/// see #329.
 pub(crate) struct ShutdownSignal {
     #[cfg(unix)]
     sigterm: Option<tokio::signal::unix::Signal>,
@@ -287,7 +300,11 @@ impl ShutdownSignal {
 /// the stdio transport closes (client disconnect / stdin EOF) or a `SIGTERM`/
 /// `SIGINT` is received, so callers can run orderly cleanup — such as
 /// [`crate::bridge::Translator::shutdown_servers`] — before the process
-/// exits.
+/// exits. `shutdown_signal` is dropped when this function returns, and this
+/// function does no draining of its own after a signal arrives — so a
+/// repeat signal during the post-return cleanup in [`crate::shutdown`] is
+/// caught only by the second `ShutdownSignal` that function registers for
+/// itself, not by this one (see [`ShutdownSignal`]'s docs and #329).
 ///
 /// `shutdown_signal` is constructed by [`crate::serve_with`] *before* any
 /// startup work runs (see [`ShutdownSignal`]'s docs) and is raced here
@@ -368,6 +385,15 @@ pub(crate) async fn run_stdio(
 /// startup work runs (see [`ShutdownSignal`]'s docs), so its registration
 /// predates this function's own `TcpListener::bind` call — a signal between
 /// bind and the graceful-shutdown future's first poll is still caught.
+/// `shutdown_signal` is moved into (and dropped by) the
+/// `with_graceful_shutdown` closure below once it resolves — i.e. as soon as
+/// the *first* signal is received, well before this function returns — so
+/// there is no listener at all for a repeat signal arriving during the
+/// connection-drain wait that follows (bounded by
+/// [`HTTP_GRACEFUL_SHUTDOWN_TIMEOUT`]). [`crate::shutdown`]'s own
+/// registration only takes effect once *this* function returns, so it
+/// covers the post-transport cleanup window, not the drain wait inside this
+/// one; see #329 and the TODO on the closure below for that gap.
 #[cfg(feature = "transport-http")]
 // `session_manager` and `service` are moved into `app`, which is served until
 // shutdown — clippy's drop-tightening heuristic misreads that as an
@@ -425,6 +451,13 @@ pub(crate) async fn run_http(
     // (below). Cloned first so the force-timeout branch can observe that
     // same moment independently of the `with_graceful_shutdown` closure,
     // which consumes its own clone.
+    // TODO(#349): `shutdown_signal` is dropped
+    // once this closure resolves, leaving the connection-drain wait below
+    // (up to `HTTP_GRACEFUL_SHUTDOWN_TIMEOUT`) with no signal listener at
+    // all -- a repeat signal there is silently discarded the same way a
+    // repeat signal during post-transport cleanup used to be, before this
+    // fix added one there. Not addressed here; this fix only covers the
+    // window after `run_http` returns.
     let cancel_for_force_timeout = cancel.clone();
     let serve = axum::serve(listener, app).with_graceful_shutdown(async move {
         shutdown_signal.recv().await;
@@ -674,6 +707,54 @@ mod tests {
     fn test_transport_stdio_variant() {
         let t = super::Transport::Stdio;
         assert!(matches!(t, super::Transport::Stdio));
+    }
+
+    /// #329 regression: `crate::shutdown`'s cleanup-window fix hinges on a
+    /// freshly constructed `ShutdownSignal` still receiving real OS signals
+    /// after an *earlier* `ShutdownSignal` (e.g. the one `run_stdio`/
+    /// `run_http` held) has already been dropped — proving there is no
+    /// window in which the OS handler itself gets deregistered (per
+    /// `ShutdownSignal`'s corrected struct doc: `tokio::signal` never
+    /// uninstalls it, regardless of how many instances are constructed or
+    /// dropped). Exercises this with a real self-sent `SIGTERM` via the
+    /// external `kill` binary rather than mocking `ShutdownSignal`, since
+    /// that's the exact mechanism `crate::shutdown`'s force-exit task relies
+    /// on. Safe under `cargo nextest`'s one-process-per-test model, so no
+    /// other test's signal disposition is affected.
+    ///
+    /// Deliberately does not go through `crate::shutdown` itself: a signal
+    /// caught there unconditionally calls `std::process::exit(1)`, which
+    /// would kill this test's own process for real rather than fail an
+    /// assertion — see the #329 regression-test handoff for why a test
+    /// triggering `std::process::exit(1)` isn't attempted here.
+    #[tokio::test]
+    async fn test_fresh_shutdown_signal_still_receives_sigterm_after_prior_instance_dropped() {
+        let earlier = super::ShutdownSignal::new();
+        drop(earlier);
+
+        let mut cleanup_signal = super::ShutdownSignal::new();
+
+        let pid = std::process::id();
+        let signal_sender = tokio::spawn(async move {
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+            let status = std::process::Command::new("kill")
+                .arg("-TERM")
+                .arg(pid.to_string())
+                .status()
+                .unwrap();
+            assert!(status.success(), "`kill -TERM {pid}` must succeed");
+        });
+
+        let result =
+            tokio::time::timeout(std::time::Duration::from_secs(5), cleanup_signal.recv()).await;
+        signal_sender.await.unwrap();
+
+        assert!(
+            result.is_ok(),
+            "a freshly constructed ShutdownSignal must still receive a real SIGTERM sent after \
+             an earlier instance was dropped — this is the exact mechanism crate::shutdown's \
+             cleanup-window force-exit task depends on"
+        );
     }
 
     /// #241: `run_stdio` must not hang when the transport never even


### PR DESCRIPTION
## Summary

- `shutdown()` re-registers a fresh `ShutdownSignal` for the duration of `shutdown_servers()`/`await_lsp_init_handle` cleanup and force-exits on the first repeat SIGTERM/SIGINT it catches during that window, covering both the stdio and HTTP transports (`shutdown()` is the shared post-transport path).
- Corrects the actual mechanism at play: `tokio::signal` never deregisters its OS-level handler, so the pre-fix window was not at risk of an OS-default-disposition kill as originally assumed — repeat signals were instead silently discarded with no live receiver, making cleanup uninterruptible short of `SIGKILL`. Doc comments and the CHANGELOG entry reflect the corrected root cause.
- The escalation task is aborted via a drop guard on every exit path from `shutdown()`, including a panic unwind, so it never lingers past normal completion.

## Out of scope

The HTTP transport's own axum connection-drain window (inside `run_http`, before `shutdown()` runs, bounded by `HTTP_GRACEFUL_SHUTDOWN_TIMEOUT`) is a separate, larger uncovered window and is tracked in #349.

## Test plan

- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features --workspace -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --lib --bins` (696 passed, 1 skipped)
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`
- [x] New regression test in `transport.rs` confirming a fresh `ShutdownSignal` still receives a real `SIGTERM` after a prior instance is dropped

Closes #329