### PR TITLE
feat(mcp): allow serverInfo title, description and instructions to be configured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Optional `[mcp]` config section** — `title`, `description`, and `instructions` override `serverInfo.title`/`serverInfo.description`/`ServerInfo.instructions` in the MCP `initialize` response. All three default to the existing hardcoded text when omitted; `instructions` replaces the built-in capability blurb rather than appending to it. Each field is capped (128/1024/4096 UTF-8 bytes respectively), enforced by `ServerConfig::validate()`. (#347)
+
+### Changed
+
+- **`McplsServer::new`/`BridgeContext::new` signatures** — Breaking change: both now take an additional `mcp: McpConfig` parameter, carrying the new `[mcp]` section (see Added) through to `get_info`. `ServerConfig`/`BridgeContext` (both `pub`, neither `#[non_exhaustive]`) also gain a public `mcp` field, breaking any downstream struct-literal construction. Acceptable pre-1.0. (#347)
+
 ### Removed
 
 - **`async-trait` direct dependency** — dropped from the workspace and `mcpls-core`; unused now that no trait in the crate needs it, remains available transitively through `rmcp`'s own optional dependency when its `--all-features` build enables it.

--- a/README.md
+++ b/README.md
@@ -263,6 +263,11 @@ project_markers = ["Cargo.toml", "rust-toolchain.toml", ".rust-version"]
 <summary><strong>Full Configuration Example</strong></summary>
 
 ```toml
+[mcp]
+title = "My Custom Bridge"
+description = "Internal LSP bridge for Acme Corp"
+instructions = "Use get_hover before get_definition."
+
 [workspace]
 roots = ["/path/to/project"]
 heuristics_max_depth = 10
@@ -288,6 +293,12 @@ checkOnSave.command = "clippy"
 extensions = ["nu"]
 language_id = "nushell"
 ```
+
+> [!NOTE]
+> `[mcp]` is entirely optional — omitting it (or any of its three fields)
+> keeps mcpls's built-in `serverInfo`/`instructions` text unchanged. A
+> configured `instructions` **replaces** the built-in capability blurb
+> rather than appending to it.
 
 See [Configuration Reference](docs/user-guide/configuration.md) for all options.
 

--- a/crates/mcpls-core/src/bridge/translator/routing.rs
+++ b/crates/mcpls-core/src/bridge/translator/routing.rs
@@ -603,6 +603,7 @@ mod tests {
         ];
 
         let config = crate::config::ServerConfig {
+            mcp: crate::config::McpConfig::default(),
             workspace: WorkspaceConfig {
                 roots: vec![PathBuf::from("/tmp/test-workspace")],
                 position_encodings: vec!["utf-8".to_string()],

--- a/crates/mcpls-core/src/config/mod.rs
+++ b/crates/mcpls-core/src/config/mod.rs
@@ -37,6 +37,10 @@ pub struct LanguageExtensionMapping {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct ServerConfig {
+    /// MCP `serverInfo`/`initialize` presentation overrides.
+    #[serde(default)]
+    pub mcp: McpConfig,
+
     /// Workspace configuration.
     #[serde(default)]
     pub workspace: WorkspaceConfig,
@@ -57,6 +61,81 @@ pub struct ServerConfig {
     #[serde(skip)]
     pub project_config_ignored: bool,
 }
+
+/// Optional overrides for the text mcpls reports about itself over MCP.
+///
+/// Every field is `None` by default, which keeps today's hardcoded
+/// `serverInfo.title`/`description` and built-in capability blurb
+/// unchanged. `serverInfo.name`, `version`, and `website_url` are not
+/// configurable here: `name` is the MCP-spec machine identifier asserted in
+/// integration tests, and `version`/`website_url` are project metadata, not
+/// presentation text.
+///
+/// A configured [`instructions`](Self::instructions) **replaces** the
+/// built-in capability blurb in `ServerInfo.instructions` rather than
+/// appending to it -- an agent that reads `instructions` at connection time
+/// (see `skills/mcpls/SKILL.md`) sees only the configured text, plus the
+/// unrelated untrusted-project-config NOTE (see
+/// [`ServerConfig::project_config_ignored`]), which is always appended
+/// afterward regardless of this field.
+///
+/// Every field reaches an MCP client verbatim on every `initialize`
+/// response, into what is typically an LLM context window -- this is why
+/// [`ServerConfig::validate`] enforces the `MAX_MCP_*` byte caps on all
+/// three.
+///
+/// # Examples
+///
+/// ```
+/// use mcpls_core::config::ServerConfig;
+///
+/// let toml = r#"
+///     [mcp]
+///     title = "My Custom Bridge"
+///     description = "Internal LSP bridge for Acme Corp"
+///     instructions = "Use get_hover before get_definition."
+/// "#;
+/// let config: ServerConfig = toml::from_str(toml).unwrap();
+/// assert_eq!(config.mcp.title.as_deref(), Some("My Custom Bridge"));
+/// ```
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct McpConfig {
+    /// Overrides `serverInfo.title`. Omit to keep the built-in title.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+
+    /// Overrides `serverInfo.description`. Omit to keep the built-in
+    /// description (`CARGO_PKG_DESCRIPTION`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+
+    /// Replaces the built-in `ServerInfo.instructions` capability blurb.
+    /// Omit to keep the built-in text. The untrusted-project-config NOTE
+    /// (see [`ServerConfig::project_config_ignored`]) is still appended
+    /// after this value when set.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub instructions: Option<String>,
+}
+
+/// Maximum byte length of a configured [`McpConfig::title`].
+///
+/// UTF-8 bytes, not chars, consistent with `MAX_CONFIG_FILE_BYTES`. Named
+/// so the limit can appear in the [`Error::InvalidConfig`] message it backs.
+pub const MAX_MCP_TITLE_BYTES: usize = 128;
+
+/// Maximum byte length of a configured [`McpConfig::description`].
+///
+/// UTF-8 bytes, not chars. See [`MAX_MCP_TITLE_BYTES`].
+pub const MAX_MCP_DESCRIPTION_BYTES: usize = 1024;
+
+/// Maximum byte length of a configured [`McpConfig::instructions`].
+///
+/// UTF-8 bytes, not chars. Applies to the raw configured string only -- the
+/// untrusted-project-config NOTE appended in `McplsServer::get_info` is
+/// fixed-size built-in text and does not count against this budget. See
+/// [`MAX_MCP_TITLE_BYTES`].
+pub const MAX_MCP_INSTRUCTIONS_BYTES: usize = 4096;
 
 /// Workspace-level configuration.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -750,6 +829,8 @@ impl ServerConfig {
     /// assert!(config.validate().is_ok());
     /// ```
     pub fn validate(&self) -> Result<()> {
+        self.validate_mcp()?;
+
         if self.workspace.position_encodings.is_empty() {
             return Err(Error::InvalidConfig(
                 "workspace.position_encodings cannot be empty".to_string(),
@@ -860,11 +941,59 @@ impl ServerConfig {
         }
         Ok(())
     }
+
+    /// Validates the `[mcp]` section: each configured field is rejected if
+    /// whitespace-only or over its `MAX_MCP_*` byte cap. Split out of
+    /// [`Self::validate`] to keep that function under clippy's line count
+    /// threshold.
+    fn validate_mcp(&self) -> Result<()> {
+        validate_mcp_field(self.mcp.title.as_deref(), "mcp.title", MAX_MCP_TITLE_BYTES)?;
+        validate_mcp_field(
+            self.mcp.description.as_deref(),
+            "mcp.description",
+            MAX_MCP_DESCRIPTION_BYTES,
+        )?;
+        validate_mcp_field(
+            self.mcp.instructions.as_deref(),
+            "mcp.instructions",
+            MAX_MCP_INSTRUCTIONS_BYTES,
+        )
+    }
+}
+
+/// Validates one [`McpConfig`] string field: rejects a whitespace-only value
+/// before checking length, so `title = "   "` reports "cannot be empty"
+/// rather than a length error, and caps only the raw configured string --
+/// text appended later (e.g. the untrusted-project-config NOTE in
+/// `McplsServer::get_info`) is not part of `value` and is unaffected.
+fn validate_mcp_field(value: Option<&str>, field: &str, max_bytes: usize) -> Result<()> {
+    let Some(value) = value else {
+        return Ok(());
+    };
+    if value.trim().is_empty() {
+        // `rsplit('.').next()` always yields at least one item for any
+        // input (including one with no '.'), so `unwrap_or(field)` never
+        // actually falls back for the "mcp.<field>" strings this is called
+        // with -- kept as a defensive default rather than an `unwrap()`,
+        // since `clippy::unwrap_used` is a workspace-wide warn-as-error.
+        return Err(Error::InvalidConfig(format!(
+            "{field} cannot be empty (omit `{}` to use the built-in default)",
+            field.rsplit('.').next().unwrap_or(field)
+        )));
+    }
+    let len = value.len();
+    if len > max_bytes {
+        return Err(Error::InvalidConfig(format!(
+            "{field} exceeds the maximum of {max_bytes} bytes ({len} given)"
+        )));
+    }
+    Ok(())
 }
 
 impl Default for ServerConfig {
     fn default() -> Self {
         Self {
+            mcp: McpConfig::default(),
             workspace: WorkspaceConfig::default(),
             lsp_servers: vec![
                 LspServerConfig::rust_analyzer(),
@@ -1666,6 +1795,7 @@ mod tests {
     #[test]
     fn test_build_effective_extension_map_overrides_with_file_patterns() {
         let config = ServerConfig {
+            mcp: McpConfig::default(),
             workspace: WorkspaceConfig::default(),
             lsp_servers: vec![LspServerConfig {
                 language_id: "cpp".to_string(),
@@ -1691,6 +1821,7 @@ mod tests {
     #[test]
     fn test_build_effective_extension_map_derives_tsx_language_id() {
         let config = ServerConfig {
+            mcp: McpConfig::default(),
             workspace: WorkspaceConfig::default(),
             lsp_servers: vec![LspServerConfig {
                 language_id: "typescript".to_string(),
@@ -1716,6 +1847,7 @@ mod tests {
     #[test]
     fn test_build_effective_extension_map_derives_jsx_language_id() {
         let config = ServerConfig {
+            mcp: McpConfig::default(),
             workspace: WorkspaceConfig::default(),
             lsp_servers: vec![LspServerConfig {
                 language_id: "javascript".to_string(),
@@ -1741,6 +1873,7 @@ mod tests {
     #[test]
     fn test_build_effective_extension_map_ignores_complex_patterns_without_extension() {
         let config = ServerConfig {
+            mcp: McpConfig::default(),
             workspace: WorkspaceConfig::default(),
             lsp_servers: vec![LspServerConfig {
                 language_id: "cpp".to_string(),
@@ -2032,6 +2165,7 @@ mod tests {
 
         let content = fs::read_to_string(&config_path).unwrap();
 
+        assert!(content.contains("[mcp]"));
         assert!(content.contains("[workspace]"));
         assert!(content.contains("[[workspace.language_extensions]]"));
         assert!(content.contains("[[lsp_servers]]"));
@@ -2214,5 +2348,274 @@ mod tests {
         );
         assert_eq!(round_tripped.max_documents, original.max_documents);
         assert_eq!(round_tripped.max_file_size, original.max_file_size);
+    }
+
+    #[test]
+    fn test_mcp_config_parses_from_toml_section() {
+        let tmp_dir = TempDir::new().unwrap();
+        let config_path = tmp_dir.path().join("config.toml");
+
+        let toml_content = r#"
+            [mcp]
+            title = "Custom Title"
+            description = "Custom description"
+            instructions = "Custom instructions."
+        "#;
+
+        fs::write(&config_path, toml_content).unwrap();
+
+        let config = ServerConfig::load_from(&config_path).unwrap();
+        assert_eq!(config.mcp.title.as_deref(), Some("Custom Title"));
+        assert_eq!(
+            config.mcp.description.as_deref(),
+            Some("Custom description")
+        );
+        assert_eq!(
+            config.mcp.instructions.as_deref(),
+            Some("Custom instructions.")
+        );
+    }
+
+    #[test]
+    fn test_mcp_config_defaults_to_none_when_section_absent() {
+        let tmp_dir = TempDir::new().unwrap();
+        let config_path = tmp_dir.path().join("config.toml");
+
+        fs::write(&config_path, "[workspace]\nroots = []\n").unwrap();
+
+        let config = ServerConfig::load_from(&config_path).unwrap();
+        assert_eq!(config.mcp.title, None);
+        assert_eq!(config.mcp.description, None);
+        assert_eq!(config.mcp.instructions, None);
+    }
+
+    #[test]
+    fn test_mcp_config_rejects_unknown_field() {
+        let tmp_dir = TempDir::new().unwrap();
+        let config_path = tmp_dir.path().join("config.toml");
+
+        // `tool_prefix` is deliberately not implemented yet (deferred
+        // follow-up); `deny_unknown_fields` must reject it rather than
+        // silently ignoring it.
+        fs::write(&config_path, "[mcp]\ntool_prefix = \"x\"\n").unwrap();
+
+        let result = ServerConfig::load_from(&config_path);
+        assert!(matches!(result, Err(Error::TomlDe(_))));
+    }
+
+    #[test]
+    fn test_validate_rejects_empty_mcp_title() {
+        let tmp_dir = TempDir::new().unwrap();
+        let config_path = tmp_dir.path().join("config.toml");
+
+        fs::write(&config_path, "[mcp]\ntitle = \"\"\n").unwrap();
+
+        let result = ServerConfig::load_from(&config_path);
+        if let Err(Error::InvalidConfig(msg)) = result {
+            assert_eq!(
+                msg,
+                "mcp.title cannot be empty (omit `title` to use the built-in default)"
+            );
+        } else {
+            panic!("Expected InvalidConfig error, got {result:?}");
+        }
+    }
+
+    /// A whitespace-only value must report as *empty*, not over-length --
+    /// the trim-empty check must run before the length check.
+    #[test]
+    fn test_validate_rejects_whitespace_only_mcp_title_as_empty() {
+        let tmp_dir = TempDir::new().unwrap();
+        let config_path = tmp_dir.path().join("config.toml");
+
+        fs::write(&config_path, "[mcp]\ntitle = \"   \"\n").unwrap();
+
+        let result = ServerConfig::load_from(&config_path);
+        if let Err(Error::InvalidConfig(msg)) = result {
+            assert!(msg.contains("cannot be empty"));
+        } else {
+            panic!("Expected InvalidConfig error, got {result:?}");
+        }
+    }
+
+    #[test]
+    fn test_validate_rejects_empty_mcp_description() {
+        let tmp_dir = TempDir::new().unwrap();
+        let config_path = tmp_dir.path().join("config.toml");
+
+        fs::write(&config_path, "[mcp]\ndescription = \"\"\n").unwrap();
+
+        let result = ServerConfig::load_from(&config_path);
+        if let Err(Error::InvalidConfig(msg)) = result {
+            assert_eq!(
+                msg,
+                "mcp.description cannot be empty (omit `description` to use the built-in \
+                 default)"
+            );
+        } else {
+            panic!("Expected InvalidConfig error, got {result:?}");
+        }
+    }
+
+    #[test]
+    fn test_validate_rejects_empty_mcp_instructions() {
+        let tmp_dir = TempDir::new().unwrap();
+        let config_path = tmp_dir.path().join("config.toml");
+
+        fs::write(&config_path, "[mcp]\ninstructions = \"\"\n").unwrap();
+
+        let result = ServerConfig::load_from(&config_path);
+        if let Err(Error::InvalidConfig(msg)) = result {
+            assert_eq!(
+                msg,
+                "mcp.instructions cannot be empty (omit `instructions` to use the built-in \
+                 default)"
+            );
+        } else {
+            panic!("Expected InvalidConfig error, got {result:?}");
+        }
+    }
+
+    #[test]
+    fn test_validate_rejects_over_length_mcp_title() {
+        let tmp_dir = TempDir::new().unwrap();
+        let config_path = tmp_dir.path().join("config.toml");
+
+        let title = "a".repeat(MAX_MCP_TITLE_BYTES + 1);
+        fs::write(&config_path, format!("[mcp]\ntitle = \"{title}\"\n")).unwrap();
+
+        let result = ServerConfig::load_from(&config_path);
+        if let Err(Error::InvalidConfig(msg)) = result {
+            assert_eq!(
+                msg,
+                format!(
+                    "mcp.title exceeds the maximum of {MAX_MCP_TITLE_BYTES} bytes ({} given)",
+                    MAX_MCP_TITLE_BYTES + 1
+                )
+            );
+        } else {
+            panic!("Expected InvalidConfig error, got {result:?}");
+        }
+    }
+
+    #[test]
+    fn test_validate_accepts_mcp_title_at_exact_cap() {
+        let tmp_dir = TempDir::new().unwrap();
+        let config_path = tmp_dir.path().join("config.toml");
+
+        let title = "a".repeat(MAX_MCP_TITLE_BYTES);
+        fs::write(&config_path, format!("[mcp]\ntitle = \"{title}\"\n")).unwrap();
+
+        let result = ServerConfig::load_from(&config_path);
+        assert!(result.is_ok(), "expected Ok, got {result:?}");
+    }
+
+    #[test]
+    fn test_validate_rejects_over_length_mcp_description() {
+        let tmp_dir = TempDir::new().unwrap();
+        let config_path = tmp_dir.path().join("config.toml");
+
+        let description = "a".repeat(MAX_MCP_DESCRIPTION_BYTES + 1);
+        fs::write(
+            &config_path,
+            format!("[mcp]\ndescription = \"{description}\"\n"),
+        )
+        .unwrap();
+
+        let result = ServerConfig::load_from(&config_path);
+        if let Err(Error::InvalidConfig(msg)) = result {
+            assert!(msg.contains("mcp.description exceeds the maximum"));
+            assert!(msg.contains(&(MAX_MCP_DESCRIPTION_BYTES + 1).to_string()));
+        } else {
+            panic!("Expected InvalidConfig error, got {result:?}");
+        }
+    }
+
+    #[test]
+    fn test_validate_accepts_mcp_description_at_exact_cap() {
+        let tmp_dir = TempDir::new().unwrap();
+        let config_path = tmp_dir.path().join("config.toml");
+
+        let description = "a".repeat(MAX_MCP_DESCRIPTION_BYTES);
+        fs::write(
+            &config_path,
+            format!("[mcp]\ndescription = \"{description}\"\n"),
+        )
+        .unwrap();
+
+        let result = ServerConfig::load_from(&config_path);
+        assert!(result.is_ok(), "expected Ok, got {result:?}");
+    }
+
+    /// Pins the documented "bytes, not chars" contract: `é` is 1 char but 2
+    /// UTF-8 bytes, so a naive `.chars().count()` cap would accept both
+    /// cases below. `MAX_MCP_TITLE_BYTES` (128) is even, so 64 `é`s land
+    /// exactly at the byte cap and 65 land one byte over it.
+    #[test]
+    fn test_validate_rejects_multibyte_title_over_byte_cap_though_under_char_cap() {
+        let tmp_dir = TempDir::new().unwrap();
+        let config_path = tmp_dir.path().join("config.toml");
+
+        let title = "é".repeat(65);
+        assert_eq!(title.len(), MAX_MCP_TITLE_BYTES + 2);
+        assert_eq!(title.chars().count(), 65);
+        fs::write(&config_path, format!("[mcp]\ntitle = \"{title}\"\n")).unwrap();
+
+        let result = ServerConfig::load_from(&config_path);
+        if let Err(Error::InvalidConfig(msg)) = result {
+            assert!(msg.contains("mcp.title exceeds the maximum"));
+        } else {
+            panic!("Expected InvalidConfig error, got {result:?}");
+        }
+    }
+
+    #[test]
+    fn test_validate_accepts_multibyte_title_at_exact_byte_cap() {
+        let tmp_dir = TempDir::new().unwrap();
+        let config_path = tmp_dir.path().join("config.toml");
+
+        let title = "é".repeat(64);
+        assert_eq!(title.len(), MAX_MCP_TITLE_BYTES);
+        fs::write(&config_path, format!("[mcp]\ntitle = \"{title}\"\n")).unwrap();
+
+        let result = ServerConfig::load_from(&config_path);
+        assert!(result.is_ok(), "expected Ok, got {result:?}");
+    }
+
+    #[test]
+    fn test_validate_rejects_over_length_mcp_instructions() {
+        let tmp_dir = TempDir::new().unwrap();
+        let config_path = tmp_dir.path().join("config.toml");
+
+        let instructions = "a".repeat(MAX_MCP_INSTRUCTIONS_BYTES + 1);
+        fs::write(
+            &config_path,
+            format!("[mcp]\ninstructions = \"{instructions}\"\n"),
+        )
+        .unwrap();
+
+        let result = ServerConfig::load_from(&config_path);
+        if let Err(Error::InvalidConfig(msg)) = result {
+            assert!(msg.contains("mcp.instructions exceeds the maximum"));
+            assert!(msg.contains(&(MAX_MCP_INSTRUCTIONS_BYTES + 1).to_string()));
+        } else {
+            panic!("Expected InvalidConfig error, got {result:?}");
+        }
+    }
+
+    #[test]
+    fn test_validate_accepts_mcp_instructions_at_exact_cap() {
+        let tmp_dir = TempDir::new().unwrap();
+        let config_path = tmp_dir.path().join("config.toml");
+
+        let instructions = "a".repeat(MAX_MCP_INSTRUCTIONS_BYTES);
+        fs::write(
+            &config_path,
+            format!("[mcp]\ninstructions = \"{instructions}\"\n"),
+        )
+        .unwrap();
+
+        let result = ServerConfig::load_from(&config_path);
+        assert!(result.is_ok(), "expected Ok, got {result:?}");
     }
 }

--- a/crates/mcpls-core/src/config/mod.rs
+++ b/crates/mcpls-core/src/config/mod.rs
@@ -977,7 +977,7 @@ fn validate_mcp_field(value: Option<&str>, field: &str, max_bytes: usize) -> Res
         // with -- kept as a defensive default rather than an `unwrap()`,
         // since `clippy::unwrap_used` is a workspace-wide warn-as-error.
         return Err(Error::InvalidConfig(format!(
-            "{field} cannot be empty (omit `{}` to use the built-in default)",
+            "{field} cannot be empty (omit `{}` from the `[mcp]` section to use the built-in default)",
             field.rsplit('.').next().unwrap_or(field)
         )));
     }
@@ -2414,7 +2414,8 @@ mod tests {
         if let Err(Error::InvalidConfig(msg)) = result {
             assert_eq!(
                 msg,
-                "mcp.title cannot be empty (omit `title` to use the built-in default)"
+                "mcp.title cannot be empty (omit `title` from the `[mcp]` section to use the \
+                 built-in default)"
             );
         } else {
             panic!("Expected InvalidConfig error, got {result:?}");
@@ -2449,8 +2450,8 @@ mod tests {
         if let Err(Error::InvalidConfig(msg)) = result {
             assert_eq!(
                 msg,
-                "mcp.description cannot be empty (omit `description` to use the built-in \
-                 default)"
+                "mcp.description cannot be empty (omit `description` from the `[mcp]` section \
+                 to use the built-in default)"
             );
         } else {
             panic!("Expected InvalidConfig error, got {result:?}");
@@ -2468,8 +2469,8 @@ mod tests {
         if let Err(Error::InvalidConfig(msg)) = result {
             assert_eq!(
                 msg,
-                "mcp.instructions cannot be empty (omit `instructions` to use the built-in \
-                 default)"
+                "mcp.instructions cannot be empty (omit `instructions` from the `[mcp]` \
+                 section to use the built-in default)"
             );
         } else {
             panic!("Expected InvalidConfig error, got {result:?}");

--- a/crates/mcpls-core/src/lib.rs
+++ b/crates/mcpls-core/src/lib.rs
@@ -548,7 +548,7 @@ pub async fn serve_with(config: ServerConfig, transport: Transport) -> Result<()
     // check here; rejected as unnecessary ceremony for a pre-1.0 API (#282).
     config.validate()?;
 
-    let project_config_ignored = config.project_config_ignored;
+    let (project_config_ignored, mcp) = (config.project_config_ignored, config.mcp.clone());
     // `current_dir()` always returns an absolute path. Configs loaded from a
     // TOML file have already had relative roots rebased to that file's
     // directory in `ServerConfig::load_from`; this second pass covers
@@ -683,6 +683,7 @@ pub async fn serve_with(config: ServerConfig, transport: Transport) -> Result<()
         Arc::clone(&workspace_roots_snapshot),
         Arc::clone(&subscriptions),
         project_config_ignored,
+        mcp,
     );
     info!("MCPLS server initialized successfully");
 
@@ -1591,6 +1592,7 @@ mod tests {
             // transport/MCP error from the closed test connection, NOT a fail-fast
             // server-availability error.
             let config = ServerConfig {
+                mcp: crate::config::McpConfig::default(),
                 workspace: WorkspaceConfig {
                     roots: vec![PathBuf::from("/tmp/test-workspace")],
                     position_encodings: vec!["utf-8".to_string(), "utf-16".to_string()],
@@ -1644,6 +1646,7 @@ mod tests {
             // serve() blocks until the MCP transport closes, so it will error with a
             // connection/transport error — not NoServersAvailable.
             let config = ServerConfig {
+                mcp: crate::config::McpConfig::default(),
                 workspace: WorkspaceConfig {
                     roots: vec![PathBuf::from("/tmp/test-workspace")],
                     position_encodings: vec!["utf-8".to_string(), "utf-16".to_string()],
@@ -1700,6 +1703,7 @@ mod tests {
             doomed_cwd.close().unwrap();
 
             let config = ServerConfig {
+                mcp: crate::config::McpConfig::default(),
                 workspace: WorkspaceConfig {
                     roots: vec![workspace_root],
                     position_encodings: vec!["utf-8".to_string(), "utf-16".to_string()],
@@ -1750,6 +1754,7 @@ mod tests {
             use crate::config::{LspServerConfig, WorkspaceConfig};
 
             let config = ServerConfig {
+                mcp: crate::config::McpConfig::default(),
                 workspace: WorkspaceConfig {
                     roots: vec![PathBuf::from("/tmp/test-workspace")],
                     position_encodings: vec!["utf-8".to_string(), "utf-16".to_string()],

--- a/crates/mcpls-core/src/lib.rs
+++ b/crates/mcpls-core/src/lib.rs
@@ -548,7 +548,6 @@ pub async fn serve_with(config: ServerConfig, transport: Transport) -> Result<()
     // check here; rejected as unnecessary ceremony for a pre-1.0 API (#282).
     config.validate()?;
 
-    let (project_config_ignored, mcp) = (config.project_config_ignored, config.mcp.clone());
     // `current_dir()` always returns an absolute path. Configs loaded from a
     // TOML file have already had relative roots rebased to that file's
     // directory in `ServerConfig::load_from`; this second pass covers
@@ -622,6 +621,8 @@ pub async fn serve_with(config: ServerConfig, transport: Transport) -> Result<()
         .with_extensions(extension_map)
         .with_router(router)
         .with_notification_cache(Arc::clone(&notification_cache));
+    // moved, not cloned -- `config`'s last use is above
+    let (project_config_ignored, mcp) = (config.project_config_ignored, config.mcp);
     translator.set_workspace_roots(workspace_roots.clone());
 
     // Mark applicable servers as "expected" so a tool call that arrives while

--- a/crates/mcpls-core/src/mcp/handlers.rs
+++ b/crates/mcpls-core/src/mcp/handlers.rs
@@ -10,6 +10,7 @@ use std::sync::Arc;
 use tokio::sync::Mutex;
 
 use crate::bridge::{NotificationCache, ResourceSubscriptions, Translator};
+use crate::config::McpConfig;
 
 /// Shared context for all tool handlers.
 ///
@@ -46,6 +47,9 @@ pub struct BridgeContext {
     /// (stderr's `tracing::warn!` at load time is typically invisible to an
     /// MCP client).
     pub project_config_ignored: bool,
+    /// Configured `serverInfo`/`instructions` presentation overrides, read by
+    /// `McplsServer::get_info`.
+    pub mcp: McpConfig,
 }
 
 impl BridgeContext {
@@ -57,6 +61,7 @@ impl BridgeContext {
         workspace_roots: Arc<[PathBuf]>,
         subscriptions: Arc<ResourceSubscriptions>,
         project_config_ignored: bool,
+        mcp: McpConfig,
     ) -> Self {
         Self {
             translator,
@@ -64,6 +69,7 @@ impl BridgeContext {
             workspace_roots,
             subscriptions,
             project_config_ignored,
+            mcp,
         }
     }
 }
@@ -85,6 +91,7 @@ mod tests {
             workspace_roots,
             subscriptions,
             false,
+            McpConfig::default(),
         );
         assert_eq!(Arc::strong_count(&context.translator), 1);
     }

--- a/crates/mcpls-core/src/mcp/server.rs
+++ b/crates/mcpls-core/src/mcp/server.rs
@@ -29,6 +29,24 @@ use crate::bridge::{
     DiagnosticInfo, NotificationCache, PositionEncoding, ResourceSubscriptions, Translator,
     validate_path_against_roots,
 };
+use crate::config::McpConfig;
+
+/// Built-in `serverInfo.title`, used when `[mcp].title` is not configured.
+const DEFAULT_SERVER_TITLE: &str = "MCPLS - MCP to LSP Bridge";
+
+/// Built-in `serverInfo.description`, used when `[mcp].description` is not
+/// configured. Sourced from the crate's own `Cargo.toml` `description` field.
+const DEFAULT_SERVER_DESCRIPTION: &str = env!("CARGO_PKG_DESCRIPTION");
+
+/// Built-in `ServerInfo.instructions` capability blurb, used when
+/// `[mcp].instructions` is not configured. A configured value replaces this
+/// text entirely rather than appending to it -- see [`McpConfig::instructions`].
+const DEFAULT_INSTRUCTIONS: &str = concat!(
+    "Universal MCP to LSP bridge. Exposes Language Server Protocol ",
+    "capabilities as MCP tools for semantic code intelligence. ",
+    "Supports hover, definition, references, diagnostics, rename, ",
+    "completions, symbols, and formatting."
+);
 
 /// MCP server that exposes LSP capabilities as tools.
 #[derive(Clone)]
@@ -160,7 +178,9 @@ impl McplsServer {
     /// `project_config_ignored` reports whether a CWD-discovered
     /// `./mcpls.toml` was skipped as untrusted when the active config was
     /// loaded (see [`ServerConfig::project_config_ignored`](crate::config::ServerConfig::project_config_ignored));
-    /// `get_info` surfaces it in [`ServerInfo::instructions`].
+    /// `get_info` surfaces it in [`ServerInfo::instructions`]. `mcp` carries
+    /// the configured `[mcp]` presentation overrides (see
+    /// [`crate::config::McpConfig`]), also read by `get_info`.
     #[must_use]
     pub fn new(
         translator: Arc<Translator>,
@@ -168,6 +188,7 @@ impl McplsServer {
         workspace_roots: Arc<[PathBuf]>,
         subscriptions: Arc<ResourceSubscriptions>,
         project_config_ignored: bool,
+        mcp: McpConfig,
     ) -> Self {
         let context = Arc::new(BridgeContext::new(
             translator,
@@ -175,6 +196,7 @@ impl McplsServer {
             workspace_roots,
             subscriptions,
             project_config_ignored,
+            mcp,
         ));
         Self { context }
     }
@@ -817,8 +839,20 @@ impl ServerHandler for McplsServer {
 
     fn get_info(&self) -> ServerInfo {
         let mut implementation = Implementation::new("mcpls", env!("CARGO_PKG_VERSION"));
-        implementation.title = Some("MCPLS - MCP to LSP Bridge".to_string());
-        implementation.description = Some(env!("CARGO_PKG_DESCRIPTION").to_string());
+        implementation.title = Some(
+            self.context
+                .mcp
+                .title
+                .clone()
+                .unwrap_or_else(|| DEFAULT_SERVER_TITLE.to_string()),
+        );
+        implementation.description = Some(
+            self.context
+                .mcp
+                .description
+                .clone()
+                .unwrap_or_else(|| DEFAULT_SERVER_DESCRIPTION.to_string()),
+        );
         implementation.website_url = Some("https://github.com/bug-ops/mcpls".to_string());
 
         let capabilities = ServerCapabilities::builder()
@@ -828,13 +862,12 @@ impl ServerHandler for McplsServer {
             .build();
         let mut server_info = ServerInfo::new(capabilities);
         server_info.server_info = implementation;
-        let mut instructions = concat!(
-            "Universal MCP to LSP bridge. Exposes Language Server Protocol ",
-            "capabilities as MCP tools for semantic code intelligence. ",
-            "Supports hover, definition, references, diagnostics, rename, ",
-            "completions, symbols, and formatting."
-        )
-        .to_string();
+        let mut instructions = self
+            .context
+            .mcp
+            .instructions
+            .clone()
+            .unwrap_or_else(|| DEFAULT_INSTRUCTIONS.to_string());
 
         if self.context.project_config_ignored {
             instructions.push_str(
@@ -860,6 +893,13 @@ mod tests {
     }
 
     fn create_test_server_with_ignored_flag(project_config_ignored: bool) -> McplsServer {
+        create_test_server_with_mcp_config(project_config_ignored, McpConfig::default())
+    }
+
+    fn create_test_server_with_mcp_config(
+        project_config_ignored: bool,
+        mcp: McpConfig,
+    ) -> McplsServer {
         let translator = Arc::new(Translator::new());
         let notification_cache = Arc::new(Mutex::new(NotificationCache::new()));
         let workspace_roots: Arc<[PathBuf]> = Arc::from(Vec::new());
@@ -870,6 +910,7 @@ mod tests {
             workspace_roots,
             subscriptions,
             project_config_ignored,
+            mcp,
         )
     }
 
@@ -899,6 +940,61 @@ mod tests {
         let instructions = info.instructions.unwrap();
         assert!(instructions.contains("ignored as untrusted"));
         assert!(instructions.contains("--trust-project-config"));
+    }
+
+    #[tokio::test]
+    async fn test_get_info_default_mcp_config_uses_built_in_text() {
+        let server = create_test_server_with_mcp_config(false, McpConfig::default());
+        let info = server.get_info();
+
+        assert_eq!(
+            info.server_info.title.as_deref(),
+            Some(DEFAULT_SERVER_TITLE)
+        );
+        assert_eq!(
+            info.server_info.description.as_deref(),
+            Some(DEFAULT_SERVER_DESCRIPTION)
+        );
+        assert_eq!(info.instructions.as_deref(), Some(DEFAULT_INSTRUCTIONS));
+    }
+
+    #[tokio::test]
+    async fn test_get_info_reflects_configured_mcp_fields() {
+        let mcp = McpConfig {
+            title: Some("Custom Title".to_string()),
+            description: Some("Custom description".to_string()),
+            instructions: Some("Custom instructions.".to_string()),
+        };
+        let server = create_test_server_with_mcp_config(false, mcp);
+        let info = server.get_info();
+
+        assert_eq!(info.server_info.title.as_deref(), Some("Custom Title"));
+        assert_eq!(
+            info.server_info.description.as_deref(),
+            Some("Custom description")
+        );
+        assert_eq!(info.instructions.as_deref(), Some("Custom instructions."));
+    }
+
+    /// Configured `instructions` replace the built-in blurb, but the
+    /// untrusted-project-config NOTE must still be appended afterward --
+    /// including when `instructions` sits exactly at
+    /// `MAX_MCP_INSTRUCTIONS_BYTES`, proving the NOTE is outside the user's
+    /// budget rather than truncated to make room for it.
+    #[tokio::test]
+    async fn test_get_info_appends_ignore_notice_after_configured_instructions_at_cap() {
+        let instructions = "a".repeat(crate::config::MAX_MCP_INSTRUCTIONS_BYTES);
+        let mcp = McpConfig {
+            title: None,
+            description: None,
+            instructions: Some(instructions.clone()),
+        };
+        let server = create_test_server_with_mcp_config(true, mcp);
+        let info = server.get_info();
+
+        let returned_instructions = info.instructions.unwrap();
+        assert!(returned_instructions.starts_with(&instructions));
+        assert!(returned_instructions.contains("ignored as untrusted"));
     }
 
     #[tokio::test]

--- a/crates/mcpls-core/src/transport.rs
+++ b/crates/mcpls-core/src/transport.rs
@@ -787,13 +787,21 @@ mod tests {
         use tokio::sync::Mutex;
 
         use crate::bridge::{NotificationCache, ResourceSubscriptions, Translator};
+        use crate::config::McpConfig;
         use crate::mcp::McplsServer;
 
         let translator = Arc::new(Translator::new());
         let notification_cache = Arc::new(Mutex::new(NotificationCache::new()));
         let workspace_roots: Arc<[PathBuf]> = Arc::from(Vec::new());
         let subs = Arc::new(ResourceSubscriptions::new());
-        let server = McplsServer::new(translator, notification_cache, workspace_roots, subs, false);
+        let server = McplsServer::new(
+            translator,
+            notification_cache,
+            workspace_roots,
+            subs,
+            false,
+            McpConfig::default(),
+        );
         let peer_cell = tokio::sync::OnceCell::new();
 
         let outcome = tokio::time::timeout(
@@ -886,14 +894,21 @@ mod tests {
             use tokio::sync::Mutex;
 
             use crate::bridge::{NotificationCache, ResourceSubscriptions, Translator};
+            use crate::config::McpConfig;
             use crate::mcp::McplsServer;
 
             let translator = Arc::new(Translator::new());
             let notification_cache = Arc::new(Mutex::new(NotificationCache::new()));
             let workspace_roots: Arc<[PathBuf]> = Arc::from(Vec::new());
             let subs = Arc::new(ResourceSubscriptions::new());
-            let server =
-                McplsServer::new(translator, notification_cache, workspace_roots, subs, false);
+            let server = McplsServer::new(
+                translator,
+                notification_cache,
+                workspace_roots,
+                subs,
+                false,
+                McpConfig::default(),
+            );
 
             // Bind port 0 so the OS assigns a free port.
             let probe = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -983,6 +998,7 @@ mod tests {
             use tokio::sync::Mutex;
 
             use crate::bridge::{NotificationCache, ResourceSubscriptions, Translator};
+            use crate::config::McpConfig;
             use crate::mcp::McplsServer;
 
             // Hold a listener to make the port unavailable.
@@ -993,8 +1009,14 @@ mod tests {
             let notification_cache = Arc::new(Mutex::new(NotificationCache::new()));
             let workspace_roots: Arc<[PathBuf]> = Arc::from(Vec::new());
             let subs = Arc::new(ResourceSubscriptions::new());
-            let server =
-                McplsServer::new(translator, notification_cache, workspace_roots, subs, false);
+            let server = McplsServer::new(
+                translator,
+                notification_cache,
+                workspace_roots,
+                subs,
+                false,
+                McpConfig::default(),
+            );
 
             let cfg = HttpConfig::new(addr, "/mcp");
 
@@ -1017,13 +1039,21 @@ mod tests {
             use tokio::sync::Mutex;
 
             use crate::bridge::{NotificationCache, ResourceSubscriptions, Translator};
+            use crate::config::McpConfig;
             use crate::mcp::McplsServer;
 
             let translator = Arc::new(Translator::new());
             let notification_cache = Arc::new(Mutex::new(NotificationCache::new()));
             let workspace_roots: Arc<[PathBuf]> = Arc::from(Vec::new());
             let subs = Arc::new(ResourceSubscriptions::new());
-            McplsServer::new(translator, notification_cache, workspace_roots, subs, false)
+            McplsServer::new(
+                translator,
+                notification_cache,
+                workspace_roots,
+                subs,
+                false,
+                McpConfig::default(),
+            )
         }
 
         /// Sends a raw HTTP/1.1 POST request over TCP and returns the raw response

--- a/crates/mcpls-core/tests/e2e/protocol_tests.rs
+++ b/crates/mcpls-core/tests/e2e/protocol_tests.rs
@@ -47,6 +47,37 @@ fn test_e2e_initialize_handshake() -> Result<()> {
     Ok(())
 }
 
+/// Test that a configured `[mcp].title` reaches the real `initialize`
+/// response, driving the actual `serve_with` -> `McplsServer::new` ->
+/// `get_info` path (#347) rather than constructing `McpConfig` in-process.
+#[test]
+#[ignore = "Requires mcpls binary built"]
+fn test_e2e_initialize_reflects_configured_mcp_title() -> Result<()> {
+    let config_path =
+        std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/mcp_config.toml");
+
+    let mut client = McpClient::spawn_with_args(&[
+        "--config",
+        config_path
+            .to_str()
+            .ok_or_else(|| anyhow::anyhow!("Invalid config path"))?,
+    ])?;
+
+    let response = client.initialize()?;
+    let result = &response["result"];
+
+    assert_eq!(
+        result["serverInfo"]["title"], "E2E Custom Title",
+        "Configured mcp.title should surface in serverInfo.title"
+    );
+    assert_eq!(
+        result["serverInfo"]["name"], "mcpls",
+        "serverInfo.name stays hardcoded regardless of [mcp] config"
+    );
+
+    Ok(())
+}
+
 /// Test listing all available MCP tools.
 ///
 /// Validates that:

--- a/crates/mcpls-core/tests/fixtures/mcp_config.toml
+++ b/crates/mcpls-core/tests/fixtures/mcp_config.toml
@@ -1,0 +1,8 @@
+# Configuration for E2E testing of the [mcp] section (#347).
+# No LSP servers configured - tests protocol only.
+
+[mcp]
+title = "E2E Custom Title"
+
+[workspace]
+roots = []

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -20,7 +20,11 @@ mcpls uses TOML format for configuration. The file can be placed in several loca
 A `mcpls.toml` discovered in the current directory controls which command mcpls
 spawns as an LSP server (and other workspace settings), so mcpls does not load it
 automatically. Running `mcpls` inside an untrusted checkout must not execute
-commands from that checkout without explicit consent.
+commands from that checkout without explicit consent. Trusting it also confers
+authorship of the agent-facing `serverInfo.title`/`description`/`instructions`
+text (see [MCP Section](#mcp-section)) — a trusted config can replace that text
+wholesale, with no in-band marker distinguishing it from mcpls's own built-in
+wording.
 
 To load a project-local `mcpls.toml`, opt in explicitly:
 
@@ -55,6 +59,12 @@ itself the user's consent.
 ## Configuration Structure
 
 ```toml
+# Optional: MCP serverInfo/initialize presentation overrides
+[mcp]
+title = "My Custom Bridge"
+description = "Internal LSP bridge for Acme Corp"
+instructions = "Use get_hover before get_definition."
+
 # Workspace configuration
 [workspace]
 roots = ["/path/to/project1", "/path/to/project2"]
@@ -73,6 +83,41 @@ request_timeout_seconds = 30
 [lsp_servers.initialization_options]
 cargo.features = "all"
 ```
+
+## MCP Section
+
+Overrides the text mcpls reports about itself over MCP. Every field is
+optional and independent; omitting one keeps mcpls's built-in text for it.
+`serverInfo.name`, `version`, and `website_url` are not configurable —
+`name` is the MCP-spec machine identifier (asserted by clients that key off
+it), and `version`/`website_url` are project metadata rather than
+presentation text.
+
+| Field | Overrides | Default | Max size |
+|-------|-----------|---------|----------|
+| `mcp.title` | `serverInfo.title` | `"MCPLS - MCP to LSP Bridge"` | 128 bytes |
+| `mcp.description` | `serverInfo.description` | the crate's `Cargo.toml` description | 1024 bytes |
+| `mcp.instructions` | `ServerInfo.instructions` | built-in capability blurb | 4096 bytes |
+
+```toml
+[mcp]
+title = "My Custom Bridge"
+description = "Internal LSP bridge for Acme Corp"
+instructions = "Use get_hover before get_definition."
+```
+
+> [!IMPORTANT]
+> A configured `mcp.instructions` **replaces** the built-in capability
+> blurb entirely rather than appending to it — an AI agent that reads
+> `instructions` at connection time (per mcpls's own Agent Skill) will see
+> only your configured text. The untrusted-project-config NOTE (see
+> [Trusting a Project-Local Config](#trusting-a-project-local-config)) is
+> unrelated and is still appended after it when applicable.
+
+Every field's size limit is enforced in UTF-8 bytes, not characters. A
+whitespace-only value (e.g. `title = "   "`) is rejected as empty, the same
+as an actually-empty string — omit the field entirely to use the built-in
+default instead. `tool_prefix` is not implemented yet (tracked separately).
 
 ## Workspace Section
 

--- a/examples/mcpls.toml
+++ b/examples/mcpls.toml
@@ -4,6 +4,15 @@
 # unless you pass --trust-project-config (or set MCPLS_TRUST_PROJECT_CONFIG=true) —
 # see docs/user-guide/configuration.md#trusting-a-project-local-config.
 
+# MCP serverInfo/initialize presentation overrides (all optional; omit any
+# field to keep mcpls's built-in text). `instructions` REPLACES the built-in
+# capability blurb rather than appending to it. Byte caps: title 128,
+# description 1024, instructions 4096 (UTF-8 bytes).
+# [mcp]
+# title = "My Custom Bridge"
+# description = "Internal LSP bridge for Acme Corp"
+# instructions = "Use get_hover before get_definition."
+
 # Workspace settings
 [workspace]
 # Root directories for the workspace

--- a/skills/mcpls/SKILL.md
+++ b/skills/mcpls/SKILL.md
@@ -190,6 +190,13 @@ populated by `McplsServer::get_info`). **Check the server instructions surfaced 
 connection time**: if you see a note about an ignored project config, the file wasn't
 malicious-by-default — it just needs an explicit trust decision.
 
+The rest of `instructions` is not guaranteed to be mcpls's built-in capability
+blurb: a configured `[mcp].instructions` (see [Configuration
+Reference](https://github.com/bug-ops/mcpls/blob/main/docs/user-guide/configuration.md#mcp-section))
+**replaces** that text entirely. Read whatever `instructions` actually contains at
+connection time rather than assuming the built-in wording — the ignored-config NOTE
+above is still appended after it regardless.
+
 ### Starter config
 
 A minimal `mcpls.toml` — expand per-language via

--- a/skills/mcpls/references/configuration.md
+++ b/skills/mcpls/references/configuration.md
@@ -5,6 +5,22 @@ for worked examples per language, see
 [Configuration Reference](https://github.com/bug-ops/mcpls/blob/main/docs/user-guide/configuration.md)
 and [Complete Examples](https://github.com/bug-ops/mcpls/blob/main/docs/user-guide/configuration.md#complete-examples).
 
+## `[mcp]` fields
+
+Overrides the text mcpls reports about itself over MCP; every field is optional and
+independent, defaulting to mcpls's built-in text when omitted. `serverInfo.name`,
+`version`, and `website_url` are not configurable here.
+
+| Field | Type | Default | Max size | Notes |
+|---|---|---|---|---|
+| `title` | string | `"MCPLS - MCP to LSP Bridge"` | 128 bytes | Overrides `serverInfo.title`. |
+| `description` | string | crate's `Cargo.toml` description | 1024 bytes | Overrides `serverInfo.description`. |
+| `instructions` | string | built-in capability blurb | 4096 bytes | **Replaces** `ServerInfo.instructions` entirely — does not append to the built-in text. Read it at connection time instead of assuming the built-in blurb; see the note below. |
+
+Limits are UTF-8 bytes, not characters, and apply to the raw configured string,
+including surrounding whitespace — a whitespace-only value is rejected as empty
+rather than checked against the byte cap. `tool_prefix` is not implemented yet.
+
 ## `[workspace]` fields
 
 | Field | Type | Default | Notes |


### PR DESCRIPTION
## Summary

Adds an optional `[mcp]` TOML config section (`title`, `description`, `instructions`) that overrides the hardcoded `ServerInfo` fields returned in the MCP `initialize` response. Every embedder currently sees "MCPLS - MCP to LSP Bridge" regardless of which language server they're fronting, which makes tool selection harder for both the end user and the AI agent when multiple bridges are configured.

Thanks to @kun-codes for the clear writeup and the concrete `[server]`/`instructions` example in #347 — it mapped directly onto the config schema below.

- All three fields default to current behavior when omitted (fully backward compatible).
- Byte caps: `title` 128, `description` 1024, `instructions` 4096 (UTF-8 bytes), enforced in `ServerConfig::validate()` — these bound how much user-supplied text lands in an agent's context on every `initialize`.
- `instructions` replaces (not appends to) the built-in capability text; the untrusted-project-config notice is still appended afterward and is excluded from the byte budget.
- `tool_prefix` (also proposed in #347) is out of scope here — `rmcp`'s `#[tool_handler]` macro has no access to instance config, making it a materially larger change. Filed as #353.

## Breaking change

`McplsServer::new` and `BridgeContext::new` both gain an `mcp: McpConfig` parameter; `ServerConfig`/`BridgeContext` gain a public `mcp` field. Acceptable pre-1.0, documented in CHANGELOG.md.

## Test plan

- [x] Config parsing of `[mcp]`, present and absent (backward compat)
- [x] `validate()`: empty/whitespace-only rejected as empty (not over-length), exact-cap accepted, one-byte-over rejected with byte count + limit in the error
- [x] Multi-byte UTF-8 boundary case (`"é".repeat(65)` rejected vs `.repeat(64)` accepted) — pins the "bytes not chars" contract
- [x] `get_info()` reflects configured values and falls back to hardcoded defaults when unset
- [x] End-to-end test driving a real `initialize` through a fixture `mcpls.toml` and the built binary
- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features --workspace -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --lib --bins` (719 passed)
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features --workspace`

Closes #347