### PR TITLE
fix(bridge): close DocumentTracker::update race and restore diagnostics push visibility after respawn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **`DocumentTracker::update`** — Breaking change: now `async`, serializing against `ensure_open` for the same path. (#358)
 
+### Fixed
+
+- Diagnostics push notifications no longer silently vanish after an LSP server respawn; `get_cached_diagnostics`/resource reads now flag when they're degraded. (#359)
+
 ## [0.4.0] - 2026-09-05
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **`DocumentTracker::update`** — Breaking change: now `async`, serializing against `ensure_open` for the same path. (#358)
+- **`DocumentTracker::update`** — Breaking change: now `async`, serializing against `ensure_open` for the same path. (#363)
 
 ### Fixed
 
-- Diagnostics push notifications no longer silently vanish after an LSP server respawn; `get_cached_diagnostics`/resource reads now flag when they're degraded. (#359)
+- Diagnostics push notifications no longer silently vanish after an LSP server respawn; `get_cached_diagnostics`/resource reads now flag when they're degraded. (#363)
 
 ## [0.4.0] - 2026-09-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **`DocumentTracker::update`** — Breaking change: now `async`, serializing against `ensure_open` for the same path. (#358)
+
 ## [0.4.0] - 2026-09-05
 
 ### Added

--- a/crates/mcpls-core/src/bridge/notifications.rs
+++ b/crates/mcpls-core/src/bridge/notifications.rs
@@ -2,7 +2,7 @@
 //!
 //! Stores diagnostics, log messages, and server messages received from LSP servers.
 
-use std::collections::{BTreeMap, HashMap, VecDeque};
+use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
 
 use chrono::{DateTime, Utc};
 use lsp_types::{Diagnostic as LspDiagnostic, Uri};
@@ -463,6 +463,17 @@ pub struct NotificationCache {
     logs: VecDeque<LogEntry>,
     /// Recent server messages (FIFO queue with max size).
     messages: VecDeque<ServerMessage>,
+    /// Server ids whose `textDocument/publishDiagnostics` push notifications
+    /// are known to be dark: `Translator::respawn_if_dead` replaced a crashed
+    /// process for this id, and the replacement's notification receiver is
+    /// drained and discarded rather than wired into a running
+    /// `diagnostics_pump` (#249's documented trade-off -- the pump's
+    /// remaining dependencies live in `serve_with`'s scope, not
+    /// `Translator`'s). Once marked, an id is never unmarked here: only a
+    /// full mcpls process restart actually restores push diagnostics for
+    /// that server, so clearing this on a later respawn attempt would
+    /// misreport the cache as fresh again.
+    push_degraded: HashSet<ServerId>,
 }
 
 impl Default for NotificationCache {
@@ -484,6 +495,7 @@ impl NotificationCache {
             diagnostics_route_count: 1,
             logs: VecDeque::with_capacity(MAX_LOG_ENTRIES),
             messages: VecDeque::with_capacity(MAX_SERVER_MESSAGES),
+            push_degraded: HashSet::new(),
         }
     }
 
@@ -793,6 +805,37 @@ impl NotificationCache {
             self.diagnostics_owners.remove(&key);
             self.diagnostic_seq.remove(&key);
         }
+    }
+
+    /// Marks `server_id`'s push-based diagnostics as no longer live -- see
+    /// the `push_degraded` field doc for why this is permanent for the life
+    /// of the cache.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use mcpls_core::bridge::NotificationCache;
+    /// use mcpls_core::config::ServerId;
+    ///
+    /// let mut cache = NotificationCache::new();
+    /// let id: ServerId = "rust-analyzer".into();
+    /// assert!(!cache.is_push_degraded(&id));
+    /// cache.mark_push_degraded(&id);
+    /// assert!(cache.is_push_degraded(&id));
+    /// ```
+    pub fn mark_push_degraded(&mut self, server_id: &ServerId) {
+        self.push_degraded.insert(server_id.clone());
+    }
+
+    /// Whether `server_id`'s push-based diagnostics are known to be
+    /// degraded (see [`Self::mark_push_degraded`]) -- callers such as
+    /// `get_cached_diagnostics` and `read_resource` use this to flag a
+    /// cache-only result as potentially stale rather than presenting it as
+    /// current.
+    #[inline]
+    #[must_use]
+    pub fn is_push_degraded(&self, server_id: &ServerId) -> bool {
+        self.push_degraded.contains(server_id)
     }
 
     /// Clear all diagnostics, for every server.
@@ -2014,6 +2057,29 @@ mod tests {
         // Idempotent / no-op for a server with no (or no longer any) entries.
         cache.clear_server_diagnostics(&crashed);
         assert_eq!(cache.diagnostics_count(), 1);
+    }
+
+    /// #359: `mark_push_degraded` must be scoped per server and, once set,
+    /// stay set -- there is no "unmark" operation, since only a full mcpls
+    /// process restart actually restores push diagnostics for a respawned
+    /// server.
+    #[test]
+    fn test_push_degraded_is_scoped_per_server_and_permanent() {
+        let mut cache = NotificationCache::new();
+        let degraded = ServerId::from("degraded");
+        let healthy = ServerId::from("healthy");
+
+        assert!(!cache.is_push_degraded(&degraded));
+        assert!(!cache.is_push_degraded(&healthy));
+
+        cache.mark_push_degraded(&degraded);
+
+        assert!(cache.is_push_degraded(&degraded));
+        assert!(!cache.is_push_degraded(&healthy));
+
+        // Marking again is idempotent.
+        cache.mark_push_degraded(&degraded);
+        assert!(cache.is_push_degraded(&degraded));
     }
 
     /// #276: `set_diagnostics_route_count` shrinking a server's fair share

--- a/crates/mcpls-core/src/bridge/state.rs
+++ b/crates/mcpls-core/src/bridge/state.rs
@@ -380,9 +380,23 @@ impl DocumentTracker {
     /// Returns `None` if the document is not open. The updated content has no
     /// known disk provenance, so the next `ensure_open` call on this path
     /// will always re-verify by content compare rather than trusting a stat.
-    // TODO(critic): `update`/`open` may race a concurrent `ensure_open` for
-    // the same path; see #304 review.
-    pub fn update(&self, path: &Path, content: String) -> Option<i32> {
+    ///
+    /// # Concurrency
+    ///
+    /// Takes the same per-path lock as [`Self::ensure_open`] (see
+    /// `lock_path`), so this can never interleave with an `ensure_open` call
+    /// for the same path -- closing the race where `ensure_open`'s disk
+    /// phase reads a `(uri, version, disk snapshot)` under a short-lived
+    /// lock and its sync phase later commits against that now-stale
+    /// snapshot after a concurrent `update` bumped the version in between.
+    ///
+    /// **Warning**: `lock_path`'s mutex is not reentrant. Never call `update`
+    /// from a task that already holds this same path's `lock_path` guard
+    /// (e.g. from within `ensure_open`/`disk_phase`/`sync_phase`, or any
+    /// future caller nested inside one) -- doing so self-deadlocks
+    /// permanently, with no panic and no timeout to signal it.
+    pub async fn update(&self, path: &Path, content: String) -> Option<i32> {
+        let _path_guard = self.lock_path(path).await;
         lock_std(&self.documents)
             .get_mut(path)
             .map(|state| state.apply_local_edit(content))
@@ -1024,8 +1038,8 @@ mod tests {
         assert_eq!(detect_language(Path::new("unknown.xyz"), &map), "plaintext");
     }
 
-    #[test]
-    fn test_document_tracker() {
+    #[tokio::test]
+    async fn test_document_tracker() {
         let mut map = HashMap::new();
         map.insert("rs".to_string(), "rust".to_string());
 
@@ -1044,7 +1058,9 @@ mod tests {
         assert_eq!(state.version(), 1);
         assert_eq!(state.language_id(), "rust");
 
-        let new_version = tracker.update(&path, "fn main() { println!() }".to_string());
+        let new_version = tracker
+            .update(&path, "fn main() { println!() }".to_string())
+            .await;
         assert_eq!(new_version, Some(2));
 
         tracker.close(&path);
@@ -1262,13 +1278,13 @@ mod tests {
         assert_eq!(cloned.content(), state.content());
     }
 
-    #[test]
-    fn test_update_nonexistent_document() {
+    #[tokio::test]
+    async fn test_update_nonexistent_document() {
         let map = HashMap::new();
         let tracker = DocumentTracker::new(ResourceLimits::default(), map);
         let path = PathBuf::from("/test/nonexistent.rs");
 
-        let version = tracker.update(&path, "new content".to_string());
+        let version = tracker.update(&path, "new content".to_string()).await;
         assert_eq!(
             version, None,
             "Updating non-existent document should return None"
@@ -1325,8 +1341,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_document_version_increments() {
+    #[tokio::test]
+    async fn test_document_version_increments() {
         let mut map = HashMap::new();
         map.insert("rs".to_string(), "rust".to_string());
 
@@ -1336,13 +1352,13 @@ mod tests {
         tracker.open(path.clone(), "v1".to_string()).unwrap();
         assert_eq!(tracker.get(&path).unwrap().version(), 1);
 
-        tracker.update(&path, "v2".to_string());
+        tracker.update(&path, "v2".to_string()).await;
         assert_eq!(tracker.get(&path).unwrap().version(), 2);
 
-        tracker.update(&path, "v3".to_string());
+        tracker.update(&path, "v3".to_string()).await;
         assert_eq!(tracker.get(&path).unwrap().version(), 3);
 
-        tracker.update(&path, "v4".to_string());
+        tracker.update(&path, "v4".to_string()).await;
         assert_eq!(tracker.get(&path).unwrap().version(), 4);
     }
 
@@ -1581,8 +1597,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_document_tracker_concurrent_operations() {
+    #[tokio::test]
+    async fn test_document_tracker_concurrent_operations() {
         let mut map = HashMap::new();
         map.insert("rs".to_string(), "rust".to_string());
 
@@ -1597,7 +1613,7 @@ mod tests {
         assert!(tracker.is_open(&path1));
         assert!(tracker.is_open(&path2));
 
-        tracker.update(&path1, "new content1".to_string());
+        tracker.update(&path1, "new content1".to_string()).await;
         assert_eq!(tracker.get(&path1).unwrap().content(), "new content1");
         assert_eq!(tracker.get(&path2).unwrap().content(), "content2");
 
@@ -2251,7 +2267,9 @@ mod tests {
             .unwrap();
         assert!(tracker.get(&path).unwrap().disk.is_some());
 
-        tracker.update(&path, "fn main() { updated(); }".to_string());
+        tracker
+            .update(&path, "fn main() { updated(); }".to_string())
+            .await;
         assert!(
             tracker.get(&path).unwrap().disk.is_none(),
             "update() must clear disk provenance so the next ensure_open re-verifies by content"
@@ -2550,6 +2568,90 @@ mod tests {
 
         handle_a.await.unwrap().unwrap();
         assert_eq!(tracker.get(&path_a).unwrap().content(), "fn a() {}");
+    }
+
+    /// Regression for #358: `update` must serialize against a concurrent
+    /// `ensure_open` for the *same* path via the shared per-path lock, not
+    /// just against other `ensure_open` calls.
+    ///
+    /// Uses the same FIFO-blocking idiom as
+    /// `test_ensure_open_different_paths_do_not_serialize`: opening a FIFO
+    /// for read blocks deterministically until a writer connects, so
+    /// `ensure_open`'s `disk_phase_new` (and, with it, the per-path lock
+    /// acquired by `ensure_open` before any disk I/O) is guaranteed to still
+    /// be held when `update` is attempted below. Before the #358 fix,
+    /// `update` took no per-path lock at all and would have raced straight
+    /// through instead of blocking.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_update_serializes_with_concurrent_ensure_open_same_path() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("a.rs");
+
+        let status = std::process::Command::new("mkfifo")
+            .arg(&path)
+            .status()
+            .unwrap();
+        assert!(status.success(), "mkfifo must succeed to set up this test");
+
+        let (client, _server) = fake_lsp_client();
+        let tracker = Arc::new(DocumentTracker::new(
+            ResourceLimits::default(),
+            HashMap::new(),
+        ));
+
+        // Spawned so it can genuinely block on the FIFO's open() while the
+        // rest of this test proceeds concurrently on the same runtime.
+        let tracker_for_open = Arc::clone(&tracker);
+        let path_for_task = path.clone();
+        let handle_open = tokio::spawn(async move {
+            tracker_for_open
+                .ensure_open(&path_for_task, &ServerId::from("rust"), &client)
+                .await
+        });
+
+        // Give the spawned task a chance to actually reach the FIFO's
+        // blocking open() -- and, with it, acquire the per-path lock --
+        // before racing `update` against it below.
+        tokio::time::sleep(Duration::from_millis(200)).await;
+
+        // A successful (non-timeout) result here would mean `update` raced
+        // straight past `ensure_open`'s still-held per-path lock -- the
+        // exact regression #358 fixes.
+        let update_while_blocked = tokio::time::timeout(
+            Duration::from_millis(300),
+            tracker.update(&path, "raced content".to_string()),
+        )
+        .await;
+        assert!(
+            update_while_blocked.is_err(),
+            "update() must block while ensure_open holds the per-path lock for the same path"
+        );
+
+        // Unblock `ensure_open`: opening the FIFO for writing lets its
+        // open() proceed, and closing the write end (at the end of this
+        // call) delivers EOF to the read it's waiting to finish.
+        let path_writer = path.clone();
+        tokio::task::spawn_blocking(move || {
+            std::fs::write(path_writer, "fn a() {}").unwrap();
+        })
+        .await
+        .unwrap();
+
+        handle_open.await.unwrap().unwrap();
+        assert_eq!(tracker.get(&path).unwrap().content(), "fn a() {}");
+        assert_eq!(tracker.get(&path).unwrap().version(), 1);
+
+        // With the lock released, `update` must now proceed and observably
+        // apply on top of `ensure_open`'s committed state.
+        let new_version = tracker
+            .update(&path, "fn a() { updated(); }".to_string())
+            .await;
+        assert_eq!(new_version, Some(2));
+        assert_eq!(
+            tracker.get(&path).unwrap().content(),
+            "fn a() { updated(); }"
+        );
     }
 
     /// Regression for #227: N concurrent `ensure_open` calls for the same

--- a/crates/mcpls-core/src/bridge/translator/respawn.rs
+++ b/crates/mcpls-core/src/bridge/translator/respawn.rs
@@ -211,7 +211,16 @@ impl Translator {
     /// handle) live in `serve_with`'s scope, not the translator's, so
     /// reconnecting live push for a respawned server is out of scope for
     /// this fix -- it does not resume until the whole mcpls process
-    /// restarts, but stale data is no longer served as current.
+    /// restarts, but stale data is no longer served as current. For the
+    /// diagnostics-route server specifically (the only one whose push
+    /// notifications were ever cached to begin with -- see
+    /// `diagnostics_pump`'s `caches_diagnostics` gate), this is logged
+    /// (`tracing::warn!`) and recorded via
+    /// [`crate::bridge::NotificationCache::mark_push_degraded`] so
+    /// `get_cached_diagnostics`/`read_resource` can flag their result as
+    /// potentially stale rather than only being visible in logs (#359); a
+    /// respawned non-route server gets neither, since its notifications
+    /// were already discarded before this fix.
     ///
     /// A crash-looping server (repeated respawn failures) backs off
     /// exponentially (`RESPAWN_BACKOFF_BASE` up to `RESPAWN_BACKOFF_MAX`)
@@ -225,7 +234,7 @@ impl Translator {
     /// window. Returns whatever error `LspServer::spawn` produced (e.g. its
     /// command is no longer on `PATH`, or `initialize` fails again) if an
     /// actual respawn attempt failed.
-    pub(super) async fn respawn_if_dead(&self, id: &ServerId) -> Result<()> {
+    pub(crate) async fn respawn_if_dead(&self, id: &ServerId) -> Result<()> {
         if !self.is_server_dead(id) {
             return Ok(());
         }
@@ -304,7 +313,20 @@ impl Translator {
         if self.is_diagnostics_route(&language_id, id)
             && let Some(cache) = &self.notification_cache
         {
-            cache.lock().await.clear_server_diagnostics(id);
+            tracing::warn!(
+                "LSP server '{id}' (language '{language_id}') respawned; its diagnostics push \
+                 notifications are discarded rather than cached until the mcpls process is \
+                 restarted"
+            );
+            let mut cache = cache.lock().await;
+            cache.clear_server_diagnostics(id);
+            // The replacement's own push notifications are discarded (see
+            // the warn log above and this method's doc), so this server's
+            // cache entries can never be refreshed again by a push -- mark
+            // it degraded so callers like `get_cached_diagnostics` can flag
+            // a cache-only result as potentially stale instead of presenting
+            // it as current.
+            cache.mark_push_degraded(id);
         }
 
         if let Some(old_client) = old_client {
@@ -832,6 +854,15 @@ fi
                 "a different diagnostics-route server's entries must survive \
                  an unrelated server's respawn-triggered cache clear"
             );
+            assert!(
+                guard.is_push_degraded(&id),
+                "#359: the respawned diagnostics-route server must be marked as \
+                 push-degraded, since its replacement's notifications are discarded"
+            );
+            assert!(
+                !guard.is_push_degraded(&ServerId::from("python")),
+                "an unrelated, never-respawned server must not be marked degraded"
+            );
             drop(guard);
         }
 
@@ -920,6 +951,11 @@ fi
                     .is_some(),
                 "respawning a non-diagnostics-route server must not clear \
                  the diagnostics-route server's cache entries"
+            );
+            assert!(
+                !cache.lock().await.is_push_degraded(&hover_id),
+                "#359: respawning a server that is not the diagnostics route \
+                 must not mark it push-degraded either"
             );
         }
 

--- a/crates/mcpls-core/src/bridge/translator/routing.rs
+++ b/crates/mcpls-core/src/bridge/translator/routing.rs
@@ -149,6 +149,33 @@ impl Translator {
         }
     }
 
+    /// Resolve the routing identity of the diagnostics-route server for
+    /// `path`'s detected language, without requiring that server to be
+    /// currently registered.
+    ///
+    /// Mirrors [`Self::get_client_for_file`]'s language-candidate order (the
+    /// detected language, then its React base language) but only queries the
+    /// router: a cache-only caller (`get_cached_diagnostics`) has no LSP
+    /// round trip to gate a resolved server's registration on, and only
+    /// needs the id to check [`crate::bridge::NotificationCache::is_push_degraded`]
+    /// (#359) -- the id itself is stable across a respawn (the routing
+    /// identity doesn't change, only the registered client behind it does),
+    /// unlike `NotificationCache::diagnostics_owner`, which a respawn clears
+    /// along with the crashed server's stale entries.
+    #[must_use]
+    pub(crate) fn diagnostics_route_id_for_path(&self, path: &Path) -> Option<ServerId> {
+        let language = detect_language(path, &self.extension_map);
+        let mut candidates: Vec<&str> = vec![language.as_str()];
+        if let Some(base) = base_language_id(&language) {
+            candidates.push(base);
+        }
+
+        let router = lock_std(&self.router);
+        candidates
+            .iter()
+            .find_map(|lang| router.resolve(lang, ToolKind::Diagnostics).cloned())
+    }
+
     /// Validate `file_path`, then resolve its routed client via
     /// [`Self::resolve_client_for_file`] (respawn-aware), without opening
     /// the document.
@@ -548,6 +575,46 @@ mod tests {
             .get_client_for_file(&test_file, ToolKind::Hover)
             .unwrap();
         assert_eq!(client.language_id(), "typescriptreact");
+    }
+
+    /// #359: `diagnostics_route_id_for_path` must resolve the same id
+    /// `is_diagnostics_route`/the router would, without requiring a
+    /// registered client -- `get_cached_diagnostics` relies on this to look
+    /// up `NotificationCache::is_push_degraded` even when the file's server
+    /// is currently down (mid-respawn or crash-looping).
+    #[test]
+    fn test_diagnostics_route_id_for_path_resolves_without_registered_client() {
+        let temp_dir = TempDir::new().unwrap();
+        let test_file = temp_dir.path().join("main.rs");
+        fs::write(&test_file, "fn main() {}").unwrap();
+
+        let mut extension_map = HashMap::new();
+        extension_map.insert("rs".to_string(), "rust".to_string());
+        let id = ServerId::from("rust");
+
+        let translator = Translator::new()
+            .with_extensions(extension_map)
+            .with_router(ToolRouter::catch_all([(id.clone(), "rust".to_string())]));
+        // Deliberately no `register_client`/`register_server`: this must not
+        // require a live registration, unlike `get_client_for_file`.
+
+        assert_eq!(
+            translator.diagnostics_route_id_for_path(&test_file),
+            Some(id)
+        );
+    }
+
+    /// A file whose language has no configured route resolves to `None`
+    /// rather than panicking or falling back to some default server.
+    #[test]
+    fn test_diagnostics_route_id_for_path_returns_none_for_unrouted_language() {
+        let temp_dir = TempDir::new().unwrap();
+        let test_file = temp_dir.path().join("unknown.xyz");
+        fs::write(&test_file, "content").unwrap();
+
+        let translator = Translator::new();
+
+        assert_eq!(translator.diagnostics_route_id_for_path(&test_file), None);
     }
 
     #[test]

--- a/crates/mcpls-core/src/mcp/server.rs
+++ b/crates/mcpls-core/src/mcp/server.rs
@@ -3,7 +3,7 @@
 //! This module provides the MCP server that exposes LSP capabilities
 //! as MCP tools using the rmcp SDK.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use rmcp::handler::server::router::tool::ToolRouter;
@@ -26,8 +26,8 @@ use super::tools::{
 };
 use crate::bridge::resources::{make_uri, parse_uri};
 use crate::bridge::{
-    DiagnosticInfo, NotificationCache, PositionEncoding, ResourceSubscriptions, Translator,
-    validate_path_against_roots,
+    DiagnosticInfo, DiagnosticsResult, NotificationCache, PositionEncoding, ResourceSubscriptions,
+    Translator, validate_path_against_roots,
 };
 use crate::config::McpConfig;
 
@@ -47,6 +47,35 @@ const DEFAULT_INSTRUCTIONS: &str = concat!(
     "Supports hover, definition, references, diagnostics, rename, ",
     "completions, symbols, and formatting."
 );
+
+/// Response shape for the `get_cached_diagnostics` tool.
+///
+/// Wraps `DiagnosticsResult` (shared with the pull-model `get_diagnostics`
+/// handler) with a flag specific to the cache-only read: whether the file's
+/// *diagnostics-route* server (resolved via
+/// `Translator::diagnostics_route_id_for_path` from the file's detected
+/// language, independent of the cache entry's own `diagnostics_owner`)
+/// crashed and was respawned since it last published. `Translator::respawn_if_dead`
+/// discards a respawned server's push notifications rather than reconnecting
+/// them to a live `diagnostics_pump` (#359), so a cache entry from before
+/// the crash can never be refreshed by a later push -- this makes that
+/// degradation visible to the caller instead of only appearing in server
+/// logs. Deliberately not keyed on `diagnostics_owner`: a respawn clears
+/// that ownership record for the crashed server's entries in the same step
+/// that marks it degraded, so a flag derived from ownership would always
+/// read back `false` for the exact case it exists to catch.
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct CachedDiagnosticsResponse {
+    #[serde(flatten)]
+    result: DiagnosticsResult,
+    /// `true` if the file's diagnostics-route server's push notifications
+    /// are known to be dark (see
+    /// [`crate::bridge::NotificationCache::is_push_degraded`]); `false` both
+    /// when that server is healthy and when no route is configured for the
+    /// file's language at all.
+    push_notifications_degraded: bool,
+}
 
 /// MCP server that exposes LSP capabilities as tools.
 #[derive(Clone)]
@@ -137,19 +166,32 @@ fn paginate_resource_paths<'a>(
 /// `None` both when untracked and when tracked but nothing has been
 /// published yet. `uri` is deliberately omitted: the caller already knows it
 /// (it's the resource they requested).
+///
+/// `push_notifications_degraded` mirrors `get_cached_diagnostics`'s field of
+/// the same name (#359): `true` when the file's diagnostics-route server
+/// crashed and was respawned, so `subscribe`'s replay and the pump's
+/// `notify_resource_updated` calls for it have gone dark until the whole
+/// mcpls process restarts, same as this cache-only read.
 #[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
 struct ResourceDiagnosticsResponse {
     tracked: bool,
     version: Option<i32>,
     diagnostics: Vec<lsp_types::Diagnostic>,
+    push_notifications_degraded: bool,
 }
 
 impl ResourceDiagnosticsResponse {
-    fn new(tracked: bool, entry: Option<&DiagnosticInfo>) -> Self {
+    fn new(
+        tracked: bool,
+        entry: Option<&DiagnosticInfo>,
+        push_notifications_degraded: bool,
+    ) -> Self {
         Self {
             tracked,
             version: entry.and_then(|e| e.version),
             diagnostics: entry.map(|e| e.diagnostics.clone()).unwrap_or_default(),
+            push_notifications_degraded,
         }
     }
 }
@@ -166,8 +208,13 @@ impl ResourceDiagnosticsResponse {
 fn build_resource_diagnostics_response(
     document_open: bool,
     entry: Option<&DiagnosticInfo>,
+    push_notifications_degraded: bool,
 ) -> ResourceDiagnosticsResponse {
-    ResourceDiagnosticsResponse::new(document_open || entry.is_some(), entry)
+    ResourceDiagnosticsResponse::new(
+        document_open || entry.is_some(),
+        entry,
+        push_notifications_degraded,
+    )
 }
 
 #[tool_router(router = declared_tool_router)]
@@ -515,25 +562,41 @@ impl McplsServer {
         let result =
             match Translator::cached_diagnostics_uri(&self.context.workspace_roots, &file_path) {
                 Ok(uri) => {
+                    // Resolved independently of the cache lookup below: a
+                    // respawn clears `diagnostics_owner` for this server's
+                    // entries along with its stale diagnostics (#359), so
+                    // the degraded flag can't be keyed on ownership -- the
+                    // routing identity is what stays stable across a
+                    // respawn.
+                    let route_id = self
+                        .context
+                        .translator
+                        .diagnostics_route_id_for_path(Path::new(&file_path));
+
                     // Lock only long enough for the map lookup + clone: no
                     // canonicalize() or Vec mapping while `notification_cache`
                     // is held, since `diagnostics_pump` needs the same lock.
-                    let (diag_info, owner) = {
+                    let (diag_info, owner, push_degraded) = {
                         let cache = self.context.notification_cache.lock().await;
-                        (
-                            cache.get_diagnostics(&uri).cloned(),
-                            cache.diagnostics_owner(&uri).cloned(),
-                        )
+                        let owner = cache.diagnostics_owner(&uri).cloned();
+                        let push_degraded = route_id
+                            .as_ref()
+                            .is_some_and(|id| cache.is_push_degraded(id));
+                        (cache.get_diagnostics(&uri).cloned(), owner, push_degraded)
                     };
                     let encoding = owner.map_or(PositionEncoding::Utf16, |server_id| {
                         self.context.translator.position_encoding_for(&server_id)
                     });
-                    Ok(Translator::diagnostics_from_cache_entry(
+                    let result = Translator::diagnostics_from_cache_entry(
                         diag_info.as_ref(),
                         encoding,
                         self.context.translator.document_tracker(),
                     )
-                    .await)
+                    .await;
+                    Ok(CachedDiagnosticsResponse {
+                        result,
+                        push_notifications_degraded: push_degraded,
+                    })
                 }
                 Err(e) => Err(e),
             };
@@ -737,15 +800,28 @@ impl ServerHandler for McplsServer {
         let lsp_uri = crate::bridge::path_to_uri(&validated_path)
             .map_err(|e| McpError::invalid_params(e.to_string(), None))?;
 
+        // Resolved independently of the cache lookup below -- see the same
+        // reasoning on `get_cached_diagnostics` (#359): a respawn clears
+        // `diagnostics_owner` for the crashed server's entries, so the
+        // degraded flag can't be keyed on cache ownership.
+        let route_id = self
+            .context
+            .translator
+            .diagnostics_route_id_for_path(&validated_path);
+
         // Built from a borrow of the cache entry rather than `.cloned()`-ing the
         // whole `DiagnosticInfo` first: `build_resource_diagnostics_response`
         // only ever needs `version` (Copy) and its own clone of `diagnostics`,
         // so cloning the entry up front would clone `diagnostics` twice.
         let response = {
             let cache = self.context.notification_cache.lock().await;
+            let push_degraded = route_id
+                .as_ref()
+                .is_some_and(|id| cache.is_push_degraded(id));
             build_resource_diagnostics_response(
                 self.context.translator.is_document_open(&validated_path),
                 cache.get_diagnostics(lsp_uri.as_str()),
+                push_degraded,
             )
         };
 
@@ -1429,6 +1505,210 @@ mod tests {
         );
     }
 
+    /// #359: `get_cached_diagnostics` must surface `pushNotificationsDegraded`
+    /// when the cached entry's owning server was marked degraded (respawned
+    /// with its push notifications discarded), so a caller can tell the
+    /// result may be stale rather than treating it as current.
+    #[tokio::test]
+    async fn test_cached_diagnostics_tool_flags_push_degraded_owner() {
+        use std::collections::HashMap;
+        use std::fs;
+
+        use tempfile::TempDir;
+        use url::Url;
+
+        use crate::config::{ServerId, ToolRouter};
+
+        // A router + extension map is required: the degraded flag is keyed
+        // on `Translator::diagnostics_route_id_for_path` (the file's
+        // *routed* server, resolved from its detected language), not on
+        // `NotificationCache::diagnostics_owner` -- see #359's C1 fix. This
+        // is a fast unit test of that wiring alone; the slower
+        // `..._after_real_respawn` test below covers the full path through
+        // an actual crash + respawn.
+        let owner = ServerId::from("rust");
+        let notification_cache = Arc::new(Mutex::new(NotificationCache::new()));
+        let translator = Arc::new(
+            Translator::new()
+                .with_router(ToolRouter::catch_all([(owner.clone(), "rust".to_string())]))
+                .with_extensions(HashMap::from([("rs".to_string(), "rust".to_string())])),
+        );
+        let server = McplsServer::new(
+            translator,
+            Arc::clone(&notification_cache),
+            Arc::from(Vec::new()),
+            Arc::new(ResourceSubscriptions::new()),
+            false,
+            McpConfig::default(),
+        );
+
+        let temp_dir = TempDir::new().unwrap();
+        let test_file = temp_dir.path().join("test.rs");
+        fs::write(&test_file, "fn main() {}").unwrap();
+
+        let canonical_path = test_file.canonicalize().unwrap();
+        let uri: lsp_types::Uri = Url::from_file_path(&canonical_path)
+            .unwrap()
+            .as_str()
+            .parse()
+            .unwrap();
+        {
+            let mut cache = notification_cache.lock().await;
+            cache.store_diagnostics(&owner, &uri, Some(1), vec![]);
+            cache.mark_push_degraded(&owner);
+        }
+
+        let params = Parameters(CachedDiagnosticsParams {
+            file_path: test_file.to_str().unwrap().to_string(),
+        });
+        let result = server.get_cached_diagnostics(params).await;
+        assert!(result.is_ok());
+
+        let json_str = result.unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&json_str).unwrap();
+        assert_eq!(parsed.get("pushNotificationsDegraded").unwrap(), true);
+    }
+
+    /// #359 regression: drives the *actual* `respawn_if_dead` path (not a
+    /// hand-ordered `store_diagnostics`-then-`mark_push_degraded` call
+    /// sequence, which a real respawn never produces, since
+    /// `clear_server_diagnostics` removes `diagnostics_owner` for the
+    /// crashed server before `mark_push_degraded` runs) and asserts through
+    /// the real `get_cached_diagnostics` MCP handler that
+    /// `pushNotificationsDegraded` comes back `true` afterward -- proving
+    /// the flag is actually reachable in production, keyed on the stable
+    /// routing identity rather than the cleared per-URI ownership map.
+    ///
+    /// `#[cfg(unix)]`: the fake LSP server is a hand-written `sh` script, no
+    /// equivalent on Windows -- mirrors the gating on the respawn tests in
+    /// `bridge::translator::respawn`.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_cached_diagnostics_tool_flags_push_degraded_after_real_respawn() {
+        use std::collections::HashMap;
+        use std::fs;
+
+        use tempfile::TempDir;
+
+        use crate::config::{LspServerConfig, ServerId, ToolRouter};
+        use crate::lsp::{LspServer, ServerInitConfig};
+
+        let dir = TempDir::new().unwrap();
+        let script_path = dir.path().join("crash_after_init.sh");
+        // Answers the `initialize` handshake, then exits ~0.3s later --
+        // stands in for "was alive, then crashed" without a real language
+        // server binary (same shape as `respawn::tests::respawn_tests`'
+        // `write_crash_after_init_script`, duplicated here since that
+        // module's test helpers are private to it).
+        fs::write(
+            &script_path,
+            r#"body='{"jsonrpc":"2.0","id":1,"result":{"capabilities":{}}}'
+printf 'Content-Length: %d\r\n\r\n%s' ${#body} "$body"
+sleep 0.3
+"#,
+        )
+        .unwrap();
+
+        let id = ServerId::from("rust");
+        let config = ServerInitConfig {
+            server_config: LspServerConfig {
+                language_id: "rust".to_string(),
+                command: "sh".to_string(),
+                args: vec![script_path.to_string_lossy().to_string()],
+                env: HashMap::new(),
+                file_patterns: vec![],
+                initialization_options: None,
+                timeout_seconds: 5,
+                request_timeout_seconds: 5,
+                heuristics: None,
+                name: Some("rust".to_string()),
+                handles: None,
+            },
+            workspace_roots: vec![],
+            initialization_options: None,
+            position_encodings: vec!["utf-8".to_string(), "utf-16".to_string()],
+            notification_tx: None,
+        };
+
+        let seed = LspServer::spawn(config.clone()).await.unwrap();
+
+        let notification_cache = Arc::new(Mutex::new(NotificationCache::new()));
+        let translator = Arc::new(
+            Translator::new()
+                .with_router(ToolRouter::catch_all([(id.clone(), "rust".to_string())]))
+                .with_notification_cache(Arc::clone(&notification_cache))
+                .with_extensions(HashMap::from([("rs".to_string(), "rust".to_string())])),
+        );
+        translator.register_client(id.clone(), seed.client().clone());
+        translator.register_server(id.clone(), seed);
+        translator.register_server_config(id.clone(), config);
+
+        let server = McplsServer::new(
+            Arc::clone(&translator),
+            Arc::clone(&notification_cache),
+            Arc::from(Vec::new()),
+            Arc::new(ResourceSubscriptions::new()),
+            false,
+            McpConfig::default(),
+        );
+
+        // Drive real respawn attempts (a no-op while the seed is still
+        // alive) until one actually observes the crash and marks the
+        // diagnostics-route server degraded -- bounded so a broken script
+        // fails the test instead of hanging it.
+        let deadline = tokio::time::Instant::now() + tokio::time::Duration::from_secs(2);
+        loop {
+            let _ = translator.respawn_if_dead(&id).await;
+            if notification_cache.lock().await.is_push_degraded(&id) {
+                break;
+            }
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "server was never observed dead and respawned within the deadline"
+            );
+            tokio::time::sleep(tokio::time::Duration::from_millis(20)).await;
+        }
+
+        let test_file = dir.path().join("main.rs");
+        fs::write(&test_file, "fn main() {}").unwrap();
+        let params = Parameters(CachedDiagnosticsParams {
+            file_path: test_file.to_str().unwrap().to_string(),
+        });
+        let result = server.get_cached_diagnostics(params).await;
+        assert!(result.is_ok());
+
+        let json_str = result.unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&json_str).unwrap();
+        assert_eq!(
+            parsed.get("pushNotificationsDegraded").unwrap(),
+            true,
+            "a real respawn must be observable through the actual MCP handler, got: {parsed}"
+        );
+    }
+
+    /// Companion to the test above: an entry from a server that was never
+    /// marked degraded must report `pushNotificationsDegraded: false`.
+    #[tokio::test]
+    async fn test_cached_diagnostics_tool_reports_not_degraded_by_default() {
+        use tempfile::TempDir;
+
+        let server = create_test_server();
+
+        let temp_dir = TempDir::new().unwrap();
+        let test_file = temp_dir.path().join("test.rs");
+        std::fs::write(&test_file, "fn main() {}").unwrap();
+
+        let params = Parameters(CachedDiagnosticsParams {
+            file_path: test_file.to_str().unwrap().to_string(),
+        });
+        let result = server.get_cached_diagnostics(params).await;
+        assert!(result.is_ok());
+
+        let json_str = result.unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&json_str).unwrap();
+        assert_eq!(parsed.get("pushNotificationsDegraded").unwrap(), false);
+    }
+
     #[tokio::test]
     async fn test_cached_diagnostics_tool_nonexistent_file() {
         let server = create_test_server();
@@ -1883,7 +2163,7 @@ mod tests {
 
     #[test]
     fn test_resource_diagnostics_response_untracked_is_not_tracked_and_empty() {
-        let response = ResourceDiagnosticsResponse::new(false, None);
+        let response = ResourceDiagnosticsResponse::new(false, None, false);
         assert!(!response.tracked);
         assert!(response.version.is_none());
         assert!(response.diagnostics.is_empty());
@@ -1897,7 +2177,7 @@ mod tests {
 
     #[test]
     fn test_resource_diagnostics_response_tracked_but_no_cache_entry_is_clean() {
-        let response = ResourceDiagnosticsResponse::new(true, None);
+        let response = ResourceDiagnosticsResponse::new(true, None, false);
         assert!(response.tracked);
         assert!(response.version.is_none());
         assert!(response.diagnostics.is_empty());
@@ -1930,7 +2210,7 @@ mod tests {
             tags: None,
             data: None,
         }]);
-        let response = ResourceDiagnosticsResponse::new(true, Some(&entry));
+        let response = ResourceDiagnosticsResponse::new(true, Some(&entry), false);
         assert!(response.tracked);
         assert_eq!(response.version, Some(1));
         assert_eq!(response.diagnostics.len(), 1);
@@ -1956,14 +2236,14 @@ mod tests {
 
     #[test]
     fn test_build_resource_diagnostics_response_neither_open_nor_cached_is_untracked() {
-        let response = build_resource_diagnostics_response(false, None);
+        let response = build_resource_diagnostics_response(false, None, false);
         assert!(!response.tracked);
         assert!(response.diagnostics.is_empty());
     }
 
     #[test]
     fn test_build_resource_diagnostics_response_open_but_uncached_is_tracked() {
-        let response = build_resource_diagnostics_response(true, None);
+        let response = build_resource_diagnostics_response(true, None, false);
         assert!(response.tracked);
         assert!(response.diagnostics.is_empty());
     }
@@ -1997,13 +2277,25 @@ mod tests {
             data: None,
         }]);
 
-        let response = build_resource_diagnostics_response(false, Some(&entry));
+        let response = build_resource_diagnostics_response(false, Some(&entry), false);
         assert!(
             response.tracked,
             "a cached diagnostics entry must make the response tracked, \
              even for a file that was never explicitly opened"
         );
         assert_eq!(response.diagnostics.len(), 1);
+    }
+
+    /// #359 S2: `read_resource`'s response carries the same
+    /// `pushNotificationsDegraded` signal as `get_cached_diagnostics`, since
+    /// both serve the same cache and go dark the same way after a respawn.
+    #[test]
+    fn test_build_resource_diagnostics_response_flags_push_degraded() {
+        let response = build_resource_diagnostics_response(false, None, true);
+        assert!(response.push_notifications_degraded);
+
+        let json = serde_json::to_value(&response).unwrap();
+        assert_eq!(json["pushNotificationsDegraded"], true);
     }
 
     /// `parse_uri` rejects `file://` scheme — ensures `read_resource` would return an error.


### PR DESCRIPTION
## Summary

Two independent bridge-subsystem bug fixes, grouped into one PR by subsystem and priority (both P2 bugs on the "Document open state tracking" / "Diagnostics push-poll caching" critical paths).

- `DocumentTracker::update` is now async and takes the same per-path lock as `ensure_open`, closing a documented latent race between concurrent `update`/`ensure_open` calls for the same path. `update` currently has no production callers, so this closes the race before any future write-capable tool call hits it.

  **Breaking change:** `DocumentTracker::update` signature changed from `pub fn` to `pub async fn`.

- `respawn_if_dead` previously discarded a respawned LSP server's notification receiver entirely, silently and permanently dropping push-based diagnostics for that server until a full process restart. `NotificationCache` now tracks a per-server `push_degraded` flag (permanent for the process's life), resolved via a new router-based lookup (`Translator::diagnostics_route_id_for_path`) that stays correct across the respawn that caused the degradation. `get_cached_diagnostics` and `read_resource` both surface this via a `pushNotificationsDegraded` field, and a warning is logged when a diagnostics-route server's push notifications go dark.

  An earlier version of this fix keyed the flag on `NotificationCache::diagnostics_owner`, which the same respawn path clears before marking degraded — making the flag structurally unreachable in production. This was caught during review and fixed by switching to router-based resolution, independent of cache/ownership state.

## Test plan

- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features --workspace -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --lib --bins` (728 passed, 1 skipped)
- [x] `cargo test --doc`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`
- [x] New FIFO-blocking concurrency regression test proving `update` serializes against `ensure_open` for the same path
- [x] New regression test driving a real crash + `respawn_if_dead` end-to-end, asserting `pushNotificationsDegraded: true` through the actual `get_cached_diagnostics` handler

Closes #358
Closes #359