### PR TITLE
build(deps): bump rmcp to 3.2.0 and fix Cargo.toml dependency order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **`DocumentTracker::update`** — Breaking change: now `async`, serializing against `ensure_open` for the same path. (#363)
-- Bump rmcp from 3.1.4 to 3.2.0; an `initialize` request naming `protocolVersion: 2026-07-28` now receives the server's negotiated legacy version in response instead of an echo of the requested version (rmcp behavior change) (#356)
-- Reorder `mcpls-core` `Cargo.toml` dependencies into alphabetical order (#357)
+- Bump rmcp from 3.1.4 to 3.2.0; an `initialize` request naming `protocolVersion: 2026-07-28` now receives the server's negotiated legacy version in response instead of an echo of the requested version (rmcp behavior change) (#364)
+- Reorder `mcpls-core` `Cargo.toml` dependencies into alphabetical order (#364)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **`DocumentTracker::update`** — Breaking change: now `async`, serializing against `ensure_open` for the same path. (#363)
+- Bump rmcp from 3.1.4 to 3.2.0; an `initialize` request naming `protocolVersion: 2026-07-28` now receives the server's negotiated legacy version in response instead of an echo of the requested version (rmcp behavior change) (#356)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **`DocumentTracker::update`** — Breaking change: now `async`, serializing against `ensure_open` for the same path. (#363)
 - Bump rmcp from 3.1.4 to 3.2.0; an `initialize` request naming `protocolVersion: 2026-07-28` now receives the server's negotiated legacy version in response instead of an echo of the requested version (rmcp behavior change) (#356)
+- Reorder `mcpls-core` `Cargo.toml` dependencies into alphabetical order (#357)
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1276,9 +1276,9 @@ checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
 
 [[package]]
 name = "rmcp"
-version = "3.1.4"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a15bc53261a9dc37e105df006e4656c598379a8f9581f8950debb130f27a7cf"
+checksum = "42b6914fac0be956fe704a38239c3f44a9f841d1b06a5713d2f638065593f5b5"
 dependencies = [
  "async-trait",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ ignore = "0.4"
 lsp-types = "0.97"
 mcpls-core = { path = "crates/mcpls-core", version = "0.4.0" }
 predicates = "3.1"
-rmcp = "3.1.0"
+rmcp = "3.2.0"
 rstest = "0.26"
 schemars = "1.2"
 serde = "1.0"

--- a/crates/mcpls-core/Cargo.toml
+++ b/crates/mcpls-core/Cargo.toml
@@ -11,6 +11,7 @@ keywords = ["mcp", "lsp", "language-server", "protocol"]
 categories = ["development-tools"]
 
 [dependencies]
+axum = { workspace = true, optional = true }
 chrono = { workspace = true }
 dirs = { workspace = true }
 dunce = { workspace = true }
@@ -18,13 +19,12 @@ futures = { workspace = true }
 ignore = { workspace = true }
 lsp-types = { workspace = true }
 rmcp = { workspace = true, features = ["server", "transport-io", "macros"] }
-axum = { workspace = true, optional = true }
-tokio-util = { workspace = true, optional = true, features = ["rt"] }
 schemars = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
+tokio-util = { workspace = true, optional = true, features = ["rt"] }
 toml = { workspace = true }
 tracing = { workspace = true }
 url = { workspace = true }

--- a/crates/mcpls-core/src/transport.rs
+++ b/crates/mcpls-core/src/transport.rs
@@ -509,16 +509,18 @@ const HTTP_GRACEFUL_SHUTDOWN_TIMEOUT: std::time::Duration = std::time::Duration:
 /// Enforcement lives here, at the `SessionManager` layer, rather than in Axum
 /// middleware sniffing request headers, because that is the only place
 /// guaranteed to run exactly when — and only when — a session is actually
-/// created. `rmcp` 3.1.0's `StreamableHttpService::handle_post` calls
-/// `create_session` solely on legacy-mode POSTs with no `Mcp-Session-Id`
-/// header (the `initialize` handshake); modern-protocol POSTs (SEP-2567,
-/// protocol `>= 2026-07-28`, which removes sessions entirely) and
-/// `server/discover` requests share that same header-less shape but take a
-/// stateless code path that never calls `create_session`. A header-based
-/// middleware heuristic can't tell these apart without duplicating `rmcp`'s
-/// internal protocol classification, so it either 429s traffic that never
-/// consumed a session slot, or — in an all-stateless deployment — never
-/// fires at all.
+/// created. `rmcp` 3.2.0's `StreamableHttpService::handle_post` classifies
+/// every `initialize` request as legacy and always calls `create_session`,
+/// whatever protocol version it names — the handshake only exists in
+/// revisions before `2026-07-28`, so a version named in its params never
+/// routes it to the stateless path. Only *non*-`initialize` requests that
+/// carry SEP-2575 per-request `_meta` (`io.modelcontextprotocol/protocolVersion`
+/// = `2026-07-28` plus the required `clientCapabilities` key), and
+/// `server/discover` requests, take the stateless discover-lifecycle path
+/// that never calls `create_session`. A header-based middleware heuristic
+/// can't tell these apart without duplicating `rmcp`'s internal protocol
+/// classification, so it either 429s traffic that never consumed a session
+/// slot, or — in an all-stateless deployment — never fires at all.
 ///
 /// `restore_session` and `event_store` deliberately use
 /// [`SessionManager`]'s trait defaults (`NotSupported` / `None`) instead of
@@ -1341,11 +1343,17 @@ mod tests {
             server_task.abort();
         }
 
-        /// S1 non-regression: a modern-protocol (`>= 2026-07-28`, SEP-2567
-        /// stateless) request never calls `SessionManager::create_session` —
-        /// `rmcp` serves it directly without touching the session table — so
-        /// it must not be rejected by the cap even while
-        /// `max_concurrent_sessions` legacy sessions are already active. This
+        /// S1 non-regression: a non-`initialize` request carrying SEP-2575
+        /// per-request `_meta` protocol-version metadata
+        /// (`io.modelcontextprotocol/protocolVersion` = `2026-07-28` plus the
+        /// required `clientCapabilities` key) takes rmcp 3.2.0's stateless
+        /// discover-lifecycle path and never calls
+        /// `SessionManager::create_session` — `rmcp` serves it directly
+        /// without touching the session table — so it must not be rejected
+        /// by the cap even while `max_concurrent_sessions` legacy sessions
+        /// are already active. (An `initialize` request is always
+        /// classified legacy in 3.2.0 regardless of the protocol version it
+        /// names, so it cannot be used to probe the stateless path.) This
         /// guards against a future refactor reintroducing request-header
         /// sniffing for the cap decision (the bug this design replaced).
         #[tokio::test]
@@ -1373,13 +1381,19 @@ mod tests {
                 "legacy initialize should succeed and consume the sole session slot, got: {legacy}"
             );
 
-            // A stateless request (protocolVersion >= 2026-07-28) never
-            // creates a session, so it must bypass the cap entirely even
-            // though the slot above is still held.
-            let stateless_initialize = br#"{"jsonrpc":"2.0","id":2,"method":"initialize","params":{"protocolVersion":"2026-07-28","capabilities":{},"clientInfo":{"name":"test","version":"0"}}}"#;
-            let stateless = raw_http_post(addr, "/mcp", accept_headers, stateless_initialize).await;
+            // A non-`initialize` request carrying per-request `_meta`
+            // protocol-version metadata takes rmcp 3.2.0's stateless
+            // discover-lifecycle path and never creates a session, so it
+            // must bypass the cap entirely even though the slot above is
+            // still held. The `MCP-Protocol-Version` header must match the
+            // `_meta` value once the latter is present, and declaring
+            // `2026-07-28` also brings in SEP-2243's `Mcp-Method` header
+            // requirement.
+            let stateless_headers = "Accept: application/json, text/event-stream\r\nContent-Type: application/json\r\nMCP-Protocol-Version: 2026-07-28\r\nMcp-Method: resources/list\r\n";
+            let stateless_request = br#"{"jsonrpc":"2.0","id":2,"method":"resources/list","params":{"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientCapabilities":{}}}}"#;
+            let stateless = raw_http_post(addr, "/mcp", stateless_headers, stateless_request).await;
             assert!(
-                !stateless.starts_with("HTTP/1.1 429"),
+                stateless.starts_with("HTTP/1.1 200"),
                 "stateless requests must bypass the session cap entirely, got: {stateless}"
             );
 


### PR DESCRIPTION
## Summary
- Bump rmcp from 3.1.4 to 3.2.0 (OAuth credential-store refresh coordination, request-state key rotation, streamable-HTTP fixes)
- Update `CappedSessionManager`'s doc comment and rewrite `test_run_http_stateless_request_bypasses_session_cap` to match rmcp 3.2.0's new `is_legacy_request` classification (every `initialize` is now legacy/session-based regardless of declared protocol version; the stateless discover-lifecycle path is reached only via a non-`initialize` request carrying per-request `_meta` protocol-version metadata)
- Reorder `crates/mcpls-core/Cargo.toml`'s `[dependencies]` table alphabetically to match the workspace convention

## Test plan
- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features --workspace -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --lib --bins` (720/720 pass)
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`
- [x] `cargo audit` / `cargo deny check` — no new advisories, no new transitive dependencies

Closes #356
Closes #357