### PR TITLE
fix: batch of three low-risk P3 fixes (symbols, transport shutdown, diagnostics test)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Diagnostics push notifications no longer silently vanish after an LSP server respawn; `get_cached_diagnostics`/resource reads now flag when they're degraded. (#363)
+- `document_symbols` no longer redundantly recomputes the same range twice for flat (`SymbolInformation`) responses. (#361)
 
 ## [0.4.0] - 2026-09-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Diagnostics push notifications no longer silently vanish after an LSP server respawn; `get_cached_diagnostics`/resource reads now flag when they're degraded. (#363)
 - `document_symbols` no longer redundantly recomputes the same range twice for flat (`SymbolInformation`) responses. (#361)
 - HTTP transport now catches a repeat shutdown signal received during the connection-drain window and cuts the drain short instead of waiting out the full timeout. (#349)
+- Corrected a broken assertion in the ignored `test_diagnostics_with_error` integration test (test-only; no production behavior change). (#360)
 
 ## [0.4.0] - 2026-09-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Diagnostics push notifications no longer silently vanish after an LSP server respawn; `get_cached_diagnostics`/resource reads now flag when they're degraded. (#363)
 - `document_symbols` no longer redundantly recomputes the same range twice for flat (`SymbolInformation`) responses. (#361)
+- HTTP transport now catches a repeat shutdown signal received during the connection-drain window and cuts the drain short instead of waiting out the full timeout. (#349)
 
 ## [0.4.0] - 2026-09-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Diagnostics push notifications no longer silently vanish after an LSP server respawn; `get_cached_diagnostics`/resource reads now flag when they're degraded. (#363)
-- `document_symbols` no longer redundantly recomputes the same range twice for flat (`SymbolInformation`) responses. (#361)
-- HTTP transport now catches a repeat shutdown signal received during the connection-drain window and cuts the drain short instead of waiting out the full timeout. (#349)
-- Corrected a broken assertion in the ignored `test_diagnostics_with_error` integration test (test-only; no production behavior change). (#360)
+- `document_symbols` no longer redundantly recomputes the same range twice for flat (`SymbolInformation`) responses. (#365)
+- HTTP transport now catches a repeat shutdown signal received during the connection-drain window and cuts the drain short instead of waiting out the full timeout. (#365)
+- Corrected a broken assertion in the ignored `test_diagnostics_with_error` integration test (test-only; no production behavior change). (#365)
 
 ## [0.4.0] - 2026-09-05
 

--- a/crates/mcpls-core/src/bridge/translator/symbols.rs
+++ b/crates/mcpls-core/src/bridge/translator/symbols.rs
@@ -147,9 +147,7 @@ impl Translator {
                     let range = ctx
                         .normalize_range(&sym.location.uri, sym.location.range)
                         .await;
-                    let selection_range = ctx
-                        .normalize_range(&sym.location.uri, sym.location.range)
-                        .await;
+                    let selection_range = range.clone();
                     result.push(Symbol {
                         name: sym.name,
                         kind: format!("{:?}", sym.kind),
@@ -272,8 +270,18 @@ impl Translator {
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use std::collections::{HashMap, HashSet};
+    use std::fs;
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    use tempfile::TempDir;
+    use tokio::io::BufReader;
+    use tokio::time::timeout;
 
     use super::*;
+    use crate::bridge::translator::testing::{
+        read_framed_message, translator_with_capabilities, write_response,
+    };
     use crate::config::{ServerId, ToolRouter};
 
     #[tokio::test]
@@ -333,5 +341,66 @@ mod tests {
                 tool: ToolKind::WorkspaceSymbols
             })
         ));
+    }
+
+    /// #361 regression: a `Flat` (`SymbolInformation`) document-symbol
+    /// response has only one range in the wire format, so `selection_range`
+    /// must equal `range` exactly -- not merely be numerically close, which
+    /// a bug re-deriving it via a second `normalize_range` call could still
+    /// produce if line-text resolution raced with a concurrent edit.
+    #[tokio::test]
+    async fn test_handle_document_symbols_flat_response_selection_range_matches_range() {
+        let dir = TempDir::new().unwrap();
+        let server_id = ServerId::from("rust");
+        let (translator, mut server) = translator_with_capabilities(
+            &dir,
+            &server_id,
+            lsp_types::ServerCapabilities {
+                document_symbol_provider: Some(lsp_types::OneOf::Left(true)),
+                ..Default::default()
+            },
+        );
+
+        let path = dir.path().join("main.rs");
+        fs::write(&path, "fn main() {}\n").unwrap();
+        let path_str = path.to_string_lossy().to_string();
+
+        let translator = Arc::new(translator);
+        let handle = {
+            let translator = Arc::clone(&translator);
+            tokio::spawn(async move { translator.handle_document_symbols(path_str).await })
+        };
+
+        let mut wire = BufReader::new(&mut server.write_stdout);
+        let opened = read_framed_message(&mut wire).await;
+        assert_eq!(opened["method"], "textDocument/didOpen");
+        let symbol_request = read_framed_message(&mut wire).await;
+        assert_eq!(symbol_request["method"], "textDocument/documentSymbol");
+
+        write_response(
+            &mut server.read_half_stdin,
+            &symbol_request["id"],
+            serde_json::json!([{
+                "name": "main",
+                "kind": 12,
+                "location": {
+                    "uri": "file:///main.rs",
+                    "range": {
+                        "start": {"line": 0, "character": 0},
+                        "end": {"line": 0, "character": 12},
+                    },
+                },
+            }]),
+        )
+        .await;
+
+        let result = timeout(Duration::from_secs(2), handle)
+            .await
+            .expect("handler call should not hang")
+            .unwrap()
+            .expect("flat document symbol response should succeed");
+
+        assert_eq!(result.symbols.len(), 1);
+        assert_eq!(result.symbols[0].range, result.symbols[0].selection_range);
     }
 }

--- a/crates/mcpls-core/src/transport.rs
+++ b/crates/mcpls-core/src/transport.rs
@@ -387,13 +387,25 @@ pub(crate) async fn run_stdio(
 /// bind and the graceful-shutdown future's first poll is still caught.
 /// `shutdown_signal` is moved into (and dropped by) the
 /// `with_graceful_shutdown` closure below once it resolves — i.e. as soon as
-/// the *first* signal is received, well before this function returns — so
-/// there is no listener at all for a repeat signal arriving during the
+/// the *first* signal is received, well before this function returns. A
+/// second, freshly constructed `ShutdownSignal` then covers the
 /// connection-drain wait that follows (bounded by
-/// [`HTTP_GRACEFUL_SHUTDOWN_TIMEOUT`]). [`crate::shutdown`]'s own
-/// registration only takes effect once *this* function returns, so it
-/// covers the post-transport cleanup window, not the drain wait inside this
-/// one; see #329 and the TODO on the closure below for that gap.
+/// [`HTTP_GRACEFUL_SHUTDOWN_TIMEOUT`]): a repeat signal caught there cuts the
+/// drain short (dropping `serve` the same way the timeout branch already
+/// does) instead of making the operator wait out the full timeout.
+///
+/// Cutting the drain short is *not* an immediate process exit: this function
+/// still returns `Ok(())` normally, and its caller ([`crate::serve_with`])
+/// proceeds straight into the ordinary post-transport shutdown sequence
+/// ([`crate::shutdown`] — LSP server shutdown plus any pending background
+/// init task, bounded by its own ~15s worst case). [`crate::shutdown`]'s own
+/// registration (#329) takes over once *this* function returns, covering
+/// that cleanup window and escalating to a forced `std::process::exit(1)` on
+/// any *further* repeat signal — so an operator wanting a true immediate exit
+/// needs a third signal, not a second. This is a deliberate choice, not an
+/// oversight: calling `exit(1)` directly from this branch would skip
+/// unwinding and forfeit `kill_on_drop` cleanup of any still-running LSP
+/// child processes, which is worse than requiring one more signal.
 #[cfg(feature = "transport-http")]
 // `session_manager` and `service` are moved into `app`, which is served until
 // shutdown — clippy's drop-tightening heuristic misreads that as an
@@ -448,17 +460,11 @@ pub(crate) async fn run_http(
     }
 
     // `cancel` is cancelled exactly once, when the shutdown signal fires
-    // (below). Cloned first so the force-timeout branch can observe that
-    // same moment independently of the `with_graceful_shutdown` closure,
-    // which consumes its own clone.
-    // TODO(#349): `shutdown_signal` is dropped
-    // once this closure resolves, leaving the connection-drain wait below
-    // (up to `HTTP_GRACEFUL_SHUTDOWN_TIMEOUT`) with no signal listener at
-    // all -- a repeat signal there is silently discarded the same way a
-    // repeat signal during post-transport cleanup used to be, before this
-    // fix added one there. Not addressed here; this fix only covers the
-    // window after `run_http` returns.
+    // (below). Cloned first so the force-timeout and repeat-signal branches
+    // can each observe that same moment independently of the
+    // `with_graceful_shutdown` closure, which consumes its own clone.
     let cancel_for_force_timeout = cancel.clone();
+    let cancel_for_repeat_signal = cancel.clone();
     let serve = axum::serve(listener, app).with_graceful_shutdown(async move {
         shutdown_signal.recv().await;
         cancel.cancel();
@@ -482,6 +488,33 @@ pub(crate) async fn run_http(
             tracing::warn!(
                 timeout = ?HTTP_GRACEFUL_SHUTDOWN_TIMEOUT,
                 "HTTP graceful shutdown did not complete in time, proceeding with shutdown anyway"
+            );
+            Ok(())
+        }
+        // #349: `shutdown_signal` above is consumed and dropped as soon as
+        // the first signal arrives, leaving no listener for a repeat signal
+        // during the connection-drain wait that follows. Wait for `cancel`
+        // first and only then construct a fresh `ShutdownSignal` -- rather
+        // than registering one up front, alongside `shutdown_signal` -- so
+        // it starts with no pending signal of its own: `tokio::signal`
+        // fans a delivered signal out to every live listener, so a listener
+        // already registered before the first signal arrived would
+        // independently observe that same signal and misreport it as a
+        // repeat. This leaves a much smaller, accepted gap instead: between
+        // `cancel.cancel()` firing and `ShutdownSignal::new()` actually
+        // registering on the next scheduler hop, there is no pollable
+        // listener at all, so a signal delivered in that sub-millisecond
+        // window is lost. Registering up front would only trade this for
+        // the coalescing problem above -- it is not fully closable either
+        // way, and the window is far below human reaction time to a second
+        // keypress.
+        () = async move {
+            cancel_for_repeat_signal.cancelled().await;
+            let mut repeat_signal = ShutdownSignal::new();
+            repeat_signal.recv().await;
+        } => {
+            tracing::warn!(
+                "repeat shutdown signal received during HTTP connection drain, cutting drain short"
             );
             Ok(())
         }

--- a/crates/mcpls-core/tests/fixtures/rust_workspace/src/lib.rs
+++ b/crates/mcpls-core/tests/fixtures/rust_workspace/src/lib.rs
@@ -92,6 +92,11 @@ pub trait Greet {
 pub struct CodeActionTarget;
 
 // split to multi-line so RA can offer "implement missing members" inside the block
+//
+// Also relied upon by `test_diagnostics_with_error` (rust_analyzer_tests.rs),
+// which asserts on the E0046 "not all trait items implemented" diagnostic
+// this empty impl produces. Don't fill in `hello()` without checking that
+// test first.
 impl Greet for CodeActionTarget {
 }
 

--- a/crates/mcpls-core/tests/integration/rust_analyzer_tests.rs
+++ b/crates/mcpls-core/tests/integration/rust_analyzer_tests.rs
@@ -416,9 +416,15 @@ async fn test_diagnostics_with_error() {
     // Give rust-analyzer extra time to analyze and generate diagnostics
     wait_for_indexing_ready(&translator, &rust_workspace_path(), Duration::from_secs(30)).await;
 
-    // Get diagnostics from lib.rs (has intentional error on line 37). No
-    // push notifications are captured in this harness, so the cache is
-    // empty and handle_diagnostics falls back to the pull-only result.
+    // lib.rs has two intentional errors: an undefined variable in
+    // has_error() (line 37) and an incomplete trait impl for
+    // CodeActionTarget. The former is a flycheck/cargo-check diagnostic,
+    // only ever delivered via textDocument/publishDiagnostics push; this
+    // harness never wires push notifications into the cache, so the cache
+    // stays empty and handle_diagnostics falls back to the pull-only
+    // (textDocument/diagnostic) result, which only ever surfaces
+    // rust-analyzer's own native diagnostics — the missing-trait-item
+    // error (E0046), not the flycheck error.
     let notification_cache = Mutex::new(NotificationCache::new());
     let result = timeout(
         Duration::from_secs(10),
@@ -440,9 +446,9 @@ async fn test_diagnostics_with_error() {
     let diag_json = diag_result.unwrap();
     let diag_str = serde_json::to_string(&diag_json).unwrap();
 
-    // Should contain the error about undefined_variable
+    // Should contain the native "missing trait items" error reachable via pull
     assert!(
-        diag_str.contains("undefined_variable") || diag_str.contains("cannot find"),
+        diag_str.contains("not all trait items implemented") || diag_str.contains("E0046"),
         "Diagnostics should report the intentional error, got: {}",
         diag_str
     );


### PR DESCRIPTION
## Summary

Three independent, unrelated P3 bug fixes triaged and bundled into one batch PR:

- **#361** — `handle_document_symbols`'s `Flat` (`SymbolInformation`) arm called `normalize_range` twice with identical arguments, doubling tracker-lock and line-text-extraction cost per symbol whenever the negotiated encoding is not UTF-16. Now reuses the first computed range.
- **#349** — Follow-up to #329. `run_http`'s axum connection-drain window (up to 30s) had no live listener for a repeat SIGTERM/SIGINT, so a repeat signal there was silently discarded. A repeat signal now cuts the drain short; the normal post-transport shutdown sequence still runs afterward to preserve `kill_on_drop` cleanup of LSP child processes, with a further repeat signal escalating via the existing #329 mechanism.
- **#360** — `test_diagnostics_with_error` (ignored real-rust-analyzer integration test) asserted an unreachable flycheck diagnostic from an intentionally-empty `NotificationCache`. Now asserts the diagnostic actually reachable via the pull-only path. Test-only change, no production behavior affected.

## Test plan

- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features --workspace -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --lib --bins` (729/729 passed)
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`
- [x] `cargo nextest run -p mcpls-core --test integration_tests --all-features -E 'test(test_diagnostics_with_error)' --run-ignored ignored-only` (live against rust-analyzer 1.98.0)
- [x] Two independent adversarial critique passes on the batch (first pass found a significant gap in #349's fix vs. the issue's literal wording, resolved via explicit documentation of the deliberate design choice; second pass approved)

Closes #361
Closes #349
Closes #360