### PR TITLE
refactor(config): non_exhaustive ToolKind/NoServerReason, rename get_language_for_extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`DocumentTracker::update`** — Breaking change: now `async`, serializing against `ensure_open` for the same path. (#363)
 - Bump rmcp from 3.1.4 to 3.2.0; an `initialize` request naming `protocolVersion: 2026-07-28` now receives the server's negotiated legacy version in response instead of an echo of the requested version (rmcp behavior change) (#364)
 - Reorder `mcpls-core` `Cargo.toml` dependencies into alphabetical order (#364)
-- **`ToolKind`/`NoServerReason`** — Breaking change: both marked `#[non_exhaustive]`; `ToolKind::ALL` is now `&[ToolKind]` instead of a fixed-size array. (#310)
-- **`WorkspaceConfig::get_language_for_extension`** — Breaking change: renamed to `language_for_extension`. (#305)
+- **`ToolKind`/`NoServerReason`** — Breaking change: both marked `#[non_exhaustive]`; `ToolKind::ALL` is now `&[ToolKind]` instead of a fixed-size array. (#366)
+- **`WorkspaceConfig::get_language_for_extension`** — Breaking change: renamed to `language_for_extension`. (#366)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`DocumentTracker::update`** — Breaking change: now `async`, serializing against `ensure_open` for the same path. (#363)
 - Bump rmcp from 3.1.4 to 3.2.0; an `initialize` request naming `protocolVersion: 2026-07-28` now receives the server's negotiated legacy version in response instead of an echo of the requested version (rmcp behavior change) (#364)
 - Reorder `mcpls-core` `Cargo.toml` dependencies into alphabetical order (#364)
+- **`ToolKind`/`NoServerReason`** — Breaking change: both marked `#[non_exhaustive]`; `ToolKind::ALL` is now `&[ToolKind]` instead of a fixed-size array. (#310)
+- **`WorkspaceConfig::get_language_for_extension`** — Breaking change: renamed to `language_for_extension`. (#305)
 
 ### Fixed
 

--- a/crates/mcpls-core/src/config/mod.rs
+++ b/crates/mcpls-core/src/config/mod.rs
@@ -230,7 +230,7 @@ impl WorkspaceConfig {
         map
     }
 
-    /// Get the language ID for a file extension.
+    /// Returns the language ID for a file extension.
     ///
     /// # Arguments
     ///
@@ -240,7 +240,7 @@ impl WorkspaceConfig {
     ///
     /// The language ID if found, `None` otherwise.
     #[must_use]
-    pub fn get_language_for_extension(&self, extension: &str) -> Option<String> {
+    pub fn language_for_extension(&self, extension: &str) -> Option<String> {
         for mapping in &self.language_extensions {
             if mapping.extensions.contains(&extension.to_string()) {
                 return Some(mapping.language_id.clone());
@@ -1897,7 +1897,7 @@ mod tests {
     }
 
     #[test]
-    fn test_get_language_for_extension() {
+    fn test_language_for_extension() {
         let workspace = WorkspaceConfig {
             roots: vec![],
             position_encodings: vec![],
@@ -1917,18 +1917,18 @@ mod tests {
         };
 
         assert_eq!(
-            workspace.get_language_for_extension("hpp"),
+            workspace.language_for_extension("hpp"),
             Some("cpp".to_string())
         );
         assert_eq!(
-            workspace.get_language_for_extension("hh"),
+            workspace.language_for_extension("hh"),
             Some("cpp".to_string())
         );
         assert_eq!(
-            workspace.get_language_for_extension("py"),
+            workspace.language_for_extension("py"),
             Some("python".to_string())
         );
-        assert_eq!(workspace.get_language_for_extension("unknown"), None);
+        assert_eq!(workspace.language_for_extension("unknown"), None);
     }
 
     #[test]
@@ -1937,15 +1937,15 @@ mod tests {
         let map = workspace.build_extension_map();
         assert!(!map.is_empty());
         assert_eq!(
-            workspace.get_language_for_extension("rs"),
+            workspace.language_for_extension("rs"),
             Some("rust".to_string())
         );
         assert_eq!(
-            workspace.get_language_for_extension("py"),
+            workspace.language_for_extension("py"),
             Some("python".to_string())
         );
         assert_eq!(
-            workspace.get_language_for_extension("cpp"),
+            workspace.language_for_extension("cpp"),
             Some("cpp".to_string())
         );
     }

--- a/crates/mcpls-core/src/config/routing.rs
+++ b/crates/mcpls-core/src/config/routing.rs
@@ -80,6 +80,7 @@ impl From<&str> for ServerId {
 /// ```
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
+#[non_exhaustive]
 pub enum ToolKind {
     /// `textDocument/hover`.
     Hover,
@@ -116,7 +117,7 @@ pub enum ToolKind {
 impl ToolKind {
     /// Every routable tool, in a fixed order. Used to compute the §5
     /// coverage warning and to build error messages that enumerate tools.
-    pub const ALL: [Self; 15] = [
+    pub const ALL: &[Self] = &[
         Self::Hover,
         Self::Definition,
         Self::TypeDefinition,
@@ -198,6 +199,7 @@ struct LanguageRoutes {
 /// Why [`ToolRouter::resolve_any`] could not find a server for a
 /// workspace-wide tool.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum NoServerReason {
     /// No server is registered in this workspace at all. Reflects what has
     /// *registered* (i.e. finished spawning), not what is configured in
@@ -771,6 +773,13 @@ mod tests {
         assert_eq!(ToolKind::Hover.as_str(), "hover");
         assert_eq!(ToolKind::CallHierarchy.as_str(), "call_hierarchy");
         assert_eq!(ToolKind::ALL.len(), 15);
+
+        // `ALL` is a slice now, so nothing pins its element count at compile
+        // time the way `[Self; 15]` used to -- guard against duplicate or
+        // missing entries at runtime instead.
+        let unique_names: std::collections::HashSet<&str> =
+            ToolKind::ALL.iter().map(ToolKind::as_str).collect();
+        assert_eq!(unique_names.len(), ToolKind::ALL.len());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Mark `ToolKind` and `NoServerReason` `#[non_exhaustive]` so a future tool addition stays a semver-minor bump for downstream exhaustive matchers instead of a de facto major break; change `ToolKind::ALL` from `[Self; 15]` to `&'static [Self]` since the fixed array length broke on growth the same way.
- Rename `WorkspaceConfig::get_language_for_extension` to `language_for_extension` (pure lookup, no side effects — `get_` is reserved for getter/setter pairs or disambiguation per the Rust API Guidelines).
- Added a runtime dedup/coverage assertion for `ToolKind::ALL` since the slice no longer pins the element count at compile time.

Both are pre-1.0 breaking changes per project convention (no deprecation shims before v1.0.0).

Closes #310
Closes #305

## Test plan
- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features --workspace -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --lib --bins` (729 passed, 1 skipped)
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`
- [x] `cargo test --doc`