### PR TITLE
refactor(mcp): type-safe position params, drop unused re-exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Reorder `mcpls-core` `Cargo.toml` dependencies into alphabetical order (#364)
 - **`ToolKind`/`NoServerReason`** — Breaking change: both marked `#[non_exhaustive]`; `ToolKind::ALL` is now `&[ToolKind]` instead of a fixed-size array. (#366)
 - **`WorkspaceConfig::get_language_for_extension`** — Breaking change: renamed to `language_for_extension`. (#366)
+- **`Translator::handle_*` position-based methods** — Breaking change: now take a `Position { line, character }` struct instead of two adjacent bare `u32` arguments, so a call site can no longer swap `line`/`character` without a compile error. (#367)
+
+### Removed
+
+- **`mcpls_core::mcp::{PositionParams, RangeParams, ReferencesParams, RenameParams, CompletionsParams, DocumentSymbolsParams, FormatDocumentParams, WorkspaceSymbolParams, CallHierarchyCallsParams, DiagnosticsParams}`** — Breaking change: `mcp::mod`'s `pub use tools::{...}` re-export block is removed entirely. This includes `PositionParams`, which a previous entry in this changelog (#302) told embedders to use directly after the position-only wrapper structs were collapsed into it — that guidance no longer applies. No in-tree caller ever named any of these types through `mcp::mod` (every tool handler in `server.rs` extracts them via `Parameters<T>` from `mcp::tools` directly), and MCP tool arguments are ordinary JSON matching each tool's published schema, not a Rust type a caller needs to name. No deprecation shim, per pre-1.0 policy. (#367)
 
 ### Fixed
 

--- a/crates/mcpls-core/src/bridge/mod.rs
+++ b/crates/mcpls-core/src/bridge/mod.rs
@@ -25,7 +25,8 @@ pub(crate) use translator::validate_path_against_roots;
 pub use translator::{
     Completion, CompletionsResult, DefinitionResult, Diagnostic, DiagnosticSeverity,
     DiagnosticsResult, DocumentChanges, DocumentSymbolsResult, FormatDocumentResult, HoverResult,
-    Location, Position2D, Range, ReferencesResult, RenameResult, Symbol, TextEdit, Translator,
+    Location, Position, Position2D, Range, ReferencesResult, RenameResult, Symbol, TextEdit,
+    Translator,
 };
 
 /// Lock a `std::sync::Mutex`, recovering the guard if a previous holder

--- a/crates/mcpls-core/src/bridge/translator/assist.rs
+++ b/crates/mcpls-core/src/bridge/translator/assist.rs
@@ -8,7 +8,7 @@ use lsp_types::{
 
 use super::Translator;
 use super::dto::{
-    Completion, CompletionsResult, InlayHintEntry, InlayHintsResult, SignatureHelpResult,
+    Completion, CompletionsResult, InlayHintEntry, InlayHintsResult, Position, SignatureHelpResult,
     SignatureInfo, SignatureParameter,
 };
 use crate::config::ToolKind;
@@ -58,10 +58,10 @@ impl Translator {
     pub async fn handle_completions(
         &self,
         file_path: String,
-        line: u32,
-        character: u32,
+        position: Position,
         trigger: Option<String>,
     ) -> Result<CompletionsResult> {
+        let Position { line, character } = position;
         validate_completions_params(trigger.as_deref())?;
 
         let (server_id, client, uri) = self
@@ -136,9 +136,9 @@ impl Translator {
     pub async fn handle_signature_help(
         &self,
         file_path: String,
-        line: u32,
-        character: u32,
+        position: Position,
     ) -> Result<SignatureHelpResult> {
+        let Position { line, character } = position;
         let (server_id, client, uri) = self
             .prepare_gated_document(
                 &file_path,
@@ -218,10 +218,8 @@ impl Translator {
     pub async fn handle_inlay_hints(
         &self,
         file_path: String,
-        start_line: u32,
-        start_character: u32,
-        end_line: u32,
-        end_character: u32,
+        start: Position,
+        end: Position,
     ) -> Result<InlayHintsResult> {
         let (server_id, client, uri) = self
             .prepare_gated_document(
@@ -239,8 +237,8 @@ impl Translator {
         let ctx = self.encoding_ctx(&server_id);
         let response_uri = uri.clone();
 
-        let lsp_start = ctx.to_lsp(&uri, start_line, start_character).await;
-        let lsp_end = ctx.to_lsp(&uri, end_line, end_character).await;
+        let lsp_start = ctx.to_lsp(&uri, start.line, start.character).await;
+        let lsp_end = ctx.to_lsp(&uri, end.line, end.character).await;
 
         let params = InlayHintParams {
             text_document: TextDocumentIdentifier { uri },

--- a/crates/mcpls-core/src/bridge/translator/call_hierarchy.rs
+++ b/crates/mcpls-core/src/bridge/translator/call_hierarchy.rs
@@ -10,7 +10,7 @@ use lsp_types::{
 use super::Translator;
 use super::dto::{
     CallHierarchyItemResult, CallHierarchyPrepareResult, IncomingCall, IncomingCallsResult,
-    OutgoingCall, OutgoingCallsResult,
+    OutgoingCall, OutgoingCallsResult, Position,
 };
 use super::encoding_ctx::EncodingCtx;
 use super::routing::MAX_POSITION_VALUE;
@@ -117,9 +117,9 @@ impl Translator {
     pub async fn handle_call_hierarchy_prepare(
         &self,
         file_path: String,
-        line: u32,
-        character: u32,
+        position: Position,
     ) -> Result<CallHierarchyPrepareResult> {
+        let Position { line, character } = position;
         // Validate position bounds
         if line < 1 || character < 1 {
             return Err(Error::InvalidToolParams(
@@ -319,7 +319,7 @@ mod tests {
     use url::Url;
 
     use super::*;
-    use crate::bridge::translator::dto::{Position2D, Range};
+    use crate::bridge::translator::dto::{Position, Position2D, Range};
     use crate::bridge::translator::testing::*;
     use crate::config::ServerId;
 
@@ -327,12 +327,24 @@ mod tests {
     async fn test_handle_call_hierarchy_prepare_invalid_position_zero() {
         let translator = Translator::new();
         let result = translator
-            .handle_call_hierarchy_prepare("/tmp/test.rs".to_string(), 0, 1)
+            .handle_call_hierarchy_prepare(
+                "/tmp/test.rs".to_string(),
+                Position {
+                    line: 0,
+                    character: 1,
+                },
+            )
             .await;
         assert!(matches!(result, Err(Error::InvalidToolParams(_))));
 
         let result = translator
-            .handle_call_hierarchy_prepare("/tmp/test.rs".to_string(), 1, 0)
+            .handle_call_hierarchy_prepare(
+                "/tmp/test.rs".to_string(),
+                Position {
+                    line: 1,
+                    character: 0,
+                },
+            )
             .await;
         assert!(matches!(result, Err(Error::InvalidToolParams(_))));
     }
@@ -341,12 +353,24 @@ mod tests {
     async fn test_handle_call_hierarchy_prepare_invalid_position_too_large() {
         let translator = Translator::new();
         let result = translator
-            .handle_call_hierarchy_prepare("/tmp/test.rs".to_string(), 1_000_001, 1)
+            .handle_call_hierarchy_prepare(
+                "/tmp/test.rs".to_string(),
+                Position {
+                    line: 1_000_001,
+                    character: 1,
+                },
+            )
             .await;
         assert!(matches!(result, Err(Error::InvalidToolParams(_))));
 
         let result = translator
-            .handle_call_hierarchy_prepare("/tmp/test.rs".to_string(), 1, 1_000_001)
+            .handle_call_hierarchy_prepare(
+                "/tmp/test.rs".to_string(),
+                Position {
+                    line: 1,
+                    character: 1_000_001,
+                },
+            )
             .await;
         assert!(matches!(result, Err(Error::InvalidToolParams(_))));
     }

--- a/crates/mcpls-core/src/bridge/translator/dto.rs
+++ b/crates/mcpls-core/src/bridge/translator/dto.rs
@@ -12,6 +12,22 @@ pub struct Position2D {
     pub character: u32,
 }
 
+/// A 1-based MCP position taken as input by `Translator::handle_*` methods.
+///
+/// Kept distinct from [`Position2D`] (which carries an *output* position back
+/// to the caller) so passing a position into a handler always goes through a
+/// named-field struct literal (`Position { line, character }`) instead of two
+/// adjacent bare `u32` arguments -- a call site that swaps `line` and
+/// `character` no longer compiles instead of silently sending a wrong
+/// position to the LSP server (#322).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Position {
+    /// Line number (1-based).
+    pub line: u32,
+    /// Character offset (1-based).
+    pub character: u32,
+}
+
 /// Range in a document (1-based for MCP).
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Range {

--- a/crates/mcpls-core/src/bridge/translator/edits.rs
+++ b/crates/mcpls-core/src/bridge/translator/edits.rs
@@ -10,7 +10,7 @@ use super::Translator;
 use super::diagnostics::diagnostic_to_mcp;
 use super::dto::{
     CodeAction, CodeActionsResult, CommandDescription, DocumentChanges, FormatDocumentResult,
-    RenameResult, TextEdit, WorkspaceEditDescription,
+    Position, RenameResult, TextEdit, WorkspaceEditDescription,
 };
 use super::encoding_ctx::EncodingCtx;
 use super::routing::{MAX_POSITION_VALUE, MAX_RANGE_LINES};
@@ -20,10 +20,8 @@ use crate::error::{Error, Result};
 /// Convert LSP range to MCP range (0-based to 1-based).
 /// Validate parameters for `handle_code_actions`.
 fn validate_code_action_params(
-    start_line: u32,
-    start_character: u32,
-    end_line: u32,
-    end_character: u32,
+    start: Position,
+    end: Position,
     kind_filter: Option<&str>,
 ) -> Result<()> {
     const VALID_ACTION_KINDS: &[&str] = &[
@@ -35,6 +33,15 @@ fn validate_code_action_params(
         "source",
         "source.organizeImports",
     ];
+
+    let Position {
+        line: start_line,
+        character: start_character,
+    } = start;
+    let Position {
+        line: end_line,
+        character: end_character,
+    } = end;
 
     if let Some(kind) = kind_filter
         && !VALID_ACTION_KINDS
@@ -173,10 +180,10 @@ impl Translator {
     pub async fn handle_rename(
         &self,
         file_path: String,
-        line: u32,
-        character: u32,
+        position: Position,
         new_name: String,
     ) -> Result<RenameResult> {
+        let Position { line, character } = position;
         validate_rename_params(&new_name)?;
 
         let (server_id, client, uri) = self
@@ -333,19 +340,11 @@ impl Translator {
     pub async fn handle_code_actions(
         &self,
         file_path: String,
-        start_line: u32,
-        start_character: u32,
-        end_line: u32,
-        end_character: u32,
+        start: Position,
+        end: Position,
         kind_filter: Option<String>,
     ) -> Result<CodeActionsResult> {
-        validate_code_action_params(
-            start_line,
-            start_character,
-            end_line,
-            end_character,
-            kind_filter.as_deref(),
-        )?;
+        validate_code_action_params(start, end, kind_filter.as_deref())?;
 
         let (server_id, client, uri) = self
             .prepare_gated_document(
@@ -367,8 +366,8 @@ impl Translator {
         let response_uri = uri.clone();
 
         let range = lsp_types::Range {
-            start: ctx.to_lsp(&uri, start_line, start_character).await,
-            end: ctx.to_lsp(&uri, end_line, end_character).await,
+            start: ctx.to_lsp(&uri, start.line, start.character).await,
+            end: ctx.to_lsp(&uri, end.line, end.character).await,
         };
 
         // Build context with optional kind filter
@@ -469,10 +468,14 @@ mod tests {
         let result = translator
             .handle_code_actions(
                 "/tmp/test.rs".to_string(),
-                1,
-                1,
-                1,
-                10,
+                Position {
+                    line: 1,
+                    character: 1,
+                },
+                Position {
+                    line: 1,
+                    character: 10,
+                },
                 Some("invalid_kind".to_string()),
             )
             .await;
@@ -491,10 +494,14 @@ mod tests {
         let result = translator
             .handle_code_actions(
                 test_file.to_str().unwrap().to_string(),
-                1,
-                1,
-                1,
-                10,
+                Position {
+                    line: 1,
+                    character: 1,
+                },
+                Position {
+                    line: 1,
+                    character: 10,
+                },
                 Some("quickfix".to_string()),
             )
             .await;
@@ -515,10 +522,14 @@ mod tests {
         let result = translator
             .handle_code_actions(
                 test_file.to_str().unwrap().to_string(),
-                1,
-                1,
-                1,
-                10,
+                Position {
+                    line: 1,
+                    character: 1,
+                },
+                Position {
+                    line: 1,
+                    character: 10,
+                },
                 Some("refactor".to_string()),
             )
             .await;
@@ -538,10 +549,14 @@ mod tests {
         let result = translator
             .handle_code_actions(
                 test_file.to_str().unwrap().to_string(),
-                1,
-                1,
-                1,
-                10,
+                Position {
+                    line: 1,
+                    character: 1,
+                },
+                Position {
+                    line: 1,
+                    character: 10,
+                },
                 Some("refactor.extract".to_string()),
             )
             .await;
@@ -561,10 +576,14 @@ mod tests {
         let result = translator
             .handle_code_actions(
                 test_file.to_str().unwrap().to_string(),
-                1,
-                1,
-                1,
-                10,
+                Position {
+                    line: 1,
+                    character: 1,
+                },
+                Position {
+                    line: 1,
+                    character: 10,
+                },
                 Some("source.organizeImports".to_string()),
             )
             .await;
@@ -576,7 +595,18 @@ mod tests {
     async fn test_handle_code_actions_invalid_range_zero() {
         let translator = Translator::new();
         let result = translator
-            .handle_code_actions("/tmp/test.rs".to_string(), 0, 1, 1, 10, None)
+            .handle_code_actions(
+                "/tmp/test.rs".to_string(),
+                Position {
+                    line: 0,
+                    character: 1,
+                },
+                Position {
+                    line: 1,
+                    character: 10,
+                },
+                None,
+            )
             .await;
         assert!(matches!(result, Err(Error::InvalidToolParams(_))));
     }
@@ -585,7 +615,18 @@ mod tests {
     async fn test_handle_code_actions_invalid_range_order() {
         let translator = Translator::new();
         let result = translator
-            .handle_code_actions("/tmp/test.rs".to_string(), 10, 5, 5, 1, None)
+            .handle_code_actions(
+                "/tmp/test.rs".to_string(),
+                Position {
+                    line: 10,
+                    character: 5,
+                },
+                Position {
+                    line: 5,
+                    character: 1,
+                },
+                None,
+            )
             .await;
         assert!(matches!(result, Err(Error::InvalidToolParams(_))));
     }
@@ -601,7 +642,18 @@ mod tests {
 
         // Empty range (same position) should be valid
         let result = translator
-            .handle_code_actions(test_file.to_str().unwrap().to_string(), 1, 5, 1, 5, None)
+            .handle_code_actions(
+                test_file.to_str().unwrap().to_string(),
+                Position {
+                    line: 1,
+                    character: 5,
+                },
+                Position {
+                    line: 1,
+                    character: 5,
+                },
+                None,
+            )
             .await;
         // Will fail due to no LSP server, but validates range is accepted
         assert!(result.is_err());

--- a/crates/mcpls-core/src/bridge/translator/navigation.rs
+++ b/crates/mcpls-core/src/bridge/translator/navigation.rs
@@ -8,7 +8,9 @@ use lsp_types::{
 };
 
 use super::Translator;
-use super::dto::{DefinitionResult, HoverResult, Location, LocationsResult, ReferencesResult};
+use super::dto::{
+    DefinitionResult, HoverResult, Location, LocationsResult, Position, ReferencesResult,
+};
 use super::encoding_ctx::EncodingCtx;
 use crate::config::ToolKind;
 use crate::error::Result;
@@ -68,12 +70,8 @@ impl Translator {
     ///
     /// Returns an error if the LSP request fails, the file cannot be opened,
     /// or the routed server does not advertise `hoverProvider` support.
-    pub async fn handle_hover(
-        &self,
-        file_path: String,
-        line: u32,
-        character: u32,
-    ) -> Result<HoverResult> {
+    pub async fn handle_hover(&self, file_path: String, position: Position) -> Result<HoverResult> {
+        let Position { line, character } = position;
         let (server_id, client, uri) = self
             .prepare_gated_document(&file_path, ToolKind::Hover, "hoverProvider", |caps| {
                 matches!(
@@ -128,9 +126,9 @@ impl Translator {
     pub async fn handle_definition(
         &self,
         file_path: String,
-        line: u32,
-        character: u32,
+        position: Position,
     ) -> Result<DefinitionResult> {
+        let Position { line, character } = position;
         let (server_id, client, uri) = self
             .prepare_gated_document(
                 &file_path,
@@ -176,10 +174,10 @@ impl Translator {
     pub async fn handle_references(
         &self,
         file_path: String,
-        line: u32,
-        character: u32,
+        position: Position,
         include_declaration: bool,
     ) -> Result<ReferencesResult> {
+        let Position { line, character } = position;
         let (server_id, client, uri) = self
             .prepare_gated_document(
                 &file_path,
@@ -239,9 +237,9 @@ impl Translator {
     pub async fn handle_implementation(
         &self,
         file_path: String,
-        line: u32,
-        character: u32,
+        position: Position,
     ) -> Result<LocationsResult> {
+        let Position { line, character } = position;
         let (server_id, client, uri) = self
             .prepare_gated_document(
                 &file_path,
@@ -295,9 +293,9 @@ impl Translator {
     pub async fn handle_type_definition(
         &self,
         file_path: String,
-        line: u32,
-        character: u32,
+        position: Position,
     ) -> Result<LocationsResult> {
+        let Position { line, character } = position;
         let (server_id, client, uri) = self
             .prepare_gated_document(
                 &file_path,

--- a/crates/mcpls-core/src/bridge/translator/routing.rs
+++ b/crates/mcpls-core/src/bridge/translator/routing.rs
@@ -355,6 +355,7 @@ mod tests {
     use super::*;
     use crate::bridge::NotificationCache;
     use crate::bridge::translator::assist::MAX_TRIGGER_CHARACTER_BYTES;
+    use crate::bridge::translator::dto::Position;
     use crate::bridge::translator::edits::MAX_NEW_NAME_LENGTH;
     use crate::bridge::translator::testing::*;
     use crate::config::{LspServerConfig, ToolRouter};
@@ -739,7 +740,17 @@ mod tests {
         let slow = {
             let translator = Arc::clone(&translator);
             let path = path_a.to_string_lossy().to_string();
-            tokio::spawn(async move { translator.handle_hover(path, 1, 1).await })
+            tokio::spawn(async move {
+                translator
+                    .handle_hover(
+                        path,
+                        Position {
+                            line: 1,
+                            character: 1,
+                        },
+                    )
+                    .await
+            })
         };
 
         // Wait for the slow task to actually reach its LSP request (i.e. the
@@ -755,7 +766,17 @@ mod tests {
         let fast = {
             let translator = Arc::clone(&translator);
             let path = path_b.to_string_lossy().to_string();
-            tokio::spawn(async move { translator.handle_hover(path, 1, 1).await })
+            tokio::spawn(async move {
+                translator
+                    .handle_hover(
+                        path,
+                        Position {
+                            line: 1,
+                            character: 1,
+                        },
+                    )
+                    .await
+            })
         };
 
         let mut wire_b = BufReader::new(&mut server_b.write_stdout);
@@ -816,7 +837,17 @@ mod tests {
             .map(|_| {
                 let translator = Arc::clone(&translator);
                 let path_str = path_str.clone();
-                tokio::spawn(async move { translator.handle_hover(path_str, 1, 1).await })
+                tokio::spawn(async move {
+                    translator
+                        .handle_hover(
+                            path_str,
+                            Position {
+                                line: 1,
+                                character: 1,
+                            },
+                        )
+                        .await
+                })
             })
             .collect();
 
@@ -903,7 +934,7 @@ mod tests {
         // rename is claimed by neither server -> NoServerForTool, checked
         // first so it can't be masked by either server's wire state.
         let rename_result = translator
-            .handle_rename(path_str.clone(), 1, 1, "renamed".to_string())
+            .handle_rename(path_str.clone(), pos(1, 1), "renamed".to_string())
             .await;
         assert!(
             matches!(
@@ -920,7 +951,7 @@ mod tests {
         let hover = {
             let translator = Arc::clone(&translator);
             let path_str = path_str.clone();
-            tokio::spawn(async move { translator.handle_hover(path_str, 1, 1).await })
+            tokio::spawn(async move { translator.handle_hover(path_str, pos(1, 1)).await })
         };
         let mut wire_pyright = BufReader::new(&mut server_pyright.write_stdout);
         let opened = read_framed_message(&mut wire_pyright).await;
@@ -1020,7 +1051,14 @@ mod tests {
         let new_name = "a".repeat(MAX_NEW_NAME_LENGTH + 1);
 
         let result = translator
-            .handle_rename("/main.rs".to_string(), 1, 1, new_name)
+            .handle_rename(
+                "/main.rs".to_string(),
+                Position {
+                    line: 1,
+                    character: 1,
+                },
+                new_name,
+            )
             .await;
 
         assert!(matches!(result, Err(Error::InvalidToolParams(_))));
@@ -1042,8 +1080,10 @@ mod tests {
         let result = translator
             .handle_rename(
                 path.to_string_lossy().to_string(),
-                1,
-                1,
+                Position {
+                    line: 1,
+                    character: 1,
+                },
                 "renamed".to_string(),
             )
             .await;
@@ -1071,7 +1111,18 @@ mod tests {
         fs::write(&path, "fn main() {}").unwrap();
 
         let result = translator
-            .handle_code_actions(path.to_string_lossy().to_string(), 1, 1, 1, 5, None)
+            .handle_code_actions(
+                path.to_string_lossy().to_string(),
+                Position {
+                    line: 1,
+                    character: 1,
+                },
+                Position {
+                    line: 1,
+                    character: 5,
+                },
+                None,
+            )
             .await;
 
         assert!(matches!(
@@ -1097,7 +1148,13 @@ mod tests {
         fs::write(&path, "fn main() {}").unwrap();
 
         let result = translator
-            .handle_signature_help(path.to_string_lossy().to_string(), 1, 1)
+            .handle_signature_help(
+                path.to_string_lossy().to_string(),
+                Position {
+                    line: 1,
+                    character: 1,
+                },
+            )
             .await;
 
         assert!(matches!(
@@ -1230,7 +1287,13 @@ mod tests {
         fs::write(&path, "fn main() {}").unwrap();
 
         let result = translator
-            .handle_call_hierarchy_prepare(path.to_string_lossy().to_string(), 1, 1)
+            .handle_call_hierarchy_prepare(
+                path.to_string_lossy().to_string(),
+                Position {
+                    line: 1,
+                    character: 1,
+                },
+            )
             .await;
 
         assert!(matches!(
@@ -1256,7 +1319,17 @@ mod tests {
         fs::write(&path, "fn main() {}").unwrap();
 
         let result = translator
-            .handle_inlay_hints(path.to_string_lossy().to_string(), 1, 1, 10, 1)
+            .handle_inlay_hints(
+                path.to_string_lossy().to_string(),
+                Position {
+                    line: 1,
+                    character: 1,
+                },
+                Position {
+                    line: 10,
+                    character: 1,
+                },
+            )
             .await;
 
         assert!(matches!(
@@ -1282,7 +1355,13 @@ mod tests {
         fs::write(&path, "fn main() {}").unwrap();
 
         let result = translator
-            .handle_hover(path.to_string_lossy().to_string(), 1, 1)
+            .handle_hover(
+                path.to_string_lossy().to_string(),
+                Position {
+                    line: 1,
+                    character: 1,
+                },
+            )
             .await;
 
         assert!(matches!(
@@ -1308,7 +1387,13 @@ mod tests {
         fs::write(&path, "fn main() {}").unwrap();
 
         let result = translator
-            .handle_definition(path.to_string_lossy().to_string(), 1, 1)
+            .handle_definition(
+                path.to_string_lossy().to_string(),
+                Position {
+                    line: 1,
+                    character: 1,
+                },
+            )
             .await;
 
         assert!(matches!(
@@ -1334,7 +1419,14 @@ mod tests {
         fs::write(&path, "fn main() {}").unwrap();
 
         let result = translator
-            .handle_references(path.to_string_lossy().to_string(), 1, 1, false)
+            .handle_references(
+                path.to_string_lossy().to_string(),
+                Position {
+                    line: 1,
+                    character: 1,
+                },
+                false,
+            )
             .await;
 
         assert!(matches!(
@@ -1354,7 +1446,14 @@ mod tests {
         let trigger = "a".repeat(MAX_TRIGGER_CHARACTER_BYTES + 1);
 
         let result = translator
-            .handle_completions("/main.rs".to_string(), 1, 1, Some(trigger))
+            .handle_completions(
+                "/main.rs".to_string(),
+                Position {
+                    line: 1,
+                    character: 1,
+                },
+                Some(trigger),
+            )
             .await;
 
         assert!(matches!(result, Err(Error::InvalidToolParams(_))));
@@ -1374,7 +1473,14 @@ mod tests {
         fs::write(&path, "fn main() {}").unwrap();
 
         let result = translator
-            .handle_completions(path.to_string_lossy().to_string(), 1, 1, None)
+            .handle_completions(
+                path.to_string_lossy().to_string(),
+                Position {
+                    line: 1,
+                    character: 1,
+                },
+                None,
+            )
             .await;
 
         assert!(matches!(
@@ -1449,7 +1555,13 @@ mod tests {
         fs::write(&path, "fn main() {}").unwrap();
 
         let result = translator
-            .handle_implementation(path.to_string_lossy().to_string(), 1, 1)
+            .handle_implementation(
+                path.to_string_lossy().to_string(),
+                Position {
+                    line: 1,
+                    character: 1,
+                },
+            )
             .await;
 
         assert!(matches!(
@@ -1475,7 +1587,13 @@ mod tests {
         fs::write(&path, "fn main() {}").unwrap();
 
         let result = translator
-            .handle_type_definition(path.to_string_lossy().to_string(), 1, 1)
+            .handle_type_definition(
+                path.to_string_lossy().to_string(),
+                Position {
+                    line: 1,
+                    character: 1,
+                },
+            )
             .await;
 
         assert!(matches!(
@@ -1539,7 +1657,14 @@ mod tests {
             let translator = Arc::clone(&translator);
             tokio::spawn(async move {
                 translator
-                    .handle_rename(path_str, 1, 1, "renamed".to_string())
+                    .handle_rename(
+                        path_str,
+                        Position {
+                            line: 1,
+                            character: 1,
+                        },
+                        "renamed".to_string(),
+                    )
                     .await
             })
         };

--- a/crates/mcpls-core/src/bridge/translator/testing.rs
+++ b/crates/mcpls-core/src/bridge/translator/testing.rs
@@ -11,6 +11,7 @@ use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
 use tokio::process::{Child, ChildStdin, ChildStdout, Command};
 
 use super::Translator;
+use super::dto::Position;
 use super::encoding_ctx::EncodingCtx;
 use crate::bridge::encoding::PositionEncoding;
 use crate::bridge::state::ResourceLimits;
@@ -19,6 +20,11 @@ use crate::config::{LspServerConfig, ServerId, ToolRouter};
 use crate::lsp::{LspClient, LspServer, LspTransport};
 
 type JsonValue = serde_json::Value;
+
+/// Shorthand for building a [`Position`] test fixture.
+pub(super) const fn pos(line: u32, character: u32) -> Position {
+    Position { line, character }
+}
 
 /// A UTF-16 `EncodingCtx`, matching the pre-negotiation behavior: no
 /// disk reads, pure line/column offsetting.

--- a/crates/mcpls-core/src/mcp/mod.rs
+++ b/crates/mcpls-core/src/mcp/mod.rs
@@ -8,8 +8,12 @@ mod server;
 mod tools;
 
 pub use server::McplsServer;
-pub use tools::{
-    CallHierarchyCallsParams, CompletionsParams, DiagnosticsParams, DocumentSymbolsParams,
-    FormatDocumentParams, PositionParams, RangeParams, ReferencesParams, RenameParams,
-    WorkspaceSymbolParams,
-};
+
+// `mcp::tools`'s param structs (e.g. `PositionParams`, `ReferencesParams`)
+// are intentionally not re-exported here: every tool handler in `server.rs`
+// extracts them via `Parameters<T>` from `super::tools` directly, and no
+// in-tree caller ever names one through this module. A caller that needs to
+// construct MCP tool arguments should send JSON matching each tool's
+// published schema rather than depend on these internal Rust types -- don't
+// reintroduce a partial `pub use` list here without a documented reason (see
+// #320).

--- a/crates/mcpls-core/src/mcp/server.rs
+++ b/crates/mcpls-core/src/mcp/server.rs
@@ -26,8 +26,8 @@ use super::tools::{
 };
 use crate::bridge::resources::{make_uri, parse_uri};
 use crate::bridge::{
-    DiagnosticInfo, DiagnosticsResult, NotificationCache, PositionEncoding, ResourceSubscriptions,
-    Translator, validate_path_against_roots,
+    DiagnosticInfo, DiagnosticsResult, NotificationCache, Position, PositionEncoding,
+    ResourceSubscriptions, Translator, validate_path_against_roots,
 };
 use crate::config::McpConfig;
 
@@ -285,7 +285,7 @@ impl McplsServer {
         to_tool_result(
             self.context
                 .translator
-                .handle_hover(file_path, line, character)
+                .handle_hover(file_path, Position { line, character })
                 .await,
         )
     }
@@ -306,7 +306,7 @@ impl McplsServer {
         to_tool_result(
             self.context
                 .translator
-                .handle_definition(file_path, line, character)
+                .handle_definition(file_path, Position { line, character })
                 .await,
         )
     }
@@ -331,7 +331,7 @@ impl McplsServer {
         to_tool_result(
             self.context
                 .translator
-                .handle_references(file_path, line, character, include_declaration)
+                .handle_references(file_path, Position { line, character }, include_declaration)
                 .await,
         )
     }
@@ -378,7 +378,7 @@ impl McplsServer {
         to_tool_result(
             self.context
                 .translator
-                .handle_rename(file_path, line, character, new_name)
+                .handle_rename(file_path, Position { line, character }, new_name)
                 .await,
         )
     }
@@ -403,7 +403,7 @@ impl McplsServer {
         to_tool_result(
             self.context
                 .translator
-                .handle_completions(file_path, line, character, trigger)
+                .handle_completions(file_path, Position { line, character }, trigger)
                 .await,
         )
     }
@@ -495,10 +495,14 @@ impl McplsServer {
                 .translator
                 .handle_code_actions(
                     file_path,
-                    start_line,
-                    start_character,
-                    end_line,
-                    end_character,
+                    Position {
+                        line: start_line,
+                        character: start_character,
+                    },
+                    Position {
+                        line: end_line,
+                        character: end_character,
+                    },
                     kind_filter,
                 )
                 .await,
@@ -521,7 +525,7 @@ impl McplsServer {
         to_tool_result(
             self.context
                 .translator
-                .handle_call_hierarchy_prepare(file_path, line, character)
+                .handle_call_hierarchy_prepare(file_path, Position { line, character })
                 .await,
         )
     }
@@ -650,7 +654,7 @@ impl McplsServer {
         to_tool_result(
             self.context
                 .translator
-                .handle_signature_help(file_path, line, character)
+                .handle_signature_help(file_path, Position { line, character })
                 .await,
         )
     }
@@ -671,7 +675,7 @@ impl McplsServer {
         to_tool_result(
             self.context
                 .translator
-                .handle_implementation(file_path, line, character)
+                .handle_implementation(file_path, Position { line, character })
                 .await,
         )
     }
@@ -692,7 +696,7 @@ impl McplsServer {
         to_tool_result(
             self.context
                 .translator
-                .handle_type_definition(file_path, line, character)
+                .handle_type_definition(file_path, Position { line, character })
                 .await,
         )
     }
@@ -720,10 +724,14 @@ impl McplsServer {
                 .translator
                 .handle_inlay_hints(
                     file_path,
-                    start_line,
-                    start_character,
-                    end_line,
-                    end_character,
+                    Position {
+                        line: start_line,
+                        character: start_character,
+                    },
+                    Position {
+                        line: end_line,
+                        character: end_character,
+                    },
                 )
                 .await,
         )

--- a/crates/mcpls-core/tests/integration/rust_analyzer_tests.rs
+++ b/crates/mcpls-core/tests/integration/rust_analyzer_tests.rs
@@ -14,7 +14,7 @@ use std::path::Path;
 use std::sync::{Arc, Once};
 use std::time::{Duration, Instant};
 
-use mcpls_core::bridge::{NotificationCache, Translator};
+use mcpls_core::bridge::{NotificationCache, Position, Translator};
 use mcpls_core::config::{LspServerConfig, ServerId, ToolRouter};
 use mcpls_core::lsp::{LspServer, ServerInitConfig};
 use tokio::sync::Mutex;
@@ -119,7 +119,13 @@ async fn wait_for_indexing_ready(
         let hover_result = translator
             .lock()
             .await
-            .handle_hover(file_path.clone(), add_line, add_col)
+            .handle_hover(
+                file_path.clone(),
+                Position {
+                    line: add_line,
+                    character: add_col,
+                },
+            )
             .await;
 
         match hover_result {
@@ -164,8 +170,10 @@ async fn test_hover_on_std_vec() {
         Duration::from_secs(10),
         translator.lock().await.handle_hover(
             file_path.to_string_lossy().to_string(),
-            20,
-            19, // Position on "String"
+            Position {
+                line: 20,
+                character: 19, // Position on "String"
+            },
         ),
     )
     .await;
@@ -209,8 +217,10 @@ async fn test_hover_on_u64_type() {
         Duration::from_secs(10),
         translator.lock().await.handle_hover(
             file_path.to_string_lossy().to_string(),
-            19,
-            13, // Position on "u64"
+            Position {
+                line: 19,
+                character: 13, // Position on "u64"
+            },
         ),
     )
     .await;
@@ -250,8 +260,10 @@ async fn test_definition_user_struct() {
         Duration::from_secs(10),
         translator.lock().await.handle_definition(
             types_file.to_string_lossy().to_string(),
-            9,
-            16, // Position on "User"
+            Position {
+                line: 9,
+                character: 16, // Position on "User"
+            },
         ),
     )
     .await;
@@ -295,8 +307,10 @@ async fn test_definition_across_files() {
         Duration::from_secs(10),
         translator.lock().await.handle_definition(
             functions_file.to_string_lossy().to_string(),
-            3,
-            24, // Position on "Repository"
+            Position {
+                line: 3,
+                character: 24, // Position on "Repository"
+            },
         ),
     )
     .await;
@@ -336,8 +350,10 @@ async fn test_references_create_repo_function() {
         Duration::from_secs(10),
         translator.lock().await.handle_references(
             functions_file.to_string_lossy().to_string(),
-            7,
-            12,   // Position on "create_repo"
+            Position {
+                line: 7,
+                character: 12, // Position on "create_repo"
+            },
             true, // Include declaration
         ),
     )
@@ -380,8 +396,10 @@ async fn test_references_user_struct() {
         Duration::from_secs(10),
         translator.lock().await.handle_references(
             lib_file.to_string_lossy().to_string(),
-            18,
-            15, // Position on "User"
+            Position {
+                line: 18,
+                character: 15, // Position on "User"
+            },
             true,
         ),
     )
@@ -623,8 +641,10 @@ async fn test_completions_basic() {
         Duration::from_secs(10),
         translator.lock().await.handle_completions(
             functions_file.to_string_lossy().to_string(),
-            23,
-            11, // Position after "repo."
+            Position {
+                line: 23,
+                character: 11, // Position after "repo."
+            },
             None,
         ),
     )
@@ -705,10 +725,13 @@ async fn test_timeout_handling() {
     // Very short timeout to test timeout behavior
     let result = timeout(
         Duration::from_millis(1), // 1ms - should timeout
-        translator
-            .lock()
-            .await
-            .handle_hover(lib_file.to_string_lossy().to_string(), 20, 19),
+        translator.lock().await.handle_hover(
+            lib_file.to_string_lossy().to_string(),
+            Position {
+                line: 20,
+                character: 19,
+            },
+        ),
     )
     .await;
 
@@ -730,7 +753,13 @@ async fn test_invalid_file_path() {
     let result = translator
         .lock()
         .await
-        .handle_hover("/nonexistent/file.rs".to_string(), 1, 1)
+        .handle_hover(
+            "/nonexistent/file.rs".to_string(),
+            Position {
+                line: 1,
+                character: 1,
+            },
+        )
         .await;
 
     // Should return an error (file not found or not in workspace)
@@ -756,8 +785,10 @@ async fn test_out_of_bounds_position() {
         Duration::from_secs(10),
         translator.lock().await.handle_hover(
             lib_file.to_string_lossy().to_string(),
-            99999, // Way beyond file bounds
-            1,
+            Position {
+                line: 99999, // Way beyond file bounds
+                character: 1,
+            },
         ),
     )
     .await;


### PR DESCRIPTION
## Summary
- Introduce a `Position { line, character }` struct so `Translator::handle_*` position-based methods take it by name instead of two adjacent bare `u32` arguments — a swapped call site is now a compile-time error instead of a silent runtime bug.
- Remove the `mcp/mod.rs` `pub use tools::{...}` re-export block (13 of 21 param structs re-exported with no stated rule and no in-tree callers) and document the rule at the former re-export site: construct param structs via `Parameters<T>` extraction from `mcp::tools`.

Both changes are breaking for library embedders: `Translator::handle_*` signatures change shape, and `mcpls_core::mcp::PositionParams` (previously documented as embedder-facing guidance in the #302 changelog entry) and nine sibling param structs are no longer re-exported from `mcp::mod` — import them from `mcpls_core::mcp::tools` instead.

## Test plan
- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features --workspace -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --lib --bins` (729 passed)
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`
- [x] Verified generated rustdoc renders named parameters (no `__arg` leakage) on all 11 affected `Translator::handle_*` methods
- [x] Verified zero in-tree references to the removed `mcp::mod` re-exports

Closes #322
Closes #320