### PR TITLE
docs(specs): relocate and reorganize SDD spec package by functional block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Relocated the SDD spec package from `.local/specs/` to repo-root `specs/`, reorganized into functional blocks (config/lsp/mcp/bridge/runtime/testing) with block-scoped numbering, and added retroactive specs for previously undocumented core subsystems (position encoding, config discovery, LSP lifecycle, document tracker sync, MCP tool routing). (#PR_NUMBER)
 - **`DocumentTracker::update`** — Breaking change: now `async`, serializing against `ensure_open` for the same path. (#363)
 - Bump rmcp from 3.1.4 to 3.2.0; an `initialize` request naming `protocolVersion: 2026-07-28` now receives the server's negotiated legacy version in response instead of an echo of the requested version (rmcp behavior change) (#364)
 - Reorder `mcpls-core` `Cargo.toml` dependencies into alphabetical order (#364)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Relocated the SDD spec package from `.local/specs/` to repo-root `specs/`, reorganized into functional blocks (config/lsp/mcp/bridge/runtime/testing) with block-scoped numbering, and added retroactive specs for previously undocumented core subsystems (position encoding, config discovery, LSP lifecycle, document tracker sync, MCP tool routing). (#PR_NUMBER)
+- Relocated the SDD spec package from `.local/specs/` to repo-root `specs/`, reorganized into functional blocks (config/lsp/mcp/bridge/runtime/testing) with block-scoped numbering, and added retroactive specs for previously undocumented core subsystems (position encoding, config discovery, LSP lifecycle, document tracker sync, MCP tool routing). (#368)
 - **`DocumentTracker::update`** — Breaking change: now `async`, serializing against `ensure_open` for the same path. (#363)
 - Bump rmcp from 3.1.4 to 3.2.0; an `initialize` request naming `protocolVersion: 2026-07-28` now receives the server's negotiated legacy version in response instead of an echo of the requested version (rmcp behavior change) (#364)
 - Reorder `mcpls-core` `Cargo.toml` dependencies into alphabetical order (#364)

--- a/specs/MOC-specs.md
+++ b/specs/MOC-specs.md
@@ -1,0 +1,92 @@
+# Map of Content — Specs
+
+Specs are organized into blocks matching the crate's own module boundaries
+(`config/`, `lsp/`, `mcp/`, `bridge/` — see the crate layout in the project's `CLAUDE.md`), plus
+two cross-cutting blocks that don't belong to a single module: `runtime` (CLI argument parsing,
+process signal handling, transport-level shutdown — spans `mcpls-cli` and `mcpls-core`'s top-level
+`lib.rs`/`transport.rs`) and `testing` (test-infrastructure specs that exercise the whole stack
+rather than one subsystem). Numbering restarts at 001 within each block.
+
+## config
+
+| # | Slug | Type | Priority | Status | Issue |
+|---|------|------|----------|--------|-------|
+| 001 | [[config/001-config-discovery-and-heuristics/spec\|config-discovery-and-heuristics]] | enhancement | P1 | implemented (retroactive) | — |
+
+## lsp
+
+| # | Slug | Type | Priority | Status | Issue |
+|---|------|------|----------|--------|-------|
+| 001 | [[lsp/001-lsp-server-lifecycle-and-respawn/spec\|lsp-server-lifecycle-and-respawn]] | enhancement | P1 | implemented (retroactive) | — |
+| 002 | [[lsp/002-lsp317-missing-tools/spec\|lsp317-missing-tools]] | enhancement | P3 | draft (tools now implemented — see [[testing/001-e2e-rust-analyzer-testing/spec\|testing/001]]'s Resolution; this spec's own status is stale, see note below) | #116 |
+| 003 | [[lsp/003-lsp-types-unmaintained-migration/spec\|lsp-types-unmaintained-migration]] | research | P2 | draft | #297 |
+| 004 | [[lsp/004-lsp-318-draft-gaps/spec\|lsp-318-draft-gaps]] | research | P4 | draft | #299 (also #116; #290 resolved by #289/#291) |
+
+## mcp
+
+| # | Slug | Type | Priority | Status | Issue |
+|---|------|------|----------|--------|-------|
+| 001 | [[mcp/001-mcp-tool-surface-and-routing/spec\|mcp-tool-surface-and-routing]] | enhancement | P1 | implemented (retroactive) | — |
+| 002 | [[mcp/002-mcp-resources-diagnostics/spec\|mcp-resources-diagnostics]] | enhancement | P3 | draft | #115 |
+| 003 | [[mcp/003-mcp-2026-stateless-adoption/spec\|mcp-2026-stateless-adoption]] | research | P3 | draft | #298 |
+
+## bridge
+
+| # | Slug | Type | Priority | Status | Issue |
+|---|------|------|----------|--------|-------|
+| 001 | [[bridge/001-position-encoding-layer/spec\|position-encoding-layer]] | enhancement | P1 | implemented (retroactive) | — |
+| 002 | [[bridge/002-document-tracker-synchronization/spec\|document-tracker-synchronization]] | enhancement | P1 | implemented (retroactive) | — |
+| 003 | [[bridge/003-rwlock-translator/spec\|rwlock-translator]] | enhancement | P2 | draft | #114 |
+| 004 | [[bridge/004-get-diagnostics-flycheck-gap/spec\|get-diagnostics-flycheck-gap]] | bug | P1 | draft | — |
+| 005 | [[bridge/005-expose-document-tracker-limits/spec\|expose-document-tracker-limits]] | enhancement | P2 | implemented (#324) | — |
+
+## runtime
+
+Cross-cutting: `mcpls-cli` argument/env parsing and process-level signal/transport shutdown —
+neither belongs to a single `config`/`lsp`/`mcp`/`bridge` module.
+
+| # | Slug | Type | Priority | Status | Issue |
+|---|------|------|----------|--------|-------|
+| 001 | [[runtime/001-log-json-bool-env-parsing/spec\|log-json-bool-env-parsing]] | bug | P2 | implemented (#314) | — |
+| 002 | [[runtime/002-sigterm-stdin-blocking-pool-hang/spec\|sigterm-stdin-blocking-pool-hang]] | bug | P1 | implemented (#321, #328) | — |
+
+## testing
+
+Cross-cutting: test-infrastructure specs exercising the whole MCP→mcpls→LSP stack rather than one
+subsystem.
+
+| # | Slug | Type | Priority | Status | Issue |
+|---|------|------|----------|--------|-------|
+| 001 | [[testing/001-e2e-rust-analyzer-testing/spec\|e2e-rust-analyzer-testing]] | enhancement | P2 | implemented (#125, #126, #139, #225) | — |
+
+> [!note] Block assignment and numbering rationale
+> Every spec was reassigned to the block its subject matter is *most fundamentally about*, not
+> necessarily where its implementation happens to live in the crate tree. Two calls worth flagging:
+> - `mcp/001-mcp-tool-surface-and-routing` documents `ToolRouter`/`ToolKind`/`ServerId`, whose code
+>   physically lives in `crates/mcpls-core/src/config/routing.rs` (kept there deliberately to avoid
+>   a `config → mcp → bridge → config` dependency cycle, per that file's own module doc). The spec
+>   is filed under `mcp` because its subject — which MCP tool call reaches which server — is an
+>   MCP-facing concern; its `related:` frontmatter and prose cross-link `config/001` for the
+>   config-side data it's built from.
+> - `lsp/002-lsp317-missing-tools` is filed under `lsp` (not `mcp`, even though its deliverable is 4
+>   new MCP tools) because its own content frames it as LSP-protocol-capability parity tracking
+>   (comparing mcpls against LSP spec versions and reference projects), matching the placement of
+>   its direct sibling `lsp/004-lsp-318-draft-gaps`.
+>
+> Within each block, specs are ordered: any new retroactive foundational spec first (documents the
+> subsystem itself), then the original historical bug/enhancement specs in their original relative
+> order, then research/tracking specs last. `config` has only one spec today — a real reflection of
+> the `config/` module's spec coverage prior to this pass, not a placeholder.
+>
+> Numbers are **block-scoped**, not global: `bridge/001` and `lsp/001` are different, unrelated
+> specs. Always cite a spec with its block prefix (e.g. `bridge/001`, never bare `001`).
+
+> [!warning] Known staleness: lsp/002 (formerly 003) vs. shipped code
+> [[lsp/002-lsp317-missing-tools/spec|lsp/002]]'s own file still says `**Status**: draft`, but all
+> four tools it proposes (`get_signature_help`, `go_to_implementation`, `go_to_type_definition`,
+> `get_inlay_hints`) are already implemented in `crates/mcpls-core/src/mcp/server.rs` and exercised
+> by [[testing/001-e2e-rust-analyzer-testing/spec|testing/001]]'s e2e suite. This migration did not
+> rewrite lsp/002's content (out of scope for a migration/reorganization pass — see the migration
+> report), but a human reviewer should follow up with a proper Resolution callout identifying the
+> implementing PR(s), consistent with how `bridge/005`/`runtime/001`/`runtime/002` already document
+> their own resolutions.

--- a/specs/bridge/001-position-encoding-layer/spec.md
+++ b/specs/bridge/001-position-encoding-layer/spec.md
@@ -1,0 +1,207 @@
+---
+aliases:
+  - Position encoding layer
+  - MCP/LSP position conversion
+tags:
+  - sdd
+  - spec
+  - bridge
+  - encoding
+created: 2026-08-05
+status: implemented
+related:
+  - "[[constitution]]"
+  - "[[lsp/001-lsp-server-lifecycle-and-respawn/spec]]"
+  - "[[config/001-config-discovery-and-heuristics/spec]]"
+---
+
+# Feature: Position Encoding Conversion Between MCP and LSP
+
+> [!info] Metadata
+> **Author**: retroactive spec, authored during the `.local/specs/` → `specs/` migration and gap
+> analysis (no single originating commit/PR — this documents already-shipped, working
+> functionality accreted across multiple PRs)
+> **Type**: core subsystem (critical path)
+> **Priority**: P1 (retroactive — reflects the criticality of a subsystem every tool call depends
+> on, not an open defect)
+
+> [!success] Resolution
+> This is a retroactive spec: `crates/mcpls-core/src/bridge/encoding.rs` already implements
+> everything described below. There is no single originating PR to cite — the module has been
+> extended incrementally (negotiated-encoding support via PR #289/#291 referenced from
+> [[lsp/004-lsp-318-draft-gaps/spec|spec lsp/004]]'s Resolution callout, char-boundary panic fixes, astral
+> character / surrogate-pair edge cases) rather than designed once. Representative evidence: the
+> module's 20+ unit tests (`crates/mcpls-core/src/bridge/encoding.rs`, `mod tests`) cover UTF-8,
+> UTF-16, and UTF-32 round trips, ASCII-identical-across-encodings, out-of-bounds fallback,
+> mid-character-boundary rejection, astral (non-BMP) characters, and CRLF line-ending handling.
+
+## 1. Overview
+
+### Problem Statement
+
+MCP and LSP disagree on two axes for every position mcpls translates between a client and a
+language server:
+
+1. **Line/column base**: MCP positions are 1-based (line 1, character 1 is the start of a file);
+   LSP positions are 0-based.
+2. **Character unit**: LSP's `PositionEncodingKind` allows a server to negotiate UTF-8, UTF-16, or
+   UTF-32 code units for its `character` field (`initialize`'s
+   `capabilities.general.positionEncodings`, negotiated in
+   [[lsp/001-lsp-server-lifecycle-and-respawn/spec|spec lsp/001]]'s `LspServer::spawn`). MCP's own
+   character columns are always UTF-16 code units (the pre-negotiation, universally-supported
+   default). A server that negotiates UTF-8 or UTF-32 requires re-deriving the column from the
+   line's actual text, not a fixed arithmetic offset — a naive 1:1 column mapping silently
+   corrupts every position on a line containing any multi-byte character (accented letters,
+   CJK text, emoji, or any astral-plane code point).
+
+Getting this wrong is not a cosmetic bug: every navigation tool (hover, definition, references,
+rename, call hierarchy, diagnostics ranges) depends on exact position round-tripping. A one-column
+drift on a line with a preceding multi-byte character silently points at the wrong symbol, with no
+error raised — the request "succeeds" against the wrong location.
+
+### Goal
+
+Every MCP↔LSP position conversion (a) correctly maps MCP's 1-based/UTF-16 convention to and from
+LSP's 0-based/negotiated-encoding convention, for `Utf8`/`Utf16`/`Utf32`; (b) never panics on
+untrusted input (a server-reported byte offset that lands mid-character); and (c) degrades to a
+safe fallback (the raw, unconverted value) rather than silently producing a plausible-looking but
+wrong position when an exact conversion is not possible.
+
+### Out of Scope
+
+- Negotiating which encoding a server uses — that is `LspServer::spawn`'s responsibility
+  ([[lsp/001-lsp-server-lifecycle-and-respawn/spec|spec lsp/001]]); this spec covers only the conversion
+  math once an encoding is known.
+- Line-ending normalization — `line_text` is always sourced without its terminator (via
+  `str::lines()` or equivalent), so CRLF vs. LF is not this module's concern.
+- Range conversion orchestration (which end of a range needs which line's text) — that lives in
+  `bridge/translator/encoding_ctx.rs`, a consumer of this module, not part of it.
+
+## 2. User Stories
+
+### US-001: Hover/definition/rename land on the correct symbol on a non-ASCII line
+
+AS AN AI coding agent operating on a file containing non-ASCII characters (accented letters, CJK
+comments, emoji in string literals)
+I WANT every position-based tool call to resolve to the exact character the client meant, even
+when the negotiated LSP server encoding differs from MCP's UTF-16 convention
+SO THAT hover/definition/rename/etc. never silently target the wrong symbol on such a line
+
+**Acceptance criteria:**
+```
+GIVEN a line of text containing a multi-byte UTF-8 character before the target column
+  AND the LSP server has negotiated UTF-8 position encoding
+WHEN mcpls converts an MCP (1-based, UTF-16) position to an LSP (0-based, UTF-8) position
+THEN the resulting LSP character offset correctly points at the same character the MCP caller
+     specified, re-derived from the line's actual text rather than a fixed arithmetic offset
+```
+
+### US-002: A malformed or out-of-bounds position never crashes the process
+
+AS A mcpls operator
+I WANT a server-reported byte offset that lands mid-character, or a client-reported column past
+the end of a line, to be handled gracefully
+SO THAT a single malformed position cannot panic the process (`panic = "abort"` is configured
+project-wide, so a panic here would kill every in-flight request, not just one)
+
+**Acceptance criteria:**
+```
+GIVEN a byte offset that lands inside a multi-byte character (not on a UTF-8 char boundary)
+WHEN byte_offset_to_character/character_to_byte_offset is called with that offset
+THEN the function returns an Err, never panics
+
+GIVEN an MCP character column past the end of the target line's text
+WHEN mcp_to_lsp_position converts it
+THEN the raw (unconverted) value is used as a fallback rather than erroring the whole request
+```
+
+## 3. Functional Requirements
+
+| ID | Requirement | Priority |
+|----|------------|----------|
+| FR-001 | THE SYSTEM SHALL convert an MCP position (1-based line/character) to an LSP position (0-based) via `mcp_to_lsp_position`, and the inverse via `lsp_to_mcp_position` | must |
+| FR-002 | WHEN the negotiated encoding is `Utf16` THE SYSTEM SHALL perform a pure line/column offset with no `line_text` lookup — byte-for-byte identical to fixed-encoding (pre-negotiation) behavior, since MCP's own columns are already UTF-16 | must |
+| FR-003 | WHEN the negotiated encoding is `Utf8` or `Utf32` AND `line_text` is available THE SYSTEM SHALL re-derive the column in the target encoding's units from the line's actual text, not a fixed arithmetic offset | must |
+| FR-004 | WHEN `line_text` is unavailable (e.g. the file could not be read) THE SYSTEM SHALL fall back to the raw, unconverted MCP/LSP character rather than failing the request | must |
+| FR-005 | WHEN a re-derived character offset does not round-trip exactly (lands inside a multi-unit character, e.g. a UTF-16 surrogate pair or a multi-byte UTF-8 sequence) THE SYSTEM SHALL fall back to the raw value rather than silently rounding forward to the next character boundary | must |
+| FR-006 | WHEN `byte_offset_to_character`/`character_to_byte_offset` is given a byte offset that is not on a UTF-8 character boundary THE SYSTEM SHALL return an `Err`, never panic | must |
+| FR-007 | THE SYSTEM SHALL support parsing (`PositionEncoding::from_lsp`) and serializing (`PositionEncoding::to_lsp`) the three LSP-defined encoding kind strings: `"utf-8"`, `"utf-16"`, `"utf-32"` | must |
+| FR-008 | WHEN `line.saturating_sub(1)` or `character.saturating_sub(1)` would underflow (an MCP position of `0`) THE SYSTEM SHALL clamp to `0` rather than wrapping or panicking | must |
+
+## 4. Non-Functional Requirements
+
+| ID | Category | Requirement |
+|----|----------|-------------|
+| NFR-001 | Safety | No conversion path may panic on untrusted input (a server-reported or client-reported offset), consistent with the workspace's `panic = "abort"` configuration where a single panic kills the whole process, not just one request |
+| NFR-002 | Correctness | ASCII-only text must convert identically regardless of negotiated encoding (`Utf8`==`Utf16`==`Utf32` for pure-ASCII lines), since ASCII characters are exactly 1 byte/1 UTF-16 unit/1 code point in every encoding |
+| NFR-003 | Performance | Conversion for the common case (`Utf16`, the default and most-negotiated encoding per `config/mod.rs`'s `default_position_encodings` doc comment) must be O(1) — no `line_text` scan at all |
+| NFR-004 | Testability | Every fallback path (missing `line_text`, out-of-bounds, mid-character-boundary, astral/surrogate-pair) must have a dedicated regression test, since these are exactly the cases a naive implementation gets wrong silently |
+
+## 5. Data Model
+
+| Entity | Description | Key Attributes |
+|--------|-------------|-----------------|
+| `PositionEncoding` | The three LSP-negotiable character-counting conventions | `Utf8`, `Utf16` (default), `Utf32` |
+| `EncodingConverter` | Stateless converter bound to one `PositionEncoding`, converting between byte offsets and character offsets in a given line of text | `byte_offset_to_character(text, byte_offset) -> Result<u32, String>`, `character_to_byte_offset(text, character_offset) -> Result<usize, String>` |
+| MCP position | 1-based `(line, character)`, character always in UTF-16 units | `line: u32`, `character: u32` |
+| LSP `Position` (`lsp_types::Position`) | 0-based `(line, character)`, character in the negotiated encoding's units | `line: u32`, `character: u32` |
+
+## 6. Edge Cases and Error Handling
+
+| Scenario | Expected Behavior |
+|----------|--------------------|
+| Negotiated encoding is `Utf16` | Pure arithmetic offset; `line_text` never consulted even if supplied (locked in by `test_utf16_negotiated_ignores_line_text`) |
+| Negotiated encoding is `Utf8`/`Utf32`, ASCII-only line | All three encodings agree (`test_mcp_to_lsp_position_ascii_identical_across_encodings`) |
+| Negotiated encoding is `Utf8`, line contains a 2-byte character (e.g. `é`) before the target column | Column re-derived in bytes, one further than a naive UTF-16-based offset (`test_mcp_to_lsp_position_utf8_negotiated_multibyte`) |
+| Negotiated encoding is `Utf8`, line contains an astral character (e.g. `𝄞`, 4 UTF-8 bytes / 2 UTF-16 units) | Column correctly re-derived across the surrogate pair (`test_mcp_to_lsp_position_utf8_negotiated_astral_char`) |
+| MCP character offset lands mid-surrogate-pair (client miscounted an astral character) | Falls back to the raw offset rather than rounding forward past the whole character (`test_mcp_to_lsp_position_mid_surrogate_falls_back`) |
+| Byte offset lands mid-character (not a char boundary) | `Err`, not a panic (`test_byte_offset_to_character_mid_char_boundary_does_not_panic`) — a documented regression fix, since `text[..byte_offset]` would otherwise panic and, under `panic = "abort"`, kill the whole process |
+| MCP character far past the end of a short line | Falls back to the raw (unconverted) value (`test_mcp_to_lsp_position_out_of_bounds_falls_back`) |
+| `line_text` is `None` (file unreadable) | Falls back to the raw value (`test_mcp_to_lsp_position_missing_line_text_falls_back`) |
+| MCP position `(0, 0)` | Clamped to `(0, 0)` via `saturating_sub`, no underflow (`test_saturating_sub_zero`) |
+| CRLF-terminated source line | No column shift — `line_text` never includes the terminator (`test_mcp_to_lsp_position_utf8_negotiated_crlf_line_text`) |
+
+## 7. Success Criteria
+
+| ID | Metric | Target |
+|----|--------|--------|
+| SC-001 | `cargo nextest run -E 'package(mcpls-core) and test(encoding)'` | All existing unit tests in `bridge/encoding.rs` pass |
+| SC-002 | Round-trip property: `lsp_to_mcp_position(mcp_to_lsp_position(l, c, ...), ...) == (l, c)` for the `Utf16` fast path | Holds for `line`/`char` in `1..100` (`test_roundtrip`) |
+| SC-003 | No panic on any fuzzed/adversarial byte offset within `0..=text.len()` | Every offset either succeeds or returns `Err`, never panics |
+
+## 8. Agent Boundaries
+
+### Always (without asking)
+- Add a dedicated unit test for any new fallback/edge case discovered (astral characters,
+  surrogate pairs, out-of-bounds, mid-character boundaries follow this pattern already)
+- Keep the `Utf16` fast path free of any `line_text` scan — this is a deliberate performance/
+  correctness invariant (NFR-003), not an accidental optimization
+
+### Ask First
+- Changing the fallback behavior (raw/unconverted value) to instead error the whole request —
+  this is a deliberate design choice (graceful degradation over hard failure) that several
+  existing tests lock in
+
+### Never
+- Slice `text` at a byte offset without first checking `text.is_char_boundary(offset)` — this is
+  exactly the panic class `byte_offset_to_character`'s guard exists to prevent, and under
+  `panic = "abort"` such a panic kills the entire process, not just one request
+
+## 9. Open Questions
+
+None — this is a retroactive spec documenting stable, already-shipped, well-tested behavior.
+
+## 10. See Also
+
+- [[constitution]] — project principles (not yet created for this project)
+- [[MOC-specs]] — all specifications
+- [[lsp/003-lsp-types-unmaintained-migration/spec|spec lsp/003]] — names `bridge/encoding.rs` as the
+  critical-path code most sensitive to any `lsp-types`/`ls-types` type-level divergence
+- [[lsp/004-lsp-318-draft-gaps/spec|spec lsp/004]] — Resolution callout documents the PRs (#289/#291)
+  that wired negotiated `PositionEncodingKind` into this module and `DocumentTracker`-backed line
+  lookups
+- [[lsp/001-lsp-server-lifecycle-and-respawn/spec|spec lsp/001]] — where `PositionEncodingKind` is
+  negotiated during `LspServer::spawn`'s `initialize` handshake
+- `crates/mcpls-core/src/bridge/encoding.rs` — the module this spec documents
+- `crates/mcpls-core/src/bridge/translator/encoding_ctx.rs` — consumer that orchestrates range
+  conversion using this module's single-position primitives

--- a/specs/bridge/002-document-tracker-synchronization/spec.md
+++ b/specs/bridge/002-document-tracker-synchronization/spec.md
@@ -1,0 +1,219 @@
+---
+aliases:
+  - DocumentTracker synchronization
+  - Document staleness detection
+tags:
+  - sdd
+  - spec
+  - bridge
+  - state
+created: 2026-08-05
+status: implemented
+related:
+  - "[[constitution]]"
+  - "[[lsp/001-lsp-server-lifecycle-and-respawn/spec]]"
+  - "[[mcp/001-mcp-tool-surface-and-routing/spec]]"
+---
+
+# Feature: Document State Tracking, Disk-Staleness Detection, and Per-Server Sync
+
+> [!info] Metadata
+> **Author**: retroactive spec, authored during the `.local/specs/` → `specs/` migration and gap
+> analysis (no single originating commit/PR — this documents already-shipped, working
+> functionality)
+> **Type**: core subsystem
+> **Priority**: P1 (retroactive — reflects centrality, not an open defect)
+
+> [!success] Resolution
+> This is a retroactive spec: `crates/mcpls-core/src/bridge/state.rs`'s `DocumentTracker` and
+> `DocumentState` already implement everything described below. Resource-limit enforcement
+> (`max_documents`/`max_file_size`) is already covered by
+> [[bridge/005-expose-document-tracker-limits/spec|spec bridge/005]]; this spec covers the *rest* of
+> `DocumentTracker`'s responsibilities: content caching, disk-staleness detection, per-path
+> concurrency control, and per-server sync-version tracking, none of which any existing spec
+> documents.
+
+## 1. Overview
+
+### Problem Statement
+
+Every MCP tool that needs a language server to have analyzed a file (hover, definition,
+diagnostics, etc.) must first ensure that server has received the file's current content via LSP's
+`textDocument/didOpen` (first time) or `textDocument/didChange` (subsequent edits). Naively
+re-reading the file from disk on every single tool call and always sending `didChange` would be
+both slow (a disk read per call) and wrong (a file can have unsaved, in-memory-only edits — e.g.
+an MCP host's own edit buffer — that must not be silently overwritten by a stale disk read).
+
+`DocumentTracker` solves three distinct problems at once:
+
+1. **Content caching with disk-staleness detection**: trust a cached in-memory copy of a file's
+   content when a disk stat proves it hasn't changed, but re-read and re-verify by content compare
+   when the stat is ambiguous (an mtime too recent to trust, given filesystem mtime granularity
+   varies from 1s (APFS/ext3) to 2s (FAT/exFAT)) or has changed outright.
+2. **Per-path concurrency control**: two tool calls touching the *same* file must not race each
+   other's read-modify-sync sequence, but calls touching *different* files must never block on each
+   other.
+3. **Per-server sync-version tracking**: a single document can be routed to different servers for
+   different tools (see [[mcp/001-mcp-tool-surface-and-routing/spec|spec mcp/001]]'s `ToolRouter`), and
+   each server needs its own `didOpen`/`didChange` history — one server having seen a document does
+   not mean another one has.
+
+### Goal
+
+Every tool call that touches a file gets that file's true current content synced to the correct
+LSP server(s), using the cheapest correct path available (trust the in-memory cache when a disk
+stat proves nothing has changed; otherwise re-verify), without two concurrent calls for the same
+path corrupting each other's view of the document's version, and without one server's sync history
+being confused with another's.
+
+### Out of Scope
+
+- Resource-limit enforcement (`max_documents`/`max_file_size`) — already
+  [[bridge/005-expose-document-tracker-limits/spec|spec bridge/005]].
+- What happens to a server's sync history when that server crashes and is respawned — already
+  covered by [[lsp/001-lsp-server-lifecycle-and-respawn/spec|spec lsp/001]]'s FR-009
+  (`DocumentTracker::forget_server`), which this spec's data structures support but does not
+  itself specify the trigger for.
+- Position/range conversion of any content this tracker holds — [[bridge/001-position-encoding-layer/spec|spec bridge/001]].
+
+## 2. User Stories
+
+### US-001: Repeated tool calls against an unchanged file don't re-read it from disk
+
+AS AN AI agent issuing several tool calls (hover, then definition, then references) against the
+same file within a short window, with no edits in between
+I WANT the file's content read from disk only once, not once per tool call
+SO THAT a burst of tool calls against the same file stays fast
+
+**Acceptance criteria:**
+```
+GIVEN a file whose (mtime, size) has not changed since it was last read
+WHEN a second tool call ensures the file is open shortly after the first
+THEN the cached in-memory content is trusted without a second disk read, once the mtime is
+     old enough (past MTIME_GRANULARITY) to be trusted as settled
+```
+
+### US-002: An externally-edited file is detected even when mtime granularity can't be trusted
+
+AS A developer whose editor, a formatter, or `git checkout`/`stash` rewrites a file between two
+mcpls tool calls happening within the same filesystem mtime tick
+I WANT the tracker to still detect the change rather than serving stale cached content
+SO THAT a rapid external edit isn't silently missed just because the OS's mtime resolution wasn't
+fine enough to distinguish before/after
+
+**Acceptance criteria:**
+```
+GIVEN a file rewritten externally within the same mtime granularity window as the tracker's last
+     read
+WHEN the next tool call ensures the file is open
+THEN the tracker re-reads and content-compares rather than trusting the stat alone, and picks up
+     the new content if it actually changed
+```
+
+### US-003: Two servers routed to the same document each get correct didOpen/didChange history
+
+AS A developer using two servers for the same language (e.g. pyright for hover, a linter LSP for
+diagnostics, routed per [[mcp/001-mcp-tool-surface-and-routing/spec|spec mcp/001]])
+I WANT each server to receive its own correct `didOpen` (first contact) vs. `didChange`
+(subsequent edit) sequence for a shared document
+SO THAT one server having already seen a document doesn't cause the other to incorrectly skip its
+own required `didOpen`
+
+**Acceptance criteria:**
+```
+GIVEN a document already synced to server A but never sent to server B
+WHEN a tool call routes to server B for the same document
+THEN server B receives didOpen (not didChange), independent of server A's sync history
+```
+
+## 3. Functional Requirements
+
+| ID | Requirement | Priority |
+|----|------------|----------|
+| FR-001 | THE SYSTEM SHALL track, per open document, its URI, language ID, monotonically-increasing version, in-memory content, and a per-server map of the last version synced to each server | must |
+| FR-002 | WHEN a document's on-disk `(mtime, size)` matches the last-observed snapshot AND that mtime is old enough (past a filesystem mtime-granularity margin) to be trusted as settled THE SYSTEM SHALL trust the cached in-memory content without re-reading the file | must |
+| FR-003 | WHEN a document's on-disk `(mtime, size)` does not match the last-observed snapshot, OR the mtime is not yet settled THE SYSTEM SHALL re-read the file and compare content directly rather than trusting the stat alone | must |
+| FR-004 | WHEN a not-yet-settled stat is observed repeatedly with an unchanged `(mtime, size)` THE SYSTEM SHALL debounce the (comparatively expensive) content re-read within a bounded window, while the disk stat itself is never debounced | must |
+| FR-005 | WHEN a document's content is updated via a local (non-disk) edit (`update`) THE SYSTEM SHALL bump its version, replace its content, and clear its disk provenance (so the next `ensure_open` always re-verifies by content compare rather than trusting a stale stat) | must |
+| FR-006 | THE SYSTEM SHALL serialize `ensure_open`/`update` calls for the *same* path via a per-path lock, while calls for *different* paths never block on each other | must |
+| FR-007 | THE SYSTEM SHALL track, per (document, server) pair, the last version synced to that server, so a server that has never seen a document receives `didOpen` and one that has already seen an earlier version receives `didChange` | must |
+| FR-008 | THE SYSTEM SHALL provide `forget_server(server_id)` to clear one server's entire sync history across all tracked documents, without affecting any other server's sync history for the same documents | must |
+| FR-009 | THE SYSTEM SHALL provide `line_text(path, line)`, reading from in-memory tracked content (not disk), for range/position conversion consumers ([[bridge/001-position-encoding-layer/spec|spec bridge/001]]) that need a document's current line text without an extra disk read | must |
+| FR-010 | WHEN `DocumentTracker::open` is called for an already-tracked path THE SYSTEM SHALL unconditionally replace the entry, resetting version to 1 and clearing all servers' sync history for that path | must |
+
+## 4. Non-Functional Requirements
+
+| ID | Category | Requirement |
+|----|----------|-------------|
+| NFR-001 | Performance | The common "file unchanged" path must not re-read file content — a stat comparison alone must suffice once the mtime is settled |
+| NFR-002 | Correctness | `DocumentState.version` must be monotonically non-decreasing for the lifetime of a single tracked entry — every mutation goes through a dedicated method, never a partial field write |
+| NFR-003 | Concurrency | `ensure_open`'s per-path lock is not reentrant; no code path may attempt to acquire it recursively (this must be documented plainly, since violating it self-deadlocks with no panic and no timeout to signal it) |
+| NFR-004 | Portability | The mtime-granularity margin must cover the coarsest common filesystem granularity in realistic deployment targets (FAT/exFAT at 2s), not just the finest (APFS/ext3/HFS+ at ~1s or better) |
+
+## 5. Data Model
+
+| Entity | Description | Key Attributes |
+|--------|-------------|-----------------|
+| `DocumentState` | Tracked state for one open document | `uri`, `language_id`, `version: i32` (monotonic), `content: String`, `disk: Option<DiskSync>`, `synced: HashMap<ServerId, i32>` |
+| `DiskSync` | Snapshot of a document's on-disk filesystem state as of its last verified read | `mtime: Option<SystemTime>`, `size: u64`, `mtime_settled: bool`, `content_checked_at: Instant` (excluded from equality — a debounce timer, not logical state) |
+| `DocumentTracker` | Workspace-wide tracker, shareable behind a plain `Arc` with no outer lock | `documents: StdMutex<HashMap<PathBuf, DocumentState>>`, `path_locks: StdMutex<HashMap<PathBuf, Arc<AsyncMutex<()>>>>`, `generations: StdMutex<HashMap<ServerId, u64>>` |
+
+## 6. Edge Cases and Error Handling
+
+| Scenario | Expected Behavior |
+|----------|--------------------|
+| File's `(mtime, size)` unchanged and mtime is settled | Trust cache, no re-read (FR-002) |
+| File's `(mtime, size)` unchanged but mtime is *not yet* settled (rewritten within the granularity window) | Re-read and content-compare, debounced within `DISK_CHECK_DEBOUNCE` (250ms) for repeated calls against the same unsettled snapshot |
+| File's `(mtime, size)` changed on every stat (rapid external rewrites) | Never debounced — each such call already disagrees with the cached snapshot, so it always takes the immediate re-read path |
+| Filesystem does not report mtime at all | Entry is never treated as settled; forces a content re-read outside the debounce window every time |
+| Local edit applied via `update` | Version bumps, disk provenance cleared — next `ensure_open` always re-verifies by content compare, since the new content's disk provenance is unknown |
+| `update` called from within a task that already holds the same path's lock | Self-deadlock (no panic, no timeout) — documented as a hard invariant, not handled defensively |
+| A document reopened via `open` while already tracked | Entry unconditionally replaced: version resets to 1, all servers' sync history for that path cleared |
+| Server A has synced a document, server B has not | Server B's next `ensure_open` for that document sends `didOpen`, independent of server A's already-synced state |
+| A server is forgotten via `forget_server` | Only that server's sync history is cleared across every tracked document; other servers' sync history is untouched |
+
+## 7. Success Criteria
+
+| ID | Metric | Target |
+|----|--------|--------|
+| SC-001 | `cargo nextest run -E 'package(mcpls-core) and test(state)'` | All existing `DocumentTracker`/`DocumentState` unit tests pass |
+| SC-002 | Repeated `ensure_open` calls against an unchanged file within one process lifetime | Disk content read at most once per genuine change, verified by stat-only fast path being taken on unchanged subsequent calls |
+| SC-003 | Concurrent `ensure_open` calls for two different paths | Neither blocks on the other (per-path locking, not a single tracker-wide lock) |
+
+## 8. Agent Boundaries
+
+### Always (without asking)
+- Route every document-content mutation through `DocumentState`'s dedicated methods
+  (`apply_local_edit`, `commit_reload`, `set_disk`, `mark_synced`, `forget_server`) rather than a
+  partial field write, preserving the monotonic-version invariant (NFR-002)
+- Preserve the per-path (not global) locking granularity in `ensure_open`/`update`
+
+### Ask First
+- Changing `MTIME_GRANULARITY` or `DISK_CHECK_DEBOUNCE` — both are tuned against real filesystem
+  behavior (FAT/exFAT vs. APFS/ext3), not arbitrary constants
+- Adding an eviction/LRU policy for tracked documents — explicitly out of scope per
+  [[bridge/005-expose-document-tracker-limits/spec|spec bridge/005]]'s Out of Scope section, which this spec's
+  `DocumentTracker` also respects
+
+### Never
+- Acquire a path's `lock_path` guard reentrantly from within a call that already holds it — this
+  self-deadlocks with no panic and no timeout (NFR-003)
+- Trust a disk stat match without checking `mtime_settled` — this is exactly the racy-rewrite gap
+  US-002 exists to close
+
+## 9. Open Questions
+
+None — this is a retroactive spec documenting stable, already-shipped, well-tested behavior.
+
+## 10. See Also
+
+- [[constitution]] — project principles (not yet created for this project)
+- [[MOC-specs]] — all specifications
+- [[bridge/005-expose-document-tracker-limits/spec|spec bridge/005]] — `ResourceLimits`
+  (`max_documents`/`max_file_size`) enforcement, the sibling concern this spec does not duplicate
+- [[bridge/001-position-encoding-layer/spec|spec bridge/001]] — consumer of `DocumentTracker::line_text`
+- [[lsp/001-lsp-server-lifecycle-and-respawn/spec|spec lsp/001]] — `forget_server`'s trigger (a respawned
+  server has no memory of previously-open documents)
+- [[mcp/001-mcp-tool-surface-and-routing/spec|spec mcp/001]] — `ToolRouter`, the mechanism that can route
+  one document to different servers for different tools, motivating per-server sync tracking
+- `crates/mcpls-core/src/bridge/state.rs` — `DocumentTracker`, `DocumentState`, `DiskSync`

--- a/specs/bridge/003-rwlock-translator/spec.md
+++ b/specs/bridge/003-rwlock-translator/spec.md
@@ -1,0 +1,66 @@
+# Spec bridge/003: Replace `Arc<Mutex<Translator>>` with `Arc<RwLock<Translator>>`
+
+**Type**: enhancement
+**Priority**: P2
+**Status**: draft
+
+## Problem Statement
+
+Every one of the 16 MCP tool handlers in `mcpls-core/src/mcp/server.rs` acquires a full exclusive
+`Mutex` lock on the `Translator` before dispatching an LSP request:
+
+```rust
+let mut translator = self.context.translator.lock().await;
+translator.handle_hover(...).await
+```
+
+Most LSP calls are read operations (hover, definition, references, document symbols, completions,
+call hierarchy, workspace symbol search, code actions, get_diagnostics). Only a small subset
+mutate `Translator` state (rename_symbol, format_document, and the document-open bookkeeping
+inside `DocumentTracker`).
+
+Holding an exclusive lock across the full async round-trip to the LSP server (which may take
+hundreds of milliseconds for a cold rust-analyzer query) serialises all concurrent tool calls.
+This is the root cause described in #104 (notification pump starvation) and the motivation for
+#108 (reduce lock hold time).
+
+## User Stories
+
+- As an AI agent issuing multiple simultaneous tool calls, I want hover and definition calls to
+  run concurrently rather than queued behind each other.
+- As a developer, I want the notification pump to receive push diagnostics without waiting for
+  a pending hover call to release the lock.
+
+## Functional Requirements
+
+1. `Arc<Mutex<Translator>>` must be replaced with `Arc<RwLock<Translator>>`.
+2. Read-only tool handlers (hover, definition, references, document_symbols, completions,
+   call_hierarchy, workspace_symbol_search, code_actions, get_cached_diagnostics, get_server_logs,
+   get_server_messages) must acquire a read lock (`read().await`).
+3. Mutating handlers (rename_symbol, format_document, get_diagnostics which triggers didOpen)
+   must acquire a write lock (`write().await`).
+4. The `NotificationCache` must be separated from `Translator` into its own `Arc<RwLock<...>>`
+   (per spec for #104) so the pump can write diagnostics without waiting for a read lock on the
+   full `Translator`.
+5. No deadlocks: no code path may hold a read lock and attempt to acquire a write lock.
+
+## Non-Functional Requirements
+
+- Concurrent read throughput: ≥ 2x improvement on multi-tool batches (hover + definition).
+- No regression on single-tool latency.
+- MSRV compatibility: `tokio::sync::RwLock` is available since tokio 1.0.
+
+## Alternatives Considered
+
+- **arc-swap**: Suitable for config-like data that is atomically replaced wholesale; does not
+  fit `Translator` which is mutated in-place.
+- **dashmap**: Only applicable to HashMap-shaped state; Translator has richer structure.
+- **message-passing (channel)**: Would require restructuring all 16 handlers significantly;
+  higher complexity than RwLock upgrade.
+
+## See Also
+
+- #104 — split NotificationCache out of Translator lock
+- #108 — reduce Mutex hold time
+- tokio docs: https://docs.rs/tokio/latest/tokio/sync/struct.RwLock.html
+- tokio discussion on std vs tokio Mutex: https://github.com/tokio-rs/tokio/discussions/7627

--- a/specs/bridge/004-get-diagnostics-flycheck-gap/spec.md
+++ b/specs/bridge/004-get-diagnostics-flycheck-gap/spec.md
@@ -1,0 +1,199 @@
+---
+aliases:
+  - get_diagnostics flycheck gap
+tags:
+  - sdd
+  - spec
+  - bug
+  - bridge
+  - diagnostics
+created: 2026-07-25
+status: draft
+related:
+  - "[[MOC-specs]]"
+  - "[[mcp/002-mcp-resources-diagnostics/spec]]"
+---
+
+# Feature: Fix `get_diagnostics` Silently Omitting Flycheck-Sourced Diagnostics
+
+> [!info] Metadata
+> **Author**: k05h31
+> **Branch**: fix/get-diagnostics-flycheck-gap
+> **Type**: bug
+> **Priority**: P1
+
+## 1. Overview
+
+### Problem Statement
+
+`mcp/server.rs`'s `get_diagnostics` tool (implemented by
+`Translator::handle_diagnostics`, `crates/mcpls-core/src/bridge/translator.rs`
+lines 954-1000) uses the LSP **pull** model exclusively: it sends
+`textDocument/diagnostic` to the LSP server and returns only that response's
+`items`. Separately, `NotificationCache`
+(`crates/mcpls-core/src/bridge/notifications.rs`) is populated by the LSP
+**push** model (`textDocument/publishDiagnostics`), and is exposed via the
+`get_cached_diagnostics` tool and the `resources/read` / `resources/subscribe`
+MCP resource endpoints (see [[mcp/002-mcp-resources-diagnostics/spec|Spec mcp/002]]).
+
+For rust-analyzer these two sources diverge. rust-analyzer's pull endpoint
+only returns diagnostics from its synchronous native analysis (syntax errors,
+type errors, borrow-checker errors). It never includes diagnostics sourced
+from its background "flycheck" process (`cargo check`, or clippy if
+configured) — those are lint-style warnings like `unused_imports` and
+`dead_code`, and they are delivered *only* via `publishDiagnostics` push
+notifications, never via the pull endpoint. This is a documented rust-analyzer
+behavior, not an mcpls timing bug: mcpls already holds the flycheck
+diagnostics in `NotificationCache` (proven by `get_cached_diagnostics`
+returning them correctly) at the exact moment `get_diagnostics` reports the
+file clean.
+
+`get_diagnostics` is the tool most likely to be reached for by an AI agent —
+it is the one named and described for exactly this purpose ("Diagnostics for
+a file. Returns errors, warnings, and hints with severity and location.").
+Its silent, incomplete result is worse than an error: it actively implies the
+file has no unused-import/dead-code warnings when it does, so an agent may
+skip fixing an issue it would have caught if a different tool name had been
+used.
+
+### Goal
+
+`get_diagnostics` returns the same diagnostics for a file that
+`get_cached_diagnostics` / `resources/read` would return for that file at the
+same point in time — i.e., it never silently omits warnings mcpls already
+knows about from `publishDiagnostics` pushes, for any LSP server exhibiting
+this pull/push divergence (not just rust-analyzer).
+
+### Out of Scope
+
+- Changing `get_cached_diagnostics` or the `resources/*` endpoints — they
+  already behave correctly and are not part of this bug.
+- Forcing rust-analyzer to run flycheck synchronously before responding to a
+  pull request — this is not controllable from the client side of the LSP
+  protocol.
+- Adding a way to distinguish "native" vs "flycheck" diagnostics in the tool
+  output (could be a follow-up enhancement, not required to close this gap).
+- Changing behavior for LSP servers whose pull and push diagnostics are
+  already consistent (e.g. servers with no separate background-check
+  process) — the fix must not regress or change output for those servers.
+
+## 2. User Stories
+
+### US-001: Agent gets complete diagnostics from the primary tool
+
+AS AN AI coding agent
+I WANT `get_diagnostics` to include every diagnostic mcpls already knows
+about for a file
+SO THAT I don't skip fixing warnings (e.g. unused imports, dead code) just
+because I used the tool with the more obvious name instead of
+`get_cached_diagnostics`
+
+**Acceptance criteria:**
+```
+GIVEN a Rust file with an unused import
+  AND rust-analyzer has already pushed a publishDiagnostics notification
+      for that file containing the unused_imports warning
+WHEN the AI agent calls get_diagnostics for that file
+THEN the response includes the unused_imports warning
+  AND the response is consistent with what get_cached_diagnostics returns
+      for the same file at the same point in time
+```
+
+### US-002: Native (pull-only) diagnostics still work
+
+AS AN AI coding agent
+I WANT `get_diagnostics` to still report native LSP errors correctly (e.g.
+type errors) with the fix applied
+SO THAT the fix for the flycheck gap does not regress the currently-working
+pull path
+
+**Acceptance criteria:**
+```
+GIVEN a Rust file with a genuine type error (e.g. E0308 mismatched types)
+WHEN the AI agent calls get_diagnostics for that file
+THEN the response includes the type error
+  AND the fix does not require rust-analyzer to have pushed a
+      publishDiagnostics notification first for this case to work
+```
+
+## 3. Functional Requirements
+
+The fix must guarantee:
+
+| ID | Requirement | Priority |
+|----|------------|----------|
+| FR-001 | WHEN `get_diagnostics` is called for a file THE SYSTEM SHALL return a diagnostics set that is a superset of (or equal to) what `NotificationCache` currently holds for that file's URI, merged with what the LSP pull response (`textDocument/diagnostic`) returns | must |
+| FR-002 | WHEN the pull response (`textDocument/diagnostic`) for a file is empty or incomplete relative to the cached diagnostics THE SYSTEM SHALL NOT report the file as having zero diagnostics if `NotificationCache` holds non-empty diagnostics for that URI | must |
+| FR-003 | WHEN the pull response and the cached diagnostics both contain a diagnostic that is semantically the same (same range, severity, code, message) THE SYSTEM SHALL NOT return duplicate entries for it | must |
+| FR-004 | WHEN `NotificationCache` has no entry yet for a file (e.g., no `publishDiagnostics` has arrived) THE SYSTEM SHALL fall back to the pull response alone, exactly as today | must |
+| FR-005 | WHEN the merge/fallback logic runs THE SYSTEM SHALL NOT introduce an additional LSP round-trip beyond the existing `textDocument/diagnostic` pull request (the cache read is in-process and already exists) | must |
+| FR-006 | WHEN `get_diagnostics` is called for a language server whose pull and push diagnostics are already consistent THE SYSTEM SHALL produce the same observable output as before this fix (no regression for non-rust-analyzer or non-divergent servers) | must |
+
+## 4. Non-Functional Requirements
+
+| ID | Category | Requirement |
+|----|----------|-------------|
+| NFR-001 | Performance | Merge/dedup logic must be O(n) or O(n log n) in the number of diagnostics for the file (typically single/low double digits) — no measurable added latency to `get_diagnostics` beyond the existing pull round-trip |
+| NFR-002 | Concurrency | Reading `NotificationCache` inside `handle_diagnostics` must follow the existing lock-ordering discipline documented in `translator.rs` (cache lock must not be held across the LSP pull await point) — see [[bridge/003-rwlock-translator/spec|Spec bridge/003]] |
+| NFR-003 | Consistency | Merged output must use the same `Diagnostic` → MCP mapping (severity, range normalization, code) already used by both `handle_diagnostics` and `diagnostics_from_cache_entry`, so the two code paths do not diverge in formatting |
+
+## 5. Data Model
+
+No new entities. The fix operates on two existing shapes:
+
+| Entity | Description | Key Attributes |
+|--------|-------------|----------------|
+| Pull diagnostics | Result of `textDocument/diagnostic` LSP request, as consumed today in `handle_diagnostics` | `items: Vec<lsp_types::Diagnostic>` |
+| `DiagnosticInfo` (cached) | Existing cache entry keyed by document URI in `NotificationCache`, populated by `publishDiagnostics` | `uri`, `version`, `diagnostics: Vec<lsp_types::Diagnostic>` |
+| Merged `DiagnosticsResult` | MCP-facing output of `get_diagnostics` after the fix | `diagnostics: Vec<Diagnostic>` (existing MCP type, unchanged shape) |
+
+## 6. Edge Cases and Error Handling
+
+| Scenario | Expected Behavior |
+|----------|-------------------|
+| No cache entry exists yet for the file (fresh file, no push received) | Fall back to pull response only, unchanged from current behavior (FR-004) |
+| Cache entry exists but is empty (server previously cleared diagnostics via an empty `publishDiagnostics`) | Empty cache and empty pull both yield an empty result — no false positives from stale cache data |
+| Cache entry is stale relative to the current document version (file edited since last `publishDiagnostics`) | `[NEEDS CLARIFICATION: should merge check DiagnosticInfo.version against the current document version and skip/flag stale cache entries, or is "cache is eventually consistent, same as get_cached_diagnostics already accepts" an acceptable behavior for this fix?]` |
+| Pull and cache both return the same diagnostic with minor formatting differences (e.g. different code representation) | Dedup must compare on normalized (range, severity, message, code) tuples, not raw equality, to avoid duplicate-looking entries |
+| LSP server does not support `textDocument/diagnostic` pull at all | Existing error/fallback behavior for missing pull capability is unchanged; cache-only result should still be considered, per FR-001 |
+| Workspace/path validation failure for the requested file | Unchanged — existing `prepare_document` validation runs before any diagnostics logic, as today |
+
+## 7. Success Criteria
+
+| ID | Metric | Target |
+|----|--------|--------|
+| SC-001 | Reproduction scenario from the bug report (unused import via rust-analyzer flycheck) | `get_diagnostics` returns the `unused_imports` warning, matching `get_cached_diagnostics` output |
+| SC-002 | Control scenario from the bug report (E0308 type error) | `get_diagnostics` continues to return the error correctly, unchanged |
+| SC-003 | No duplicate diagnostics reported when pull and cache overlap | 0 duplicate entries in test coverage for overlapping pull+cache scenarios |
+| SC-004 | Existing `handle_diagnostics` unit/integration tests | All pass unchanged (or updated only where the merge behavior is the explicit subject of the test) |
+
+## 8. Agent Boundaries
+
+### Always (without asking)
+- Reuse the existing `diagnostics_from_cache_entry` / `Diagnostic` mapping helpers rather than duplicating conversion logic
+- Add/update unit tests covering: cache-empty fallback, cache-and-pull merge with overlap, cache-and-pull merge with no overlap, dedup
+- Follow the lock-ordering discipline already documented around `NotificationCache` in `translator.rs` (see comments near `cached_diagnostics_uri`)
+
+### Ask First
+- Any change to `get_cached_diagnostics` or `resources/*` behavior (out of scope; flag if the fix seems to require touching them)
+- Resolving the staleness question in the Edge Cases table (version-check vs. eventually-consistent) — pick a default but confirm before merging if it affects the public `DiagnosticsResult` shape
+
+### Never
+- Add an additional LSP request/round-trip to work around this (violates NFR-001/FR-005)
+- Silently change the JSON shape of `DiagnosticsResult` (e.g. adding a `source: pull|cache` field) without treating it as a documented, deliberate API addition
+
+## 9. Open Questions
+
+- [NEEDS CLARIFICATION: Merge strategy — should the fix (a) always merge pull ∪ cache, (b) prefer cache and only fall back to pull when cache is empty, or (c) explicitly query flycheck status via some LSP extension if available? The bug report leaves this open as "at minimum... merge/fall back to the NotificationCache when the pull response is empty or incomplete."]
+- [NEEDS CLARIFICATION: Should merged results indicate provenance (native vs. flycheck-sourced) to help agents distinguish severity classes, or is a flat merged list sufficient for v1?]
+- [NEEDS CLARIFICATION: Cache staleness handling — see Edge Cases table row on document version mismatch.]
+- [NEEDS CLARIFICATION: Does this same divergence affect other LSP servers used by mcpls (pyright, typescript-language-server, etc.), or is it rust-analyzer-specific? If server-specific, should the merge be conditional on `language_id`/server capabilities, or applied uniformly since a uniform merge is provably safe per FR-006?]
+
+## 10. See Also
+
+- [[MOC-specs]] — all specifications
+- [[bridge/003-rwlock-translator/spec|Spec bridge/003]] — `NotificationCache` / `Translator` lock-ordering discipline this fix must respect
+- [[mcp/002-mcp-resources-diagnostics/spec|Spec mcp/002]] — the `NotificationCache` / `get_cached_diagnostics` / resources design this fix reuses
+- `crates/mcpls-core/src/bridge/translator.rs::handle_diagnostics` (lines 954-1000) — code to be modified
+- `crates/mcpls-core/src/bridge/translator.rs::diagnostics_from_cache_entry` (lines 1626-1652) — existing cache→MCP mapping to reuse
+- `crates/mcpls-core/src/bridge/notifications.rs::NotificationCache` — existing push-based cache

--- a/specs/bridge/005-expose-document-tracker-limits/plan.md
+++ b/specs/bridge/005-expose-document-tracker-limits/plan.md
@@ -1,0 +1,313 @@
+---
+aliases:
+  - Expose DocumentTracker Limits Plan
+tags:
+  - sdd
+  - plan
+  - bridge
+  - config
+created: 2026-08-05
+status: implemented
+related:
+  - "[[spec]]"
+  - "[[constitution]]"
+---
+
+# Technical Plan: Expose DocumentTracker Resource Limits
+
+> [!info] References
+> **Spec**: [[spec]]
+
+> [!important] Resolution of Open Questions
+> This plan resolves the spec's primary `[NEEDS CLARIFICATION]` (Section 9,
+> spec.md) as follows, since a plan cannot proceed without picking a
+> concrete surface. Rationale is given per decision; revisit if the user
+> disagrees before implementation starts.
+>
+> 1. **Surface: TOML config only for v1** — flat fields on `[workspace]`
+>    (`max_documents`, `max_file_size`), no new CLI flags or `MCPLS_*` env
+>    vars. Rationale: mirrors the existing `workspace.heuristics_max_depth`
+>    field, which is TOML-only with no CLI/env equivalent — the codebase's
+>    established pattern for workspace-scoped tuning knobs (as opposed to
+>    process-level knobs like `--log-level`/`MCPLS_LOG`, which *do* have CLI
+>    flags because they apply before config is even loaded). Resource limits
+>    are workspace-scoped, not process-bootstrap-scoped, so they follow the
+>    TOML-only precedent. This also keeps the change minimal per the
+>    project's simplicity/MVP conventions.
+> 2. **Location: flat on `WorkspaceConfig`**, not a new `[workspace.limits]`
+>    table. Rationale: consistent with `heuristics_max_depth` and
+>    `position_encodings`, which are flat fields on the same struct; a
+>    nested table would be the only nested table in `[workspace]` and adds
+>    structure without a clear payoff for two fields.
+> 3. **No new upper bound.** Rationale: unlike `request_timeout_seconds`
+>    (bounded by `MAX_TIMEOUT_SECONDS` because an excessive timeout blocks a
+>    request thread for real wall-clock time — a live liveness hazard),
+>    `max_documents`/`max_file_size` bound *memory*, not time; there is no
+>    equivalent hard external ceiling to mirror, and the existing `0 =
+>    unlimited` sentinel already gives operators an explicit "I accept the
+>    risk" opt-out. Adding an arbitrary upper bound would only reintroduce
+>    exactly the problem this spec exists to fix. `usize`/`u64` typing
+>    already excludes negative values; no additional validation is required
+>    beyond what serde/TOML deserialization already enforces.
+> 4. **README/config reference (FR-006) is required regardless**, added to
+>    `docs/user-guide/configuration.md`'s existing `## Workspace Section`,
+>    matching the format used for `workspace.position_encodings` and
+>    `workspace.language_extensions`.
+
+## 1. Architecture
+
+### Approach
+
+Add two new optional fields, `max_documents: usize` and `max_file_size: u64`,
+directly to `WorkspaceConfig` (`crates/mcpls-core/src/config/mod.rs:62-88`),
+each with a `#[serde(default = "...")]` pointing at a `const fn` returning
+the current hardcoded default (100, `10 * 1024 * 1024`), following the exact
+pattern already used for `heuristics_max_depth`
+(`default_heuristics_max_depth`, mod.rs:86-88, 101-103).
+
+Add a `WorkspaceConfig::resource_limits(&self) -> ResourceLimits` helper that
+maps the two fields onto the existing `bridge::state::ResourceLimits` struct.
+This keeps `ResourceLimits` itself (state.rs:135-150) unchanged — it remains
+the bridge layer's internal representation; only how it gets *constructed*
+changes.
+
+Thread the resolved `ResourceLimits` from `ServerConfig`/`WorkspaceConfig`
+through to every non-test `Translator` construction site that currently
+calls `ResourceLimits::default()` (`translator.rs:141, 249, 3280, 3295,
+4095` — the latter three are `#[cfg(test)]` and are explicitly left as
+`ResourceLimits::default()` per FR-007's test-isolation carve-out; only
+`Translator::new()` and `Translator::with_extensions()`, i.e. lines 141 and
+249, are non-test production call sites and are the two that actually need
+the config-sourced value). Since `Translator::new()` currently takes no
+arguments and is called before config is available in some paths, the
+simplest change that preserves existing call sites is to keep
+`ResourceLimits::default()` as `Translator::new()`'s internal default and
+add a `Translator::with_resource_limits(mut self, limits: ResourceLimits) ->
+Self` builder method (mirroring the existing `with_extensions`/`with_router`
+builder pattern), called from the same place in `lib.rs`/`serve()` that
+currently calls `.with_extensions(...)`.
+
+No changes to `DocumentTracker::open()`, `check_file_size()`, or the `0 =
+unlimited` guard logic — those already do the right thing once a non-default
+`ResourceLimits` reaches them.
+
+### Component Diagram
+
+```mermaid
+graph TD
+    TOML["mcpls.toml\n[workspace]\nmax_documents / max_file_size"] --> WC[WorkspaceConfig]
+    WC -->|"resource_limits()"| RL[ResourceLimits]
+    RL -->|"Translator::with_resource_limits"| T[Translator]
+    T -->|"DocumentTracker::new"| DT[DocumentTracker]
+    DT -->|"open() / check_file_size()"| GATE{"limit check\n(0 = unlimited, unchanged)"}
+```
+
+### Key Design Decisions
+
+| Decision | Choice | Rationale | Alternatives Considered |
+|----------|--------|-----------|--------------------------|
+| Config surface | TOML only, flat on `[workspace]` | Matches `heuristics_max_depth` precedent; workspace-scoped, not bootstrap-scoped | CLI flags/env vars (rejected: no precedent for workspace-scoped settings, adds surface area); nested `[workspace.limits]` table (rejected: only 2 fields, adds nesting without payoff) |
+| Upper bound validation | None beyond type constraints | No liveness/wall-clock hazard analogous to `request_timeout_seconds`; `0` already gives an explicit unlimited opt-out | Mirror `MAX_TIMEOUT_SECONDS` pattern with a `MAX_DOCUMENTS`/`MAX_FILE_SIZE` ceiling (rejected: would recreate the exact problem being fixed) |
+| Wiring mechanism | New `Translator::with_resource_limits` builder, called from `serve()` alongside `with_extensions` | Mirrors existing builder pattern (`with_router`, `with_extensions`, `with_notification_cache`); avoids threading limits through `Translator::new()`'s zero-arg signature, which several call sites (including tests) rely on | Change `Translator::new()` signature to take `ResourceLimits` (rejected: touches every construction site incl. ~30 test sites unnecessarily) |
+| `DocumentLimitExceeded` message hint (FR-005) | Append a static hint referencing `workspace.max_documents` when the *default* value (100) is still in effect; omit the hint when a non-default value is configured (message already reflects the effective ceiling) | Avoids telling a user who already raised the limit to "go raise the limit" | Always show the hint (rejected: misleading once already configured) |
+
+## 2. Project Structure
+
+```
+crates/mcpls-core/src/
+├── config/
+│   └── mod.rs              # WorkspaceConfig: + max_documents, max_file_size fields
+│                            #   + default_max_documents(), default_max_file_size()
+│                            #   + WorkspaceConfig::resource_limits()
+├── bridge/
+│   ├── state.rs             # ResourceLimits: unchanged struct; DocumentLimitExceeded
+│                            #   message gains conditional hint (FR-005)
+│   └── translator.rs        # Translator: + with_resource_limits() builder
+│                            #   Translator::new()/with_extensions() unchanged
+│                            #   (still ResourceLimits::default() as the pre-config default)
+└── lib.rs                    # serve(): call .with_resource_limits(config.workspace.resource_limits())
+
+docs/user-guide/
+└── configuration.md          # + "### `workspace.max_documents`" and
+                               #   "### `workspace.max_file_size`" under
+                               #   "## Workspace Section"
+
+README.md                     # optional: one-line mention + link to config reference
+                               # (FR-006 is satisfied primarily via configuration.md;
+                               # README already links there for all field docs)
+
+CHANGELOG.md                  # [Unreleased] entry
+```
+
+## 3. Data Model
+
+```rust
+// crates/mcpls-core/src/config/mod.rs
+
+/// Workspace-level configuration.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct WorkspaceConfig {
+    // ...existing fields unchanged (roots, position_encodings,
+    // language_extensions, heuristics_max_depth)...
+
+    /// Maximum number of documents `DocumentTracker` will keep open
+    /// simultaneously. A `textDocument/didOpen`-triggering tool call for a
+    /// document beyond this count fails with `DocumentLimitExceeded` until
+    /// an existing document is released. `0` disables the limit.
+    /// Default: 100
+    #[serde(default = "default_max_documents")]
+    pub max_documents: usize,
+
+    /// Maximum size, in bytes, of a single file `DocumentTracker` will
+    /// open. A file larger than this fails with `FileSizeLimitExceeded`.
+    /// `0` disables the limit.
+    /// Default: 10485760 (10MB)
+    #[serde(default = "default_max_file_size")]
+    pub max_file_size: u64,
+}
+
+const fn default_max_documents() -> usize {
+    100
+}
+
+const fn default_max_file_size() -> u64 {
+    10 * 1024 * 1024
+}
+
+impl WorkspaceConfig {
+    /// Maps the configured limits onto the bridge layer's `ResourceLimits`.
+    #[must_use]
+    pub fn resource_limits(&self) -> crate::bridge::state::ResourceLimits {
+        crate::bridge::state::ResourceLimits {
+            max_documents: self.max_documents,
+            max_file_size: self.max_file_size,
+        }
+    }
+}
+```
+
+`Default for WorkspaceConfig` (mod.rs:90-99) gains
+`max_documents: default_max_documents()` and `max_file_size:
+default_max_file_size()`, keeping `WorkspaceConfig::default()` in sync with
+serde's per-field defaults (existing pattern for `heuristics_max_depth`).
+
+`bridge::state::ResourceLimits` itself is **unchanged** — no new derive,
+no new fields; it remains the internal runtime representation.
+
+### Migrations
+
+None — TOML fields with serde defaults are additive and backward compatible.
+No schema/database migration involved.
+
+## 4. API Design
+
+Not applicable — no new MCP tools, HTTP endpoints, or JSON-RPC methods. This
+is a config-plumbing change plus a documentation change. The only "API"
+surface touched is:
+
+| Surface | Change |
+|---------|--------|
+| `mcpls.toml` schema | + `workspace.max_documents` (optional, default 100) |
+| `mcpls.toml` schema | + `workspace.max_file_size` (optional, default 10485760) |
+| `Translator` builder API | + `with_resource_limits(self, ResourceLimits) -> Self` |
+| `WorkspaceConfig` public API | + `resource_limits(&self) -> ResourceLimits` |
+| `Error::DocumentLimitExceeded` message | conditional hint text (FR-005) |
+
+## 5. Integration Points
+
+| System | Direction | Protocol | Notes |
+|--------|-----------|----------|-------|
+| `mcpls.toml` config file | inbound | TOML (serde) | New optional fields, additive, `deny_unknown_fields` already enforced at `ServerConfig`/`WorkspaceConfig` level — typos in field names will already error out clearly |
+| `crate::bridge::translator::Translator` | internal | Rust builder API | New `with_resource_limits` call inserted into the existing `serve()` construction chain |
+| README / `docs/user-guide/configuration.md` | outbound | Markdown | Documentation-only addition, no runtime effect |
+
+## 6. Security
+
+- Authentication/authorization: not applicable — no new external-facing
+  surface.
+- Input validation: `usize`/`u64` deserialization via serde/TOML already
+  rejects negative or non-numeric values with a clear parse error before
+  `ServerConfig::validate()` even runs; no additional validation logic is
+  added per the "no new upper bound" decision above.
+- Sensitive data: none — these are plain numeric tuning knobs, not secrets.
+- Resource-safety note: raising `max_documents`/`max_file_size` (or setting
+  either to `0`/unlimited) is an explicit, documented operator opt-in to
+  higher memory usage by `DocumentTracker` (each open document's full
+  content is held in memory, per `DocumentState.content`, state.rs:109).
+  The README addition (FR-006) must state this trade-off plainly so users
+  raising the limit understand the memory cost.
+
+## 7. Testing Strategy
+
+| Level | Framework | What to Test | Coverage Target |
+|-------|-----------|---------------|-------------------|
+| Unit | `cargo nextest` | `WorkspaceConfig` TOML deserialization: default values when fields absent (mirrors `test_load_from_toml_without_request_timeout_seconds_defaults_to_thirty`, mod.rs:748); explicit non-default values parse correctly; `resource_limits()` maps fields 1:1 | New tests added, all pass |
+| Unit | `cargo nextest` | `DocumentTracker::open()`/`check_file_size()` behavior unchanged for `ResourceLimits` built via `WorkspaceConfig::resource_limits()` with non-default values (e.g. `max_documents: 500` allows the 101st document; `max_documents: 0` never rejects) | Existing `state.rs` test patterns extended, not replaced |
+| Unit | `cargo nextest` | `DocumentLimitExceeded` message includes the hint only when the effective `max_documents` equals the default (100), and omits it otherwise | New test |
+| Integration | `cargo nextest` | `Translator::with_resource_limits` actually reaches the `DocumentTracker` used by tool dispatch — construct a `Translator`, open >100 documents with a raised limit, assert success | Extends existing translator integration tests |
+| Regression | manual / CI live-test | Re-run the original 120-file reproduction from the finding: unchanged config still fails at #101 (SC-001); raised `max_documents = 200` config succeeds through #120 (SC-002) | Both scenarios verified before closing the issue |
+| Docs | manual review | `docs/user-guide/configuration.md` renders correctly, follows the existing `### field.name` subsection format used for sibling fields | Reviewed in PR |
+
+## 8. Performance Considerations
+
+- Expected load: no change to hot-path performance — `open()`'s existing
+  lock-acquire-and-check logic (state.rs:262-270) is untouched; only the
+  *value* of `self.limits.max_documents` compared against changes based on
+  config.
+- Bottlenecks: raising `max_documents`/`max_file_size` substantially
+  increases `DocumentTracker`'s steady-state memory footprint (each open
+  document holds its full text content, per-server sync generations, and a
+  path lock). This is an explicit, documented trade-off (see Section 6), not
+  a bug — no mitigation beyond documentation is in scope for this spec (an
+  eviction/LRU policy is explicitly out of scope per spec.md Section 1).
+- Optimization plan: none needed; this change does not add any new
+  per-request work.
+
+## 9. Rollout Plan
+
+Single PR, no feature flag needed:
+
+1. Add `max_documents`/`max_file_size` fields to `WorkspaceConfig` with
+   defaults matching current hardcoded values (fully backward compatible —
+   SC-001 must still pass unchanged).
+2. Add `WorkspaceConfig::resource_limits()` and `Translator::with_resource_limits`.
+3. Wire `serve()` to call the new builder method.
+4. Add the conditional `DocumentLimitExceeded` hint (FR-005).
+5. Add/extend unit and integration tests (Section 7).
+6. Update `docs/user-guide/configuration.md` (FR-006) and `CHANGELOG.md`.
+7. Run full local check suite (`cargo +nightly fmt --check`, `cargo clippy
+   --all-targets --all-features --workspace -- -D warnings`, `cargo nextest
+   run --workspace --all-features --lib --bins`, rustdoc gate) before PR.
+8. No migration needed for existing users — config files without these
+   fields are unaffected.
+
+## 10. Constitution Compliance
+
+No `constitution.md` exists yet for this project (`.local/specs/constitution.md`
+absent). Compliance is checked against `/Users/rabax/Dev/mcpls/.claude/CLAUDE.md`
+project conventions instead:
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| `deny(unsafe_code)` workspace-wide | Compliant | No unsafe code introduced |
+| Doc comments on all `pub` items | Compliant (planned) | New fields, `resource_limits()`, and `with_resource_limits()` all get `///` doc comments per Section 3/4 |
+| Test with `cargo nextest`, mirror CI exactly | Compliant (planned) | Section 7 |
+| Conventional Commits | Compliant (planned) | Implementation PR will use `feat(config): ...` |
+| MVP / no premature abstraction | Compliant | No new table/nesting, no CLI/env surface added beyond what's needed; deliberately rejected a `[workspace.limits]` sub-table for exactly this reason |
+| Before v1.0.0: no backward-compat baggage required | N/A | Change is additive/backward-compatible anyway — no breaking change needed |
+
+## 11. Risks and Mitigations
+
+| Risk | Impact | Probability | Mitigation |
+|------|--------|--------------|-------------|
+| Users raise `max_documents`/`max_file_size` without understanding the memory trade-off, causing OOM in constrained environments | medium | low | Document the trade-off explicitly (Section 6); no auto-cap added because that would just reproduce the original bug for legitimate large-workspace use cases |
+| `with_resource_limits` builder is added but a call site is missed (e.g. a future new `Translator` construction path bypasses config) | medium | low | FR-007 explicitly enumerates all non-test call sites; grep for `ResourceLimits::default()` outside `#[cfg(test)]` blocks as a final PR-review check |
+| Conditional `DocumentLimitExceeded` hint (FR-005) logic drifts out of sync if defaults change later | low | low | Compare against the same `default_max_documents()`/`default_max_file_size()` functions used for serde defaults, not a hardcoded literal, so both stay in sync by construction |
+| Scope creep into CLI/env flags or per-server limits during implementation | low | medium | Plan explicitly scopes to TOML-only, global-only (Section "Resolution of Open Questions"); flag to user if implementer wants to expand scope |
+
+## See Also
+
+- [[spec]] — feature specification
+- [[tasks]] — implementation tasks (after this phase)
+- [[MOC-specs]] — all specifications

--- a/specs/bridge/005-expose-document-tracker-limits/spec.md
+++ b/specs/bridge/005-expose-document-tracker-limits/spec.md
@@ -1,0 +1,259 @@
+---
+aliases:
+  - Document Tracker Resource Limits
+tags:
+  - sdd
+  - spec
+  - bridge
+  - config
+created: 2026-08-05
+status: implemented
+related:
+  - "[[constitution]]"
+  - "[[config/001-config-discovery-and-heuristics/spec]]"
+  - "[[bridge/002-document-tracker-synchronization/spec]]"
+---
+
+# Feature: Expose DocumentTracker Resource Limits
+
+> [!info] Metadata
+> **Author**: rust-agents (CI cycle 017, live-testing finding)
+> **Branch**: fix/010-expose-document-tracker-limits
+> **Source finding**: enhancement, P2, filed during live-testing cycle 017
+
+> [!success] Resolution
+> Implemented by commit `e7a4dfe` (PR #324), closing #315 and #293. Matches the plan's resolved
+> design exactly: `workspace.max_documents`/`workspace.max_file_size` are flat, optional TOML
+> fields on `WorkspaceConfig` (mod.rs) with `0 = unlimited`, `WorkspaceConfig::resource_limits()`
+> maps them onto `bridge::state::ResourceLimits`, and a new `Translator::with_resource_limits`
+> builder wires the resolved limits into `serve()`'s `Translator` construction (composing
+> correctly with the existing `with_extensions` builder in either call order). No CLI/env surface
+> and no upper bound were added, per the plan's resolved design decisions. `docs/user-guide/configuration.md`
+> was updated (FR-006) and `DocumentLimitExceeded`/`FileSizeLimitExceeded` messages gained a
+> config-field hint (FR-005).
+>
+> **Deviation from the plan**: Section 10 of `plan.md` ("Constitution Compliance") assessed this
+> change as fully backward-compatible with no breaking change needed. The shipped commit is
+> `feat(config)!` and carries an explicit `BREAKING CHANGE` note covering two items outside this
+> spec's original Functional Requirements: `NotificationCache::get_logs`/`get_messages` were
+> renamed to `logs`/`messages` (dropping the redundant `get_` prefix per the Rust API Guidelines),
+> and `ResourceLimits` — previously private to `bridge::state` — is now re-exported from `bridge`,
+> making the already-`pub` `DocumentTracker::new` constructible from outside the crate for the
+> first time. Neither change was anticipated in Section 1 (Overview) or Section 8 (Agent
+> Boundaries, "Never: ... without explicit instruction") of this spec; they were bundled into the
+> same PR rather than filed separately.
+
+## 1. Overview
+
+### Problem Statement
+
+`DocumentTracker` (`crates/mcpls-core/src/bridge/state.rs`) enforces a
+`ResourceLimits` cap in `open()` (state.rs:243-272): once
+`documents.len() >= limits.max_documents`, every subsequent
+`textDocument/didOpen`-triggering tool call (hover, definition, diagnostics,
+etc.) against a *new* file hard-fails with `Error::DocumentLimitExceeded`
+(`"document limit exceeded: N/100"`) — even though the underlying LSP server
+is healthy and would happily serve the request.
+
+`ResourceLimits::default()` (state.rs:143-150) sets `max_documents: 100` and
+`max_file_size: 10 * 1024 * 1024` (10MB). Every construction site of
+`ResourceLimits` in the codebase (`translator.rs:141, 249, 3280, 3295, 4095`)
+calls `ResourceLimits::default()` — there is no TOML config field, CLI flag,
+or environment variable anywhere in `crates/mcpls-cli/src/args.rs` or
+`crates/mcpls-core/src/config/` that can override either limit (confirmed via
+grep: zero matches for `max_documents`/`max_file_size`/`ResourceLimits`
+outside `state.rs` and `translator.rs`'s `default()` call sites).
+
+`ResourceLimits` already supports `0 = unlimited` for both fields internally
+(see doc comments on `max_documents`/`max_file_size`, state.rs:137-141, and
+the `> 0` guards in `open()`/`check_file_size()`) — the gap is purely that
+nothing in the config/CLI/env layer can set a non-default value.
+
+This matters because mcpls's stated purpose is bridging AI agent clients to
+LSP servers, and agentic sessions commonly touch far more than 100 distinct
+files over a session's lifetime (a broad refactor, a repo-wide audit, or
+simply a long-running session accumulating opens over hours). There is
+currently no way for an operator to raise this ceiling even if they know
+about it, and nothing in the README documents that the limit exists, so a
+user hitting it has no actionable remedy short of restarting the mcpls
+process to reset `DocumentTracker`'s open-document set.
+
+Secondary observation (context, not the primary ask): `RESOURCE_PAGE_SIZE =
+100` in `crates/mcpls-core/src/mcp/server.rs:50-57` is deliberately decoupled
+from `max_documents` per an existing code comment, but because
+`max_documents` currently hard-caps open documents at exactly the same value
+(100) and cannot be raised, the `resources/list` pagination path
+(`next_cursor`/second page) is effectively unreachable in the shipped
+product today. Confirmed live this cycle: opening 101-120 real documents
+against the default config, the 101st and beyond all failed with
+`DocumentLimitExceeded` before a second `resources/list` page could ever be
+produced. The spec below treats this as a "why it matters" data point, not a
+requirement to fix pagination itself.
+
+### Goal
+
+An operator can either (a) raise `max_documents`/`max_file_size` above their
+current hardcoded defaults through a documented, validated configuration
+surface, so long-running or broad-scope agent sessions don't hard-fail once
+they cross 100 distinct open files; or, if the limits are intentionally
+fixed, (b) discover the limit and its rationale from the README/config
+reference before hitting it blind. Exact surface (TOML field vs. CLI flag vs.
+both vs. docs-only) is `[NEEDS CLARIFICATION]` — see Section 9.
+
+### Out of Scope
+
+- Changing `RESOURCE_PAGE_SIZE` or `resources/list` pagination behavior
+  itself (noted only as a downstream symptom).
+- Automatic/dynamic eviction policies for `DocumentTracker` (e.g. LRU
+  eviction of stale documents) — this spec only concerns making the static
+  ceiling configurable/documented, not replacing it with a different
+  resource-management strategy.
+- Per-server or per-language resource limits — `ResourceLimits` is currently
+  a single global cap shared by the whole `DocumentTracker`; splitting it
+  per-server is not in scope unless the clarification in Section 9 resolves
+  that way.
+- Changing the default values (100 documents / 10MB) — this spec is about
+  making the ceiling *configurable and/or documented*, not about picking new
+  defaults.
+
+## 2. User Stories
+
+### US-001: Raise the document ceiling for a large workspace
+
+AS A developer running mcpls against a large monorepo or a long agent session
+I WANT to configure `max_documents` above 100
+SO THAT hover/definition/diagnostics/etc. keep working past the 100th
+distinct file opened in a session, without restarting mcpls
+
+**Acceptance criteria:**
+```
+GIVEN a TOML config (or CLI flag/env var, per the chosen surface) that sets
+  max_documents to 500
+WHEN mcpls starts and a client opens more than 100 distinct documents in one
+  session
+THEN document #101 through #500 are opened successfully instead of failing
+  with DocumentLimitExceeded
+```
+
+### US-002: Raise or remove the per-file size ceiling
+
+AS A developer working with a project that contains files larger than 10MB
+(e.g. generated code, data fixtures)
+I WANT to configure `max_file_size` (including setting it to unlimited)
+SO THAT opening those files for LSP-backed tools does not fail with
+FileSizeLimitExceeded
+
+**Acceptance criteria:**
+```
+GIVEN a TOML config (or equivalent surface) that sets max_file_size to 0
+  (unlimited) or to a value above 10MB
+WHEN a client requests a tool that opens a file larger than 10MB
+THEN the file opens successfully instead of failing with
+  FileSizeLimitExceeded
+```
+
+### US-003: Understand the limit when it is hit
+
+AS A developer or operator who has not customized resource limits
+I WANT the README/config reference to document that a document-count ceiling
+exists, its default value, and how (if possible) to raise it
+SO THAT hitting `DocumentLimitExceeded` mid-session is not a surprise with no
+actionable next step
+
+**Acceptance criteria:**
+```
+GIVEN the shipped README and/or config reference documentation
+WHEN a user searches for "document limit" or reads the config field
+  reference
+THEN they find the default value (100 documents / 10MB), an explanation of
+  what happens when it is hit, and the configuration knob (if one exists) or
+  an explicit statement that restarting mcpls is the only remedy
+```
+
+## 3. Functional Requirements
+
+Use EARS notation. Prefix with FR-NNN. Exact mechanism (TOML/CLI/env) is
+`[NEEDS CLARIFICATION]` (Section 9) — requirements below are written against
+whichever surface(s) the resolved design adopts.
+
+| ID | Requirement | Priority |
+|----|------------|----------|
+| FR-001 | WHEN mcpls loads its configuration THE SYSTEM SHALL allow `max_documents` to be set to a value other than the hardcoded default of 100, via at least one of: TOML field, CLI flag, environment variable | must |
+| FR-002 | WHEN mcpls loads its configuration THE SYSTEM SHALL allow `max_file_size` to be set to a value other than the hardcoded default of 10MB, via at least one of: TOML field, CLI flag, environment variable | must |
+| FR-003 | WHEN a configured `max_documents` or `max_file_size` value is provided THE SYSTEM SHALL validate it (e.g. reject nonsensical values) following the same validation pattern used for `request_timeout_seconds` in `crates/mcpls-core/src/config/mod.rs` (reject `0` only where `0` is not the documented "unlimited" sentinel; reject values that would defeat the purpose of the limit if a sane upper/lower bound is warranted) | must |
+| FR-004 | WHEN no explicit `max_documents`/`max_file_size` configuration is provided THE SYSTEM SHALL fall back to the current defaults (100 documents, 10MB) unchanged, preserving today's out-of-the-box behavior | must |
+| FR-005 | WHEN `DocumentTracker::open()` rejects a document because the configured `max_documents` is exceeded THE SYSTEM SHALL include, in the `Error::DocumentLimitExceeded` message or accompanying context, a hint that the ceiling is configurable (if FR-001 lands) or a pointer to documentation explaining the limit (if only documentation lands) | should |
+| FR-006 | WHEN the README or config reference documentation is generated/updated THE SYSTEM SHALL document `max_documents` and `max_file_size`: their defaults, what happens when exceeded, and how (if at all) to change them | must |
+| FR-007 | WHEN `ResourceLimits` is constructed anywhere in the codebase (`translator.rs:141, 249, 3280, 3295, 4095`, and any call site added since) THE SYSTEM SHALL source the values from the resolved configuration surface rather than calling `ResourceLimits::default()` unconditionally, except in test-only construction sites which may continue using `ResourceLimits::default()` for test isolation | must |
+
+## 4. Non-Functional Requirements
+
+| ID | Category | Requirement |
+|----|----------|-------------|
+| NFR-001 | Backward compatibility | Existing configs with no limits section/flags must continue to behave exactly as today (100 documents, 10MB, unchanged error messages except for the FR-005 hint addition) |
+| NFR-002 | Consistency | The new config surface must follow the existing pattern used for `request_timeout_seconds` (per-field TOML with `#[serde(default = "...")]`, validated in `ServerConfig::validate`) or `heuristics_max_depth` (workspace-level TOML field), whichever the resolved design location (Section 9) dictates |
+| NFR-003 | Safety | If `max_documents`/`max_file_size` are made unbounded-settable, the config validation should not silently accept obviously-unsafe values (e.g. `max_documents = 1`) that would break basic operation — mirrors the existing `MAX_TIMEOUT_SECONDS` upper-bound pattern in `crates/mcpls-core/src/config/server.rs` |
+| NFR-004 | Documentation | README changes must not use GitHub-specific callout syntax if the README is also published outside GitHub (per repository doc conventions) — confirm current README publishing target before adding callouts |
+
+## 5. Data Model
+
+| Entity | Description | Key Attributes |
+|--------|-------------|-----------------|
+| `ResourceLimits` (existing, `state.rs:135-150`) | In-memory struct passed to `DocumentTracker::new`, caps open-document count and per-file byte size | `max_documents: usize` (0 = unlimited), `max_file_size: u64` (0 = unlimited) |
+| Configurable limits surface (new, location TBD) | Wherever the resolved design places the user-facing knob — e.g. a new `[workspace.limits]` TOML table, new CLI flags/env vars, or both | Candidate fields: `max_documents`, `max_file_size`; must map 1:1 onto `ResourceLimits` |
+
+## 6. Edge Cases and Error Handling
+
+| Scenario | Expected Behavior |
+|----------|--------------------|
+| Config sets `max_documents = 0` | Interpreted as unlimited, per the existing `ResourceLimits` doc comment and the `> 0` guard already in `open()` — no code change needed there, only plumbing the value through |
+| Config sets `max_file_size = 0` | Interpreted as unlimited, same rationale as above via `check_file_size()`'s existing `> 0` guard |
+| Config sets a negative or non-numeric value (TOML) | Rejected at config load/validation time with a clear error message, consistent with how `request_timeout_seconds = 0` is currently rejected in `crates/mcpls-core/src/config/mod.rs` |
+| CLI flag and TOML both set the limit to different values (if both surfaces are chosen) | Follow existing precedence pattern in the codebase (CLI/env typically override TOML, mirroring `--config`/`MCPLS_CONFIG` precedence) — must be explicitly resolved and documented if both surfaces are implemented |
+| User raises `max_documents` very high (e.g. 100,000) on a memory-constrained host | Out of scope to auto-detect and warn; NFR-003 only requires rejecting values that are unsafely *low*, not capping unsafely *high* values, unless the resolved design decides otherwise |
+| `DocumentLimitExceeded` is hit even with limits raised (genuinely more open documents than the new ceiling) | Same error as today, but message references the *effective* configured value, not always "100" |
+
+## 7. Success Criteria
+
+| ID | Metric | Target |
+|----|--------|--------|
+| SC-001 | Reproduction from the finding (120 files, default config) | Continues to fail at file #101 with unchanged defaults — regression guard proving FR-004 holds |
+| SC-002 | Reproduction with `max_documents` raised (e.g. to 200) via the chosen surface | Files #101-120 succeed, no `DocumentLimitExceeded` |
+| SC-003 | `cargo nextest run --workspace --all-features` | New/updated tests for config parsing, validation, and `DocumentTracker` wiring pass |
+| SC-004 | README / config reference | Contains a documented entry for `max_documents`/`max_file_size` discoverable by grep for "max_documents" or "document limit" |
+
+## 8. Agent Boundaries
+
+### Always (without asking)
+- Run `cargo +nightly fmt --all`, `cargo clippy --all-targets --all-features --workspace -- -D warnings`, and `cargo nextest run --workspace --all-features --lib --bins` after implementation changes
+- Follow the existing `request_timeout_seconds`/`heuristics_max_depth` config patterns (serde defaults, `ServerConfig::validate` checks) rather than inventing a new mechanism
+- Preserve `ResourceLimits`'s existing `0 = unlimited` semantics without changing `open()`/`check_file_size()` guard logic
+- Update `CHANGELOG.md` under `[Unreleased]`
+
+### Ask First
+- Which config surface to implement (TOML-only, CLI-only, both, or docs-only) — this is the open `[NEEDS CLARIFICATION]` in Section 9 and materially changes the plan
+- Whether to add an upper bound to `max_documents`/`max_file_size` (NFR-003) and what that bound should be
+- Whether `max_documents`/`max_file_size` should live under a new `[workspace.limits]` TOML table vs. flattened into `[workspace]` directly vs. a new top-level table
+
+### Never
+- Silently change the default values (100 documents, 10MB) without an explicit `BREAKING CHANGE`/major-version decision from the user
+- Remove or weaken the `ResourceLimits` enforcement itself (e.g. defaulting to unlimited) without explicit instruction — this is a resource-safety mechanism, not dead code
+- Touch `RESOURCE_PAGE_SIZE`/`resources/list` pagination logic — explicitly out of scope per Section 1
+
+## 9. Open Questions
+
+- [NEEDS CLARIFICATION: Should `max_documents`/`max_file_size` be exposed via TOML config field(s), CLI flag(s), environment variable(s), some combination, or (if the limits are judged intentionally fixed) documentation-only with no configurability at all? The finding explicitly leaves this open as a design decision for whoever picks up the issue.]
+- [NEEDS CLARIFICATION: If TOML, does it belong under the existing `[workspace]` table (alongside `heuristics_max_depth`) or a new dedicated table, e.g. `[workspace.limits]`?]
+- [NEEDS CLARIFICATION: Should there be an enforced upper bound on `max_documents`/`max_file_size` (mirroring `MAX_TIMEOUT_SECONDS`'s pattern in `config/server.rs`), or is any positive value (plus `0` for unlimited) acceptable?]
+- [NEEDS CLARIFICATION: Is `ResourceLimits` intended to remain a single global cap, or should this work also consider per-server-config limits given `LspServerConfig` already carries per-server settings like `request_timeout_seconds`? Default assumption for this spec is global-only unless redirected.]
+
+## 10. See Also
+
+- [[constitution]] — project principles
+- [[MOC-specs]] — all specifications
+- `crates/mcpls-core/src/bridge/state.rs` — `DocumentTracker`, `ResourceLimits`, `Error::DocumentLimitExceeded`
+- `crates/mcpls-core/src/bridge/translator.rs` — all `ResourceLimits::default()` construction sites
+- `crates/mcpls-core/src/config/mod.rs` — `ServerConfig`, `WorkspaceConfig`, existing validation pattern for `request_timeout_seconds`
+- `crates/mcpls-core/src/config/server.rs` — `LspServerConfig`, `MAX_TIMEOUT_SECONDS` upper-bound validation pattern
+- `crates/mcpls-cli/src/args.rs` — existing CLI flag/env var pattern (`clap` + `env = "MCPLS_*"`)
+- `crates/mcpls-core/src/mcp/server.rs:50-57` — `RESOURCE_PAGE_SIZE`, decoupled-but-currently-coupled-in-practice pagination context

--- a/specs/config/001-config-discovery-and-heuristics/spec.md
+++ b/specs/config/001-config-discovery-and-heuristics/spec.md
@@ -1,0 +1,245 @@
+---
+aliases:
+  - Config discovery and project heuristics
+  - mcpls.toml loading tiers
+tags:
+  - sdd
+  - spec
+  - config
+created: 2026-08-05
+status: implemented
+related:
+  - "[[constitution]]"
+  - "[[mcp/001-mcp-tool-surface-and-routing/spec]]"
+  - "[[lsp/001-lsp-server-lifecycle-and-respawn/spec]]"
+  - "[[bridge/001-position-encoding-layer/spec]]"
+---
+
+# Feature: Configuration Loading, Multi-Tier Discovery, and Project-Marker Heuristics
+
+> [!info] Metadata
+> **Author**: retroactive spec, authored during the `.local/specs/` → `specs/` migration and gap
+> analysis (no single originating commit/PR — this documents already-shipped, working
+> functionality accreted across many PRs, several referenced by number in the source itself:
+> #267, #279, #285, #290/#291, #297, #309, #314, #315/#293/#324, #345, #348, #359, #165, #174)
+> **Type**: core subsystem
+> **Priority**: P1 (retroactive — reflects centrality, not an open defect)
+
+> [!success] Resolution
+> This is a retroactive spec: `crates/mcpls-core/src/config/mod.rs` and
+> `crates/mcpls-core/src/config/server.rs` already implement everything described below.
+> Representative evidence: `ServerConfig::load`/`load_with_trust`/`load_from` (config/mod.rs),
+> `ServerHeuristics::is_applicable_recursive` (config/server.rs), and the default 6-server /
+> ~30-extension built-in config (`ServerConfig::default`, `default_language_extensions`). No
+> single PR authored this end-to-end; it is the accretion of the config subsystem's entire
+> history, most recently including the untrusted-project-config model (#345/#348) and the bounded
+> config-file read (#309).
+
+## 1. Overview
+
+### Problem Statement
+
+mcpls needs to answer three independent questions before it can spawn any LSP server:
+
+1. **Where is the config?** A user may supply `$MCPLS_CONFIG`/`--config` explicitly, rely on an
+   auto-discovered project-local `./mcpls.toml`, fall back to a per-user config directory, or run
+   with no config file at all (built-in defaults, auto-created on first run).
+2. **Should a project-local config be trusted?** A `./mcpls.toml` discovered relative to the
+   process's *current working directory* can be planted by whoever controls a checked-out
+   repository — unlike an explicitly-named `--config`/`$MCPLS_CONFIG` path, naming which is itself
+   the user's consent. A malicious project-local config could redirect spawned commands
+   (`lsp_servers[].command`/`args`), redirect the effective workspace (`workspace.roots`), or drive
+   a filesystem-walk denial-of-service (`workspace.heuristics_max_depth`).
+3. **Which LSP servers actually apply to this workspace?** mcpls ships ~30 built-in file-extension
+   → language-ID mappings and 6 built-in server configs (rust-analyzer, pyright,
+   typescript-language-server, gopls, clangd, zls), each gated by project-marker heuristics
+   (`Cargo.toml` → rust-analyzer, `package.json` → typescript-language-server, etc.) so mcpls
+   doesn't attempt to spawn rust-analyzer inside a pure-Python repository.
+
+Getting any of these wrong has a real blast radius: an untrusted config trusted by default is a
+supply-chain / arbitrary-command-execution risk; an over-broad or too-narrow heuristic either
+spawns servers that will never successfully analyze anything, or fails to spawn a server the
+workspace actually needs.
+
+### Goal
+
+mcpls resolves its effective configuration deterministically across four tiers (explicit
+`$MCPLS_CONFIG`/`--config` → project-local `./mcpls.toml` (opt-in trust) → per-user config
+directory → built-in defaults), validates it before use, and applies project-marker heuristics
+(recursive, depth-bounded, exclusion-aware) to decide which of the configured LSP servers actually
+apply to a given workspace — all without requiring any config file to exist at all for a
+reasonable out-of-the-box experience.
+
+### Out of Scope
+
+- Per-tool routing once multiple servers are configured for one language — that is
+  [[mcp/001-mcp-tool-surface-and-routing/spec|spec mcp/001]]'s `ToolRouter`, a distinct, later-added layer
+  (#174) that consumes this spec's `LspServerConfig`/`ServerHeuristics` output.
+- `workspace.max_documents`/`max_file_size` (resource limits) — already covered by
+  [[bridge/005-expose-document-tracker-limits/spec|spec bridge/005]].
+- `workspace.position_encodings` negotiation itself — covered by
+  [[lsp/001-lsp-server-lifecycle-and-respawn/spec|spec lsp/001]] (`LspServer::spawn`) and
+  [[bridge/001-position-encoding-layer/spec|spec bridge/001]] (the conversion math); this spec covers only that
+  the field is loaded, validated, and defaulted.
+
+## 2. User Stories
+
+### US-001: Zero-config first run
+
+AS A new mcpls user with no `mcpls.toml` anywhere
+I WANT mcpls to start with sensible built-in defaults (6 popular language servers, ~30 extension
+mappings) and write a default config file to my user config directory
+SO THAT I get useful behavior immediately and have something to edit later
+
+**Acceptance criteria:**
+```
+GIVEN no mcpls.toml exists at $MCPLS_CONFIG, ./mcpls.toml, or the platform user-config path
+WHEN ServerConfig::load() runs
+THEN it returns the built-in default config AND writes that default config to the user-config
+     path for future edits (best-effort — a write failure logs a warning and still returns
+     in-memory defaults rather than failing startup)
+```
+
+### US-002: A checked-out repository does not silently execute an attacker-controlled command
+
+AS A developer opening someone else's repository that happens to contain a `./mcpls.toml`
+I WANT that project-local config ignored by default, with a clear warning naming the exact path
+and how to opt in
+SO THAT cloning and running mcpls against an unfamiliar repository cannot silently execute an
+arbitrary command that config names
+
+**Acceptance criteria:**
+```
+GIVEN a ./mcpls.toml exists in the current working directory
+  AND the caller has not passed --trust-project-config / MCPLS_TRUST_PROJECT_CONFIG=true
+WHEN ServerConfig::load() (equivalently load_with_trust(Untrusted)) runs
+THEN the project-local file is skipped entirely (including its [workspace] section), a warning
+     names the ignored path and the opt-in flag, and project_config_ignored is set to true so an
+     MCP client can also see the ignore decision in-band
+```
+
+### US-003: A monorepo only spawns the servers its subprojects actually need
+
+AS A developer working in a monorepo containing Rust, Python, and TypeScript subprojects
+I WANT each configured LSP server to spawn only if its project markers exist somewhere in the
+workspace tree (not just the root), while excluding well-known noise directories
+SO THAT mcpls doesn't waste resources spawning irrelevant servers, and doesn't miss a nested
+subproject's server because the marker isn't at the workspace root
+
+**Acceptance criteria:**
+```
+GIVEN a workspace root containing no Cargo.toml at the root but a nested packages/rust-lib/Cargo.toml
+WHEN LspServerConfig::should_spawn is evaluated for the rust-analyzer server config
+THEN it returns true (recursive marker search finds the nested Cargo.toml, up to
+     heuristics_max_depth)
+
+GIVEN a node_modules/some-package/package.json buried inside the workspace
+WHEN the typescript-language-server heuristic searches for package.json
+THEN node_modules is excluded from the search and this nested package.json does not trigger a
+     false-positive spawn
+```
+
+## 3. Functional Requirements
+
+| ID | Requirement | Priority |
+|----|------------|----------|
+| FR-001 | THE SYSTEM SHALL resolve configuration in this precedence order: (1) `$MCPLS_CONFIG` env var, always trusted; (2) project-local `./mcpls.toml`, trusted only if the caller opts in; (3) platform user-config directory (`~/.config/mcpls/mcpls.toml` or platform equivalent); (4) built-in defaults | must |
+| FR-002 | WHEN no config file exists at any tier THE SYSTEM SHALL return the built-in default `ServerConfig` and attempt to write it to the user-config path for future discovery, without failing startup if the write fails | must |
+| FR-003 | WHEN a project-local `./mcpls.toml` is found and trust is `Untrusted` (the default) THE SYSTEM SHALL skip it entirely (not partially — including `[workspace]`), log a warning naming the resolved path and the opt-in mechanism, and set `project_config_ignored: true` on the returned config | must |
+| FR-004 | WHEN a project-local `./mcpls.toml` is found and trust is `Trusted` THE SYSTEM SHALL load it via the same path/validation logic as an explicitly-named config | must |
+| FR-005 | THE SYSTEM SHALL bound every config-file read to `MAX_CONFIG_FILE_BYTES` (8 MiB) via a `Read::take`-bounded read, not a `metadata().len()` pre-check alone, since the latter is bypassable by character devices/FIFOs reporting `len() == 0` regardless of actual readable data | must |
+| FR-006 | THE SYSTEM SHALL validate every loaded (or caller-constructed) `ServerConfig` via `ServerConfig::validate()` before it is used by `serve`/`serve_with`, rejecting the first violated rule with a diagnosable `Error::InvalidConfig` | must |
+| FR-007 | THE SYSTEM SHALL resolve relative `workspace.roots` entries against the config file's own directory for an explicitly-named config (`load_from`'s default), but against the process's current working directory for the auto-discovered global/user config tier (since that tier is not tied to any particular project) | must |
+| FR-008 | THE SYSTEM SHALL provide 6 built-in `LspServerConfig`s (rust-analyzer, pyright, typescript-language-server, gopls, clangd, zls), each gated by `ServerHeuristics::project_markers` naming the files/directories that indicate that language's project type | must |
+| FR-009 | THE SYSTEM SHALL provide ~30 built-in file-extension → language-ID mappings (`default_language_extensions`), user-overridable/-extensible via `workspace.language_extensions` | must |
+| FR-010 | WHEN `ServerHeuristics::is_applicable_recursive` searches a workspace tree for project markers THE SYSTEM SHALL search recursively up to `heuristics_max_depth` (default 10), excluding well-known noise directories (`node_modules`, `target`, `.git`, `__pycache__`, `.venv`, `venv`, `.tox`, `.mypy_cache`, `.pytest_cache`, `build`, `dist`, `.cargo`, `.rustup`, `vendor`, `coverage`, `.next`, `.nuxt`) | must |
+| FR-011 | WHEN `ServerHeuristics::project_markers` is empty THE SYSTEM SHALL treat the server as always applicable (no heuristic gating) | must |
+| FR-012 | THE SYSTEM SHALL reject (`Error::InvalidConfig`) an empty `workspace.position_encodings` list, an unrecognized encoding string, an empty `workspace.roots` entry, an empty/duplicate-claiming server config (`language_id`, `command`, `handles`), and a `timeout_seconds`/`request_timeout_seconds` of `0` or above `MAX_TIMEOUT_SECONDS` (900s) | must |
+
+## 4. Non-Functional Requirements
+
+| ID | Category | Requirement |
+|----|----------|-------------|
+| NFR-001 | Security | A project-local `./mcpls.toml`'s trust decision must default to the safer option (`Untrusted`) — an opt-in, not opt-out, security posture, since it can redirect spawned commands and workspace roots |
+| NFR-002 | Security | A config file read must never be able to block indefinitely or exhaust memory regardless of what the path points at (regular file, special device, symlink to either) — enforced by the bounded read (FR-005), not a size pre-check alone |
+| NFR-003 | Robustness | Heuristic marker search must never descend into pathological directory trees (`node_modules`, build output, VCS internals) that could make a recursive walk prohibitively slow or effectively unbounded |
+| NFR-004 | Compatibility | A config file predating a newly-added field with a serde default (e.g. `request_timeout_seconds` added after `timeout_seconds`) must still load correctly, defaulting the new field rather than failing to parse |
+| NFR-005 | Diagnosability | Every `Error::InvalidConfig` message must name the specific field and value that failed validation, not a generic "invalid config" message |
+
+## 5. Data Model
+
+| Entity | Description | Key Attributes |
+|--------|-------------|-----------------|
+| `ServerConfig` | Top-level loaded configuration | `mcp: McpConfig`, `workspace: WorkspaceConfig`, `lsp_servers: Vec<LspServerConfig>`, `project_config_ignored: bool` (load-time metadata, not user-configurable) |
+| `WorkspaceConfig` | Workspace-scoped settings | `roots`, `position_encodings`, `language_extensions`, `heuristics_max_depth`, `max_documents`, `max_file_size` |
+| `LspServerConfig` | One configured LSP server | `language_id`, `command`, `args`, `env`, `file_patterns`, `initialization_options`, `timeout_seconds`, `request_timeout_seconds`, `heuristics: Option<ServerHeuristics>`, `name: Option<String>`, `handles: Option<Vec<ToolKind>>` |
+| `ServerHeuristics` | Project-marker gating for one server | `project_markers: Vec<String>` (empty = always applicable) |
+| `ProjectConfigTrust` | Trust decision for a CWD-discovered `./mcpls.toml` | `Untrusted` (default), `Trusted` (opt-in via `--trust-project-config`/`MCPLS_TRUST_PROJECT_CONFIG`) |
+
+## 6. Edge Cases and Error Handling
+
+| Scenario | Expected Behavior |
+|----------|--------------------|
+| `$MCPLS_CONFIG` points at a nonexistent path | `Error::ConfigNotFound` |
+| Config file larger than `MAX_CONFIG_FILE_BYTES` (8 MiB) | Rejected via `Error::FileSizeLimitExceeded` before the whole file is buffered, including for special files (e.g. `/dev/zero`) that report `metadata().len() == 0` |
+| Config file exactly at the 8 MiB boundary | Accepted — the boundary itself is not rejected |
+| Config file is not valid UTF-8 | `Error::InvalidConfig` naming the UTF-8 decode failure |
+| Project-local `./mcpls.toml` exists, trust untrusted | Skipped entirely, warning logged, `project_config_ignored: true`, falls through to the next tier |
+| Two `[[lsp_servers]]` entries share a `language_id` with no explicit `name` on either | Both resolve to the same default `ServerId` — caught later by `ToolRouter::from_configs` ([[mcp/001-mcp-tool-surface-and-routing/spec|spec mcp/001]]), not by `ServerConfig::validate` itself, since two servers legitimately sharing a language with mutually exclusive `heuristics` is valid until a workspace makes both applicable |
+| A relative `workspace.roots` entry in an explicitly-named config | Resolved against that config file's own directory, then canonicalized |
+| A relative `workspace.roots` entry in the auto-discovered global/user config | Resolved against the process's current working directory instead (not tied to a particular project) |
+| A workspace root that does not exist on disk | `Error::InvalidConfig` naming the missing root and the base directory it was resolved against |
+| `workspace.roots` entry is an empty string | Rejected explicitly (`Path::is_relative()` is `true` for an empty path and would otherwise silently resolve to the base directory unchanged) |
+| Project marker exists only inside `node_modules`/`target`/`.git`/etc. | Not found — these directories are excluded from the recursive walk entirely (not merely deprioritized) |
+| Project marker exists at a depth beyond `heuristics_max_depth` | Not found; increasing `heuristics_max_depth` (default 10) finds it |
+
+## 7. Success Criteria
+
+| ID | Metric | Target |
+|----|--------|--------|
+| SC-001 | `cargo nextest run -E 'package(mcpls-core) and test(config)'` | All existing config-loading, validation, and heuristics unit tests pass |
+| SC-002 | Zero-config startup (`ServerConfig::default()`) | Returns 6 built-in servers, ~30 extension mappings, valid per `ServerConfig::validate()` |
+| SC-003 | A monorepo integration scenario (Rust root + nested Python/TypeScript subprojects) | All three servers' heuristics correctly detect their respective nested markers |
+
+## 8. Agent Boundaries
+
+### Always (without asking)
+- Preserve the `Untrusted`-by-default trust posture for a CWD-discovered `./mcpls.toml` — this is
+  a deliberate security decision, not an oversight
+- Keep `EXCLUDED_DIRECTORIES` (config/server.rs) in sync with any new well-known
+  dependency/build-output directory convention that would otherwise cause false-positive or
+  pathologically slow heuristic searches
+- Run the config-loading and heuristics test suites after any change to `ServerConfig::validate`,
+  `ServerConfig::load_from`, or `ServerHeuristics`
+
+### Ask First
+- Adding a new configuration tier or changing tier precedence (FR-001)
+- Changing the default trust posture for project-local config (NFR-001) — this is a
+  security-relevant default, not a convenience setting
+
+### Never
+- Default a CWD-discovered `./mcpls.toml` to `Trusted` — this is the exact supply-chain risk
+  US-002 exists to prevent
+- Replace the bounded `Read::take` config-file read with a `metadata().len()` pre-check alone —
+  this reopens the special-file bypass FR-005/NFR-002 close (#309)
+
+## 9. Open Questions
+
+None — this is a retroactive spec documenting stable, already-shipped, well-tested behavior.
+
+## 10. See Also
+
+- [[constitution]] — project principles (not yet created for this project)
+- [[MOC-specs]] — all specifications
+- [[bridge/005-expose-document-tracker-limits/spec|spec bridge/005]] — `workspace.max_documents`/`max_file_size`,
+  fields on the same `WorkspaceConfig` this spec documents
+- [[bridge/001-position-encoding-layer/spec|spec bridge/001]] — the conversion math consuming
+  `workspace.position_encodings` once negotiated
+- [[lsp/001-lsp-server-lifecycle-and-respawn/spec|spec lsp/001]] — where `position_encodings` is actually
+  offered during the `initialize` handshake
+- [[mcp/001-mcp-tool-surface-and-routing/spec|spec mcp/001]] — `ToolRouter`, the later-added per-tool
+  routing layer built on top of this spec's `LspServerConfig`/`ServerId`
+- `crates/mcpls-core/src/config/mod.rs` — `ServerConfig`, `WorkspaceConfig`, `McpConfig`, loading
+  and validation
+- `crates/mcpls-core/src/config/server.rs` — `LspServerConfig`, `ServerHeuristics`, built-in server
+  defaults, `MAX_TIMEOUT_SECONDS`

--- a/specs/lsp/001-lsp-server-lifecycle-and-respawn/spec.md
+++ b/specs/lsp/001-lsp-server-lifecycle-and-respawn/spec.md
@@ -1,0 +1,259 @@
+---
+aliases:
+  - LSP server lifecycle
+  - Spawn, initialize, respawn, shutdown
+tags:
+  - sdd
+  - spec
+  - lsp
+created: 2026-08-05
+status: implemented
+related:
+  - "[[constitution]]"
+  - "[[bridge/002-document-tracker-synchronization/spec]]"
+  - "[[bridge/001-position-encoding-layer/spec]]"
+  - "[[runtime/002-sigterm-stdin-blocking-pool-hang/spec]]"
+---
+
+# Feature: LSP Server Process Lifecycle — Spawn, Initialize, Crash-Recovery Respawn, Shutdown
+
+> [!info] Metadata
+> **Author**: retroactive spec, authored during the `.local/specs/` → `specs/` migration and gap
+> analysis (no single originating commit/PR — this documents already-shipped, working
+> functionality; the crash-detection/respawn mechanism references #249 (`has_exited`) and #359
+> (respawn diagnostics-degradation flagging) in its own source comments, and the shutdown path is
+> the mechanism [[runtime/002-sigterm-stdin-blocking-pool-hang/spec|spec runtime/002]] fixed the *process-exit*
+> half of)
+> **Type**: core subsystem
+> **Priority**: P1 (retroactive — reflects centrality, not an open defect)
+
+> [!success] Resolution
+> This is a retroactive spec: `crates/mcpls-core/src/lsp/lifecycle.rs` (spawn/initialize/shutdown,
+> graceful degradation across multiple servers), `crates/mcpls-core/src/lsp/client.rs` (JSON-RPC
+> request/response with retry), `crates/mcpls-core/src/lsp/transport.rs` (stdio framing), and
+> `crates/mcpls-core/src/bridge/translator/respawn.rs` (dead-server detection and
+> backoff-bounded respawn) already implement everything described below.
+
+## 1. Overview
+
+### Problem Statement
+
+mcpls bridges an AI client to potentially several LSP servers running as child processes
+(rust-analyzer, pyright, etc.), each an independent, fallible subprocess that must be:
+
+1. **Spawned** with a sanitized environment (the child's environment is cleared, then only an
+   explicit allowlist plus user-configured overrides are passed through — the LSP server does not
+   inherit mcpls's full process environment, which could otherwise leak secrets the server has no
+   need to see).
+2. **Initialized** via the LSP handshake (`initialize` → capability negotiation, including position
+   encoding — see [[bridge/001-position-encoding-layer/spec|spec bridge/001]] — → `initialized`), with one
+   server's failure not blocking the others (**graceful degradation**: `spawn_batch` attempts every
+   configured server in sequence and returns both the servers that succeeded and the failures for
+   the ones that didn't, rather than failing all-or-nothing).
+3. **Monitored for crashes** during normal operation, since a language server can die at any time
+   (OOM, a bug in the server itself, a signal from the OS). A crashed server must be distinguished
+   from "still initializing" or "never configured," and a crash-looping server must not consume a
+   full `timeout_seconds` of latency on every single subsequent tool call.
+4. **Shut down gracefully** on mcpls's own exit (`shutdown` request → `exit` notification → wait
+   for the child to exit on its own → `kill_on_drop` as a last resort), so LSP child processes are
+   never orphaned.
+
+Each of the four phases has its own genuine failure modes (a broken `PATH`, a slow `initialize`
+against a large workspace, a server that crashes mid-session, a child that ignores `exit` and must
+be killed), and getting any of them wrong either orphans processes, cascades one server's failure
+into an outage for every language, or makes crash recovery itself a performance hazard.
+
+### Goal
+
+mcpls spawns, initializes, monitors, transparently respawns, and gracefully shuts down every
+configured LSP server such that (a) one server's spawn/initialize failure never prevents any other
+configured server from running; (b) a server that crashes mid-session is detected and
+transparently replaced before the next tool call that needs it, without the caller needing to know
+a respawn happened; (c) a crash-looping server backs off exponentially rather than eating a full
+timeout on every tool call; and (d) every spawned child process is terminated (gracefully or via
+`kill_on_drop`) when mcpls exits, with no orphans.
+
+### Out of Scope
+
+- Position-encoding conversion math itself — [[bridge/001-position-encoding-layer/spec|spec bridge/001]].
+- Which server handles which tool once several are configured for one language —
+  [[mcp/001-mcp-tool-surface-and-routing/spec|spec mcp/001]]'s `ToolRouter`.
+- The OS-process-level SIGTERM/SIGINT handling that makes the whole mcpls *process* exit promptly
+  — already covered by [[runtime/002-sigterm-stdin-blocking-pool-hang/spec|spec runtime/002]]; this spec covers
+  the LSP *child* process shutdown sequence that fix's `Translator::shutdown_servers` step
+  triggers, not the parent process's own exit mechanics.
+- Reconnecting live diagnostics push notifications for a respawned server to the original
+  notification pump — explicitly out of scope per `respawn_if_dead`'s own doc comment (the pump's
+  remaining dependencies live outside `Translator`'s scope); a respawned diagnostics-route server's
+  degraded-push state is only surfaced (via `NotificationCache::mark_push_degraded`), not repaired,
+  until the whole mcpls process restarts.
+
+## 2. User Stories
+
+### US-001: One misconfigured server doesn't take down every language
+
+AS A developer with a monorepo configuring 6 LSP servers, one of which has a typo'd command path
+I WANT the other 5 servers to spawn and initialize normally
+SO THAT a single misconfiguration doesn't make every language's tools unavailable
+
+**Acceptance criteria:**
+```
+GIVEN 6 configured LSP servers, one with a nonexistent command
+WHEN LspServer::spawn_batch runs
+THEN the result has_servers() is true, partial_success() is true, and the 5 valid servers are
+     usable for their respective languages while the failed one is reported in `failures`
+```
+
+### US-002: A crashed language server is transparently replaced
+
+AS AN AI agent mid-session when rust-analyzer crashes
+I WANT my next tool call to transparently succeed against a freshly respawned rust-analyzer
+instead of failing outright
+SO THAT a single server crash doesn't end my whole session
+
+**Acceptance criteria:**
+```
+GIVEN a registered LSP server whose child process has exited unexpectedly
+WHEN the next tool call routes to that server
+THEN Translator::respawn_if_dead detects the death, respawns and re-initializes the server, and
+     the tool call proceeds against the new instance transparently
+```
+
+### US-003: A crash-looping server backs off instead of stalling every request
+
+AS A mcpls operator whose configured LSP server keeps crashing immediately after each respawn
+(e.g. a persistent misconfiguration)
+I WANT each subsequent respawn attempt to back off exponentially rather than retrying (and
+timing out) on every single tool call
+SO THAT a crash-looping server doesn't make every tool call for that language slow
+
+**Acceptance criteria:**
+```
+GIVEN a server that has failed 3 consecutive respawn attempts
+WHEN a 4th tool call arrives for that server within the current backoff window
+THEN respawn_if_dead returns Error::ServerUnavailable immediately (naming the remaining backoff
+     duration) rather than attempting another spawn and waiting for it to fail/timeout
+```
+
+### US-004: No orphaned LSP child processes after mcpls exits
+
+AS A mcpls operator
+I WANT every spawned LSP child process (rust-analyzer, pyright, etc.) to be terminated when mcpls
+shuts down, whether gracefully or forcibly
+SO THAT restarting/redeploying mcpls never leaves orphaned language-server processes consuming
+resources
+
+**Acceptance criteria:**
+```
+GIVEN a running LSP server child process
+WHEN LspServer::shutdown is called
+THEN it sends `shutdown`+`exit`, waits up to a fixed grace period for the child to exit on its
+     own, and falls back to kill_on_drop (SIGKILL) if it hasn't -- in every case, the child
+     process is gone by the time shutdown returns
+```
+
+## 3. Functional Requirements
+
+| ID | Requirement | Priority |
+|----|------------|----------|
+| FR-001 | WHEN spawning an LSP server child process THE SYSTEM SHALL clear the child's environment and pass through only an explicit allowlist (`PATH`, `HOME`/`USERPROFILE`, `TMPDIR`/`TEMP`/`TMP`, plus Windows-specific additions under `cfg(windows)`), then apply the server's configured `env` overrides last | must |
+| FR-002 | THE SYSTEM SHALL perform the `initialize` → capability-negotiation → `initialized` handshake for each server, using the server's configured `timeout_seconds` (clamped to `[1, MAX_TIMEOUT_SECONDS]`) as the handshake timeout | must |
+| FR-003 | WHEN spawning multiple configured servers (`spawn_batch`) THE SYSTEM SHALL attempt every server regardless of earlier failures and return both the successfully-initialized servers and a list of failures, never failing all-or-nothing | must |
+| FR-004 | THE SYSTEM SHALL expose `has_exited()` (non-blocking `try_wait`) so callers can detect a crashed child process without blocking on it | must |
+| FR-005 | WHEN a tool call routes to a server whose child process has exited THE SYSTEM SHALL respawn and re-initialize it before the request proceeds, transparently to the caller | must |
+| FR-006 | WHEN two concurrent tool calls both route to the same dead server THE SYSTEM SHALL single-flight the respawn (via a per-server lock) so only one respawn attempt is made; the other caller waits for it and rechecks rather than racing a second, redundant spawn | must |
+| FR-007 | WHEN a respawn attempt fails THE SYSTEM SHALL record it and apply exponential backoff (base 1s, doubling per consecutive failure, capped at 30s) before permitting another respawn attempt for that server | must |
+| FR-008 | WHEN a respawn attempt succeeds but the server dies again before surviving at least the backoff base duration THE SYSTEM SHALL count this as a failure (extending the backoff), rather than treating "successfully re-initialized" as proof of stability | must |
+| FR-009 | WHEN a server is respawned THE SYSTEM SHALL clear that server's document-sync history in `DocumentTracker` (see [[bridge/002-document-tracker-synchronization/spec|spec bridge/002]]), since the new process has no memory of any document the old one had open, and must receive `didOpen` (not `didChange`) for every document going forward | must |
+| FR-010 | WHEN the diagnostics-route server for a language is respawned THE SYSTEM SHALL mark that language's cached diagnostics as push-degraded (`NotificationCache::mark_push_degraded`) rather than silently continuing to serve stale cached diagnostics as current | must |
+| FR-011 | WHEN shutting down a server THE SYSTEM SHALL send the LSP `shutdown` request, then the `exit` notification, then wait up to a fixed grace period (3s) for the child process to exit on its own, falling back to `kill_on_drop` (SIGKILL on drop) if it does not | must |
+| FR-012 | THE SYSTEM SHALL perform the graceful-shutdown sequence (FR-011) even if the `shutdown`/`exit` handshake itself fails or times out — the child process must still be torn down (killed if necessary) regardless of handshake outcome | must |
+
+## 4. Non-Functional Requirements
+
+| ID | Category | Requirement |
+|----|----------|-------------|
+| NFR-001 | Resilience | No single server's spawn/initialize failure may prevent any other configured server from becoming available (graceful degradation, FR-003) |
+| NFR-002 | Performance | A crash-looping server must not cost more than the bounded backoff window per tool call once backed off — never a repeated full `timeout_seconds` wait per call (FR-007) |
+| NFR-003 | Security | A spawned LSP server must not inherit mcpls's full process environment by default — only the explicit allowlist plus configured overrides (FR-001); configured `env` keys/values are never logged, only an allowlist-presence count and an override count (secret-bearing env var names like `AWS_SECRET_ACCESS_KEY` must not leak via debug logs) |
+| NFR-004 | Correctness | A respawned server must never be treated as having synced state (open documents) it never actually saw (FR-009) |
+| NFR-005 | Observability | A respawn (successful or failed), a crash-loop backoff, and a diagnostics-degradation event must each be logged (`tracing::warn!`) with enough context (server id, language, backoff duration) to diagnose from logs alone |
+
+## 5. Data Model
+
+| Entity | Description | Key Attributes |
+|--------|-------------|-----------------|
+| `LspServer` | One managed, initialized LSP server instance | `client: LspClient`, `capabilities: ServerCapabilities`, `position_encoding: PositionEncodingKind`, `notification_rx`, `child: tokio::process::Child` |
+| `ServerInitConfig` | Everything needed to spawn+initialize one server | `server_config`, `workspace_roots`, `initialization_options`, `position_encodings`, `notification_tx` |
+| `ServerInitResult` | Outcome of `spawn_batch` across all configured servers | `servers: HashMap<ServerId, LspServer>`, `failures: Vec<ServerSpawnFailure>` |
+| `ServerState` | Coarse lifecycle state of a server connection | `Uninitialized`, `Initializing`, `Ready`, `ShuttingDown`, `Shutdown` |
+| `RespawnBackoff` (translator-internal) | Per-server respawn-attempt bookkeeping | `consecutive_failures: u32`, `last_attempt: Instant`, `last_attempt_succeeded: bool` |
+
+## 6. Edge Cases and Error Handling
+
+| Scenario | Expected Behavior |
+|----------|--------------------|
+| A server's command is not on `PATH` | `spawn` returns `Error::ServerSpawnFailed`; `spawn_batch` records it as a failure and continues with the rest |
+| A large workspace makes `initialize` slow | Bounded by the server's configured `timeout_seconds` (clamped to `MAX_TIMEOUT_SECONDS`), not a hardcoded 30s |
+| Server crashes between two tool calls | First call after the crash detects it via `has_exited`, respawns, and proceeds; the crash is otherwise invisible to the caller beyond added latency |
+| Two tool calls race a dead-server detection simultaneously | Single-flighted via `respawn_lock`; the loser waits for the winner's attempt and rechecks rather than double-spawning |
+| Server respawns successfully but crashes again within 1s | Counted as a failure (not a fresh, unbacked-off start), extending `consecutive_failures` |
+| Server proves stable (survives ≥1s after a successful respawn) | Backoff state cleared entirely; a later unrelated crash starts a fresh backoff sequence |
+| `shutdown`/`exit` handshake itself fails or times out | Child process is still torn down (gracefully within the grace period, or killed) regardless; the handshake error is still returned to the caller after teardown completes |
+| Child does not exit within the grace period after `exit` | `kill_on_drop` (SIGKILL) fires when the `Child` handle drops |
+| A respawned server is the diagnostics-route server for its language | That language's cached diagnostics are marked push-degraded; a healthy sibling server's own language's diagnostics are unaffected (scoped by per-server ownership, not a blanket cache clear) |
+| A respawned server is *not* the diagnostics-route server | No diagnostics-cache side effect — only document-sync history (FR-009) is cleared |
+
+## 7. Success Criteria
+
+| ID | Metric | Target |
+|----|--------|--------|
+| SC-001 | `cargo nextest run -E 'package(mcpls-core) and (test(lifecycle) or test(respawn))'` | All existing spawn/initialize/shutdown/respawn unit tests pass |
+| SC-002 | `spawn_batch` with N configured servers, M of which are invalid | `has_servers()` true iff N-M > 0; `partial_success()` true iff both 0 < (N-M) and M > 0 |
+| SC-003 | Live repro: kill a spawned rust-analyzer mid-session, issue a hover call for a Rust file | Call succeeds against a freshly respawned rust-analyzer, no error surfaced to the MCP caller |
+| SC-004 | Live repro: repeatedly kill a server immediately after each respawn | Respawn attempts space out exponentially (1s, 2s, 4s, ... capped at 30s), not immediately retried each time |
+
+## 8. Agent Boundaries
+
+### Always (without asking)
+- Preserve graceful degradation in `spawn_batch` — never make one server's failure abort the whole
+  batch
+- Preserve the exponential-backoff respawn policy exactly (base 1s, cap 30s) unless explicitly
+  asked to change it
+- Keep the diagnostics-degradation flag (FR-010) scoped to the diagnostics-route server only,
+  never clearing a healthy sibling server's cache entries
+
+### Ask First
+- Reconnecting a respawned server's push notifications to a live pump (currently explicitly out
+  of scope; doing so would need to solve the pump's-dependencies-live-elsewhere problem noted in
+  `respawn_if_dead`'s doc comment)
+- Changing the child-exit grace period (3s) or the backoff base/cap constants
+
+### Never
+- Let a respawn attempt for one server block or fail tool calls routed to a different, healthy
+  server
+- Skip the graceful `shutdown`/`exit` handshake attempt before falling back to `kill_on_drop` —
+  the handshake gives well-behaved servers a chance to flush/clean up even though the fallback
+  guarantees termination either way
+
+## 9. Open Questions
+
+None — this is a retroactive spec documenting stable, already-shipped, well-tested behavior.
+
+## 10. See Also
+
+- [[constitution]] — project principles (not yet created for this project)
+- [[MOC-specs]] — all specifications
+- [[runtime/002-sigterm-stdin-blocking-pool-hang/spec|spec runtime/002]] — the OS-process-exit half of shutdown
+  this spec's `Translator::shutdown_servers`/`LspServer::shutdown` step feeds into
+- [[bridge/001-position-encoding-layer/spec|spec bridge/001]] — the conversion math for the `PositionEncodingKind`
+  negotiated during this spec's `initialize` handshake
+- [[config/001-config-discovery-and-heuristics/spec|spec config/001]] — `LspServerConfig`/`ServerHeuristics`,
+  the configuration this spec's `spawn`/`spawn_batch` consume
+- [[bridge/002-document-tracker-synchronization/spec|spec bridge/002]] — `DocumentTracker::forget_server`,
+  invoked on respawn per FR-009
+- `crates/mcpls-core/src/lsp/lifecycle.rs` — `LspServer::spawn`/`spawn_batch`/`shutdown`,
+  `ServerInitConfig`, `ServerInitResult`
+- `crates/mcpls-core/src/lsp/client.rs` — `LspClient` JSON-RPC request/response, retry-on-cancel
+- `crates/mcpls-core/src/lsp/transport.rs` — stdio header-content framing
+- `crates/mcpls-core/src/bridge/translator/respawn.rs` — `respawn_if_dead`, `RespawnBackoff`

--- a/specs/lsp/002-lsp317-missing-tools/spec.md
+++ b/specs/lsp/002-lsp317-missing-tools/spec.md
@@ -1,0 +1,61 @@
+# Spec lsp/002: Add Missing LSP 3.17 Tools (Inlay Hints, Type Hierarchy, Signature Help)
+
+**Type**: enhancement
+**Priority**: P3
+**Status**: draft
+
+## Problem Statement
+
+mcpls exposes 16 MCP tools covering the core LSP surface. However, LSP 3.17 introduced several
+capabilities that are absent from mcpls and present in reference/competing implementations:
+
+| LSP Feature | LSP spec version | In mcpls? | In isaacphi/mcp-language-server? | In Tritlo/lsp-mcp? |
+|------------|----------------|-----------|----------------------------------|---------------------|
+| Inlay hints (`textDocument/inlayHint`) | 3.17 | No | No | No |
+| Type hierarchy (`textDocument/prepareTypeHierarchy`) | 3.17 | No | No | No |
+| Signature help (`textDocument/signatureHelp`) | 3.15 | No | No | No |
+| Go to implementation (`textDocument/implementation`) | 3.6 | No | No | No |
+| Go to type definition (`textDocument/typeDefinition`) | 3.6 | No | No | No |
+| Selection range (`textDocument/selectionRange`) | 3.15 | No | No | No |
+
+The highest-value missing capabilities for AI code navigation are:
+1. **Signature help** — method parameter hints; highly useful when AI is generating call sites
+2. **Go to implementation** — navigate from interface/trait to concrete implementations
+3. **Type hierarchy** — navigate supertype/subtype chains
+4. **Inlay hints** — inline type annotations; improves AI's ability to understand code without
+   asking for hover on every symbol
+
+These are not mere niceties: `get_signature_help` and `go_to_implementation` are explicitly
+requested by users of similar tools (see isaacphi/mcp-language-server issues).
+
+## User Stories
+
+- As an AI agent writing Rust code, I want `get_signature_help` to understand function parameter
+  types without hovering each symbol individually.
+- As an AI agent exploring a Rust codebase, I want `go_to_implementation` to find which structs
+  implement a given trait.
+- As an AI agent reviewing code, I want `get_inlay_hints` to see inferred types inline.
+
+## Functional Requirements
+
+1. Add `get_signature_help` tool — takes file_path, line, character; returns parameter labels,
+   documentation, and active parameter index.
+2. Add `go_to_implementation` tool — takes file_path, line, character; returns list of
+   implementation locations.
+3. Add `get_inlay_hints` tool — takes file_path, start_line, end_line; returns list of hint
+   labels with positions.
+4. Add `go_to_type_definition` tool — takes file_path, line, character; returns type definition
+   location.
+5. `lsp-types` 0.97 already has all required request/response types for these.
+
+## Non-Functional Requirements
+
+- Tools must follow existing 1-based position convention.
+- Each new tool needs unit tests (params serialization) and integration test stubs.
+- Graceful degradation: if the LSP server doesn't support a capability, return empty result.
+
+## See Also
+
+- LSP 3.17 spec: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/
+- lsp-types 0.97: https://docs.rs/lsp-types/0.97.0/lsp_types/
+- Existing tool pattern: `crates/mcpls-core/src/mcp/server.rs`, `crates/mcpls-core/src/bridge/translator.rs`

--- a/specs/lsp/003-lsp-types-unmaintained-migration/spec.md
+++ b/specs/lsp/003-lsp-types-unmaintained-migration/spec.md
@@ -1,0 +1,230 @@
+---
+aliases:
+  - lsp-types unmaintained
+  - ls-types migration research
+tags:
+  - sdd
+  - spec
+  - research
+  - dependency-health
+  - lsp
+created: 2026-08-05
+status: draft
+related:
+  - "[[constitution]]"
+  - "[[bridge/001-position-encoding-layer/spec]]"
+---
+
+# Feature: Migrate off unmaintained `lsp-types` (gluon-lang) to the maintained `ls-types` fork
+
+> [!info] Metadata
+> **Author**: rust-researcher (filed from dependency-health research cycle)
+> **Branch**: n/a (research spec — no implementation branch yet)
+> **Type**: research / dependency-health
+> **Priority**: P2
+
+> [!abstract]
+> This is a research spec. It documents a supply-chain risk (stale upstream
+> dependency) and the case for migrating to a maintained fork. It intentionally
+> does NOT prescribe a step-by-step migration plan — that belongs in a future
+> `/sdd plan` once the decision to migrate is confirmed and the API diff is known.
+
+## 1. Overview
+
+### Problem Statement
+
+mcpls's workspace `Cargo.toml` pins `lsp-types = "0.97"` (resolved `0.97.0` in
+`Cargo.lock`), sourced from [gluon-lang/lsp-types](https://github.com/gluon-lang/lsp-types)
+on crates.io. This crate underlies mcpls's entire LSP type modeling: the
+critical position-encoding path (`crates/mcpls-core/src/bridge/encoding.rs`)
+and all LSP request/response types across `crates/mcpls-core/src/lsp/` and
+`crates/mcpls-core/src/bridge/`.
+
+Verified via `gh api repos/gluon-lang/lsp-types`:
+- Repository is not archived, but shows no recent maintenance activity
+- Last commit: `2024-06-04T12:38:24Z` (over 2 years stale as of 2026-08-05)
+- 46 open issues, no indication of active triage
+
+The Rust LSP ecosystem has already moved on. `tower-lsp-community/tower-lsp-server`
+— itself listed as mcpls's own reference project in
+`.claude/rules/continuous-improvement.md` — switched its LSP types dependency
+in release [v0.23.0](https://github.com/tower-lsp-community/tower-lsp-server/releases/tag/v0.23.0)
+(published 2025-12-07) from `gluon-lang/lsp-types` to
+[tower-lsp-community/ls-types](https://github.com/tower-lsp-community/ls-types),
+a fork created 2025-06-04. Their release notes state verbatim:
+
+> [!quote]
+> "Change the LSP specification types library from `gluon-lang/lsp-types`
+> (which was unmaintained) to `tower-lsp-community/ls-types` (our fork)."
+
+`ls-types`'s README states it supports LSP 3.17 stable, plus LSP 3.18 draft
+features behind a `proposed` feature flag. Migrating would therefore also open
+a path to LSP 3.18 feature adoption (inline completions, folding range
+refresh, multi-range formatting, nullable `SignatureHelp.activeParameter`,
+workspace edit snippets, etc.) — features `gluon-lang/lsp-types` is very
+unlikely to ever receive given its inactivity.
+
+This is a supply-chain health / dependency-risk finding, not an active
+security advisory: `cargo deny check advisories` reported clean, and no
+RUSTSEC entry exists yet for `lsp-types`.
+
+### Goal
+
+mcpls's core LSP-type dependency tracks an actively maintained upstream, so
+that LSP 3.18 spec changes, bugfixes, and typo/documentation corrections
+continue to land without mcpls having to vendor or patch a dead dependency
+itself.
+
+### Out of Scope
+
+> [!danger] Explicit exclusions
+> - The actual migration implementation (code changes, `Cargo.toml` edit,
+>   `Cargo.lock` update) — this spec captures the *decision case*, not the
+>   *how*. A follow-up `/sdd plan` should own the migration mechanics.
+> - A full symbol-by-symbol API diff between `lsp-types 0.97` and `ls-types`
+>   current release — not yet performed (see Open Questions).
+> - Adoption of LSP 3.18 `proposed`-flagged features themselves — that is a
+>   separate feature decision gated on this migration, not part of it.
+> - Evaluating alternative LSP-types crates beyond `ls-types` (e.g. writing
+>   an in-house minimal type set) — `ls-types` is the ecosystem's de facto
+>   successor and the only fork evaluated here.
+
+## 2. User Stories
+
+### US-001: Maintainer avoids stale-dependency risk
+AS A mcpls maintainer
+I WANT the project's core LSP type dependency to come from an actively
+maintained upstream
+SO THAT critical-path code (position encoding, request/response modeling)
+is not built on a crate that will never receive further fixes, spec
+corrections, or security patches
+
+**Acceptance criteria:**
+```
+GIVEN a future LSP 3.18 spec correction or bugfix lands in ls-types
+WHEN mcpls depends on ls-types instead of gluon-lang/lsp-types
+THEN mcpls can pull in that fix via a routine dependency bump
+
+GIVEN gluon-lang/lsp-types remains uncommitted-to for another year
+WHEN this finding is reviewed at that time
+THEN the migration decision documented here is either already resolved
+     or explicitly re-affirmed as still pending
+```
+
+### US-002: Contributor evaluates migration feasibility before committing to it
+AS A mcpls contributor considering the migration
+I WANT a documented API-compatibility risk assessment (not just "it's a fork
+so it's fine")
+SO THAT the migration is not scheduled as a "trivial drop-in swap" without
+verifying actual surface compatibility with mcpls's usage of `lsp-types`
+across `crates/mcpls-core/src/lsp/` and `crates/mcpls-core/src/bridge/`
+
+**Acceptance criteria:**
+```
+GIVEN this spec is read by someone about to start the migration
+WHEN they check the Non-Functional Requirements and Open Questions sections
+THEN they find an explicit call to diff the two crates' public APIs before
+     writing any migration code, rather than assuming zero breakage
+```
+
+### US-003: End user benefits from eventual LSP 3.18 support
+AS A user of an AI client that talks to mcpls
+I WANT mcpls to be able to eventually support newer LSP 3.18 capabilities
+(inline completions, folding range refresh, multi-range formatting, nullable
+`SignatureHelp.activeParameter`, workspace edit snippets)
+SO THAT mcpls does not fall permanently behind the LSP servers it bridges to
+(e.g. rust-analyzer, pyright) as they adopt newer protocol features
+
+**Acceptance criteria:**
+```
+GIVEN mcpls has migrated to ls-types
+WHEN a future feature spec proposes adopting an LSP 3.18 capability
+THEN the underlying types already exist behind ls-types's `proposed` feature
+     flag, removing "no available Rust types" as a blocker
+```
+
+## 3. Functional Requirements
+
+Use EARS notation. Prefix with FR-NNN. Since this is a research finding
+rather than a feature under active development, these requirements describe
+the target state the project SHOULD move toward, not code to write today.
+
+| ID | Requirement | Priority |
+|----|------------|----------|
+| FR-001 | THE SYSTEM SHOULD depend on an actively maintained LSP-types crate (commits and issue triage within the last 12 months) rather than one with 2+ years of upstream inactivity | should |
+| FR-002 | WHEN the migration from `lsp-types` to `ls-types` is undertaken THE SYSTEM SHALL preserve all existing LSP request/response behavior with no regression in `crates/mcpls-core/src/bridge/encoding.rs` position-encoding logic | must |
+| FR-003 | WHEN the migration from `lsp-types` to `ls-types` is undertaken THE SYSTEM SHALL pass the full existing test suite (`cargo nextest run --workspace --all-features`) without behavioral changes attributable to the type-library swap alone | must |
+| FR-004 | WHERE `ls-types` exposes LSP 3.18 `proposed` features behind a feature flag THE SYSTEM SHALL NOT enable that feature flag as part of this migration — 3.18 feature adoption is a separate decision | must |
+| FR-005 | THE SYSTEM SHOULD re-evaluate this finding periodically (e.g. each continuous-improvement research cycle) until either the migration is completed or a documented decision is made to stay on `gluon-lang/lsp-types` | should |
+
+## 4. Non-Functional Requirements
+
+| ID | Category | Requirement |
+|----|----------|-------------|
+| NFR-001 | Compatibility | `ls-types` is a fork of `gluon-lang/lsp-types`, so its public API surface is expected to be near drop-in, but this has **not** been verified for mcpls's specific usage — a symbol-level diff of types/traits consumed in `crates/mcpls-core/src/lsp/` and `crates/mcpls-core/src/bridge/` must be performed before migration work starts |
+| NFR-002 | Maintainability | Migrating to a crate with active issue triage reduces the maintenance burden of working around unfixed upstream bugs (e.g. any of the 46 open `gluon-lang/lsp-types` issues that affect mcpls) |
+| NFR-003 | Risk (supply chain) | This is not a security advisory (`cargo deny check advisories` is clean, no RUSTSEC entry exists) — the risk is *future* unpatched issues, not a known current vulnerability. Migration urgency should be assessed as P2 (suboptimal, not broken) accordingly |
+| NFR-004 | Extensibility | Adopting `ls-types` is a prerequisite enabler for future LSP 3.18 feature work, not a requirement to adopt those features immediately |
+| NFR-005 | Verification | Before switching, `cargo tree` and a build against `ls-types` should confirm no transitive version conflicts with other workspace dependencies (e.g. `rmcp`, `tower-lsp`-adjacent crates if any) |
+
+## 5. Data Model
+
+No new domain entities — this finding concerns a dependency swap of shared
+type definitions used throughout the bridge layer, not new business data.
+
+| Entity | Description | Key Attributes |
+|--------|-------------|----------------|
+| `lsp-types` crate (current) | Upstream source of all LSP protocol types used by mcpls | v0.97.0, from `gluon-lang/lsp-types`, last commit 2024-06-04 |
+| `ls-types` crate (proposed) | Maintained fork intended as replacement | Created 2025-06-04 by `tower-lsp-community`; supports LSP 3.17 stable + LSP 3.18 draft behind `proposed` feature flag |
+
+## 6. Edge Cases and Error Handling
+
+| Scenario | Expected Behavior |
+|----------|-------------------|
+| `ls-types` public API diverges from `lsp-types` in a type/trait mcpls depends on | Migration plan (future `/sdd plan`) must enumerate and resolve each divergence before merge — not discovered mid-migration |
+| `ls-types` version resolution conflicts with another workspace dependency | Caught by `cargo tree` / `cargo build` during migration; not expected to occur per NFR-005 but must be checked, not assumed away |
+| `gluon-lang/lsp-types` resumes active maintenance before migration starts | Re-evaluate whether migration is still warranted; document the reversal in this spec's Open Questions rather than proceeding on stale premises |
+| `ls-types` itself becomes unmaintained in the future | Out of scope for this finding, but the periodic re-evaluation in FR-005 would surface it |
+
+## 7. Success Criteria
+
+Since this is a research spec, success criteria describe the research
+outcome, not implementation completion.
+
+| ID | Metric | Target |
+|----|--------|--------|
+| SC-001 | Decision recorded: migrate, defer, or reject | Documented in this spec's status or a follow-up decision note before the next continuous-improvement cycle closes this finding |
+| SC-002 | If migration is approved, a `/sdd plan` exists covering the API diff and concrete migration steps | Plan created and linked from this spec before any `Cargo.toml` change is made |
+| SC-003 | No source code, `Cargo.toml`, or `Cargo.lock` changes result from this spec alone | Verified — this spec is research-only by design |
+
+## 8. Agent Boundaries
+
+### Always (without asking)
+- Treat this spec as research/documentation only — do not modify `Cargo.toml`, `Cargo.lock`, or any source file as part of fulfilling this spec
+- Re-check `gluon-lang/lsp-types` activity (`gh api repos/gluon-lang/lsp-types --jq '.pushed_at,.open_issues_count'`) if this finding is revisited in a future cycle, to confirm the premise still holds
+
+### Ask First
+- Starting the actual migration implementation (this requires a separate `/sdd plan` and explicit maintainer approval, since it touches the critical position-encoding path)
+- Enabling `ls-types`'s `proposed` feature flag for LSP 3.18 types (separate decision from the migration itself, per FR-004)
+
+### Never
+- Swap the dependency in `Cargo.toml` without first producing the API-compatibility diff called for in NFR-001
+- Treat "it's a fork" as sufficient justification to skip verification — forks diverge
+
+## 9. Open Questions
+
+- [NEEDS CLARIFICATION: Exact API diff between `lsp-types 0.97.0` and the current `ls-types` release has not been performed. Needs a symbol-level comparison (types, trait impls, feature flags) scoped to what mcpls actually imports in `crates/mcpls-core/src/lsp/` and `crates/mcpls-core/src/bridge/` before any migration plan is written.]
+- [NEEDS CLARIFICATION: Which `ls-types` version/tag should mcpls target? Not yet pinned down — needs checking crates.io or the `tower-lsp-community/ls-types` repo for its latest published release compatible with LSP 3.17 stable.]
+- [NEEDS CLARIFICATION: Does `ls-types` publish to crates.io under a different crate name (e.g. `ls-types`) requiring a rename of the `lsp_types::` import path throughout mcpls, or does it re-export under the same `lsp_types` namespace for easier swapping? This directly affects migration blast radius across `crates/mcpls-core/src/lsp/` and `crates/mcpls-core/src/bridge/`.]
+- [NEEDS CLARIFICATION: Should this migration be bundled with any other dependency-health cleanup in the same PR, or land as an isolated, easily-revertible commit given it touches the critical position-encoding path? Recommend isolated, given the project's emphasis on graceful degradation and the sensitivity of `bridge/encoding.rs`.]
+
+## 10. See Also
+
+- [[constitution]] — project principles (not yet created for this project)
+- [[MOC-specs]] — all specifications
+- [gluon-lang/lsp-types](https://github.com/gluon-lang/lsp-types) — current upstream dependency, unmaintained since 2024-06-04
+- [tower-lsp-community/ls-types](https://github.com/tower-lsp-community/ls-types) — proposed replacement, maintained fork
+- [tower-lsp-server v0.23.0 release notes](https://github.com/tower-lsp-community/tower-lsp-server/releases/tag/v0.23.0) — precedent for this exact migration in a reference project
+- `crates/mcpls-core/src/bridge/encoding.rs` — critical position-encoding path most sensitive to any type-level divergence
+- `crates/mcpls-core/src/lsp/` — LSP client, primary consumer of `lsp-types`
+- `crates/mcpls-core/src/bridge/` — MCP-LSP translation layer, secondary consumer of `lsp-types`

--- a/specs/lsp/004-lsp-318-draft-gaps/spec.md
+++ b/specs/lsp/004-lsp-318-draft-gaps/spec.md
@@ -1,0 +1,218 @@
+---
+aliases:
+  - LSP 3.18 draft gaps
+  - LSP 3.18 watch-item
+tags:
+  - sdd
+  - spec
+  - research
+  - competitive-parity
+  - lsp
+created: 2026-08-05
+status: draft
+related:
+  - "[[constitution]]"
+---
+
+# Feature: Track LSP 3.18 (Draft) Capabilities Against mcpls's MCP Tool Surface
+
+> [!info] Metadata
+> **Author**: rust-researcher (filed from competitive-parity research cycle)
+> **Type**: research / competitive-parity
+> **Priority**: P4
+> **Related issues**: #116 (P3, unimplemented LSP 3.17-era tools), #290 (P2, negotiated position encoding not consumed — resolved, see Resolution below)
+
+> [!success] #290 resolved
+> Issue #290 (negotiated LSP position encoding not consumed) is now closed, in two parts:
+> commit `bc95b89` (PR #289) wired configured `workspace.position_encodings` into the LSP
+> `initialize` handshake, and commit `81fd7d3` (PR #291) made `mcp_to_lsp_position`/
+> `lsp_to_mcp_position` actually consume the *negotiated* `PositionEncodingKind` (rather than
+> assuming a fixed encoding) when converting positions, including an async
+> `DocumentTracker`-backed line-text lookup and a `character_to_byte_offset`/
+> `byte_offset_to_character` char-boundary guard. Both commits carry `BREAKING CHANGE` notes
+> (`ServerConfig::validate()` strictness / new `ServerInitConfig::position_encodings` field for
+> #289; several `bridge::translator` methods becoming `async` for #291). This does not change
+> this spec's own scope (LSP 3.18 draft tracking remains speculative/P4) — noted here only
+> because #290 was listed as a related issue.
+
+> [!question] Draft-spec volatility
+> [NEEDS CLARIFICATION: LSP 3.18 is still a draft; requirements may change before finalization]
+
+## 1. Overview
+
+### Problem Statement
+
+mcpls currently targets LSP 3.17 (per the reference-projects list in
+`.claude/rules/continuous-improvement.md`) and already tracks a known gap of unimplemented
+3.17-era tools in [[lsp/002-lsp317-missing-tools/spec|spec lsp/002]] / issue #116 (P3) —
+`get_signature_help`, `go_to_implementation`, `go_to_type_definition`, `get_inlay_hints`,
+`prepare_type_hierarchy` — plus a separate open issue #290 (P2) about the negotiated LSP
+position encoding not being consumed by position conversion.
+
+LSP 3.18 is now under active development at the
+[LSP 3.18 draft specification](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.18/specification/),
+with features tagged `@since 3.18.0`. Verified from the spec document, the notable new/changed
+capabilities are:
+
+| Draft capability | Nature of change | Relation to existing mcpls surface |
+|---|---|---|
+| Inline Completions | New language feature | No equivalent MCP tool concept exists yet |
+| Dynamic Text Document Content refresh | Server-initiated refresh | New notification-refresh pattern |
+| Folding Range refresh support | Server-initiated client refresh | Similar push-model to diagnostics, which `bridge/notifications.rs` already handles |
+| Multiple Range Formatting | Extends formatting request | Extends the existing single-range format tool |
+| WorkspaceEdit snippet support + metadata | Extends edit payload | Extends whatever tool surfaces `workspace/applyEdit`-style edits |
+| SignatureHelp/SignatureInformation `activeParameter` nullable | Type-signature change | Affects the not-yet-implemented `get_signature_help` (tracked in issue #116) |
+| Code Action `kind` documentation, Command tooltip support | Metadata/documentation addition | Extends existing code-action tooling, if any |
+| CompletionList `applyKind` property | New completion-list property | Extends completion tooling, if any |
+| Relative pattern support in document filters / notebook filters | Filter-matching extension | Affects document/notebook filter matching internals, not a user-facing tool |
+
+Neither of mcpls's tracked reference projects — isaacphi/mcp-language-server or Tritlo/lsp-mcp —
+implements any 3.18 draft feature yet (verified via `gh api repos/isaacphi/mcp-language-server/commits`
+and `gh api repos/Tritlo/lsp-mcp/commits`; most recent commits from mid-2025, predating the 3.18
+draft). This absence of competitive pressure, combined with the spec still being a draft, is why
+most items here are P4 (cosmetic/niche, no reference-project adoption signal, no user demand
+signal) rather than P2/P3.
+
+Separately, the `ls-types` crate (tower-lsp-community's maintained fork of `lsp-types`, tracked
+in [[lsp/003-lsp-types-unmaintained-migration/spec|spec lsp/003]]) already supports LSP 3.18 draft
+features behind a `proposed` feature flag. Migrating to that dependency is therefore a
+prerequisite for adopting any item in this list, since the current `lsp-types` dependency has no
+3.18 types at all.
+
+### Goal
+
+Establish a tracked, reviewable watch-item for LSP 3.18 draft capabilities so that a future
+continuous-improvement cycle can promote a specific capability out of this research spec into a
+proper implementation spec (following [[lsp/002-lsp317-missing-tools/spec|spec lsp/002]]'s pattern) once
+either (a) the LSP 3.18 spec finalizes, or (b) a reference project (isaacphi/mcp-language-server,
+Tritlo/lsp-mcp) or real user demand creates competitive/urgency pressure.
+
+### Out of Scope
+
+- Implementing any LSP 3.18 capability now — the spec is a draft and no MCP tool design exists
+  for most of these (e.g. Inline Completions has no established MCP tool shape in any reference
+  project)
+- Migrating the `lsp-types` → `ls-types` dependency (tracked separately in
+  [[lsp/003-lsp-types-unmaintained-migration/spec|spec lsp/003]]); this spec only notes it as a
+  prerequisite
+- Resolving issue #116 (3.17-era gaps) or issue #290 (position encoding) — those are separate,
+  already-tracked, higher-priority items
+- Committing to any MCP tool naming, request/response shape, or API design for these
+  capabilities — that is plan-phase work that should only happen once an item is promoted out of
+  research status
+
+## 2. User Stories
+
+> [!note] Speculative, low priority
+> These stories describe future value **conditional on** the LSP 3.18 draft finalizing and/or a
+> corresponding MCP tool being designed. None are actionable today.
+
+### US-001: AI agent gets real-time inline completions
+AS A future user of an mcpls-exposed inline-completion tool
+I WANT AI-generated inline completions surfaced the same way an LSP client would show them
+SO THAT the AI agent gets ghost-text-style suggestions without polling a separate completion
+tool, once Inline Completions lands in a finalized LSP spec and gains reference-project adoption
+
+### US-002: AI agent formats a discontinuous selection in one call
+AS A future user of mcpls's formatting tool
+I WANT multiple, non-contiguous ranges formatted in a single request
+SO THAT I don't need N sequential format calls for N disjoint edited regions, once Multiple
+Range Formatting is available from the underlying LSP server
+
+### US-003: AI agent distinguishes "no active parameter" from "parameter zero"
+AS A future user of `get_signature_help` (tracked in issue #116, not yet implemented)
+I WANT the `activeParameter` field to be nullable rather than defaulting to `0`
+SO THAT I can tell "cursor is past all known parameters" apart from "cursor is on the first
+parameter" — this only matters once `get_signature_help` itself is implemented and the
+underlying `lsp-types`/`ls-types` dependency exposes the 3.18 nullable-`activeParameter` shape
+
+### US-004: AI agent reacts to server-pushed folding-range invalidation
+AS A future user of a folding-range tool
+I WANT the server's folding-range refresh notification to invalidate any cached result
+SO THAT stale folding ranges aren't returned after the underlying document changes — this
+follows the same push-then-poll caching pattern `bridge/notifications.rs` already implements
+for diagnostics
+
+## 3. Functional Requirements
+
+> [!warning] Speculative and draft-spec-dependent
+> Every requirement below is a **candidate**, not a commitment. Each is gated on the LSP 3.18
+> draft finalizing and/or the referenced prerequisite work landing. None should be implemented
+> against the draft spec as-is; text uses EARS notation only to keep the candidate requirement
+> well-formed for a future promotion into an implementation spec.
+
+| ID | Candidate Requirement (speculative) | Gating condition |
+|----|------------|----------|
+| FR-001 | WHEN LSP 3.18 finalizes Inline Completions AND a reference project or user demand signal appears THE SYSTEM MAY expose an inline-completion MCP tool | Spec finalization + adoption signal |
+| FR-002 | WHEN LSP 3.18 finalizes Dynamic Text Document Content refresh THE SYSTEM MAY invalidate cached document content on server-pushed refresh, following the existing notification-caching pattern in `bridge/notifications.rs` | Spec finalization |
+| FR-003 | WHEN LSP 3.18 finalizes Folding Range refresh support AND mcpls exposes a folding-range tool THE SYSTEM MAY invalidate cached folding ranges on server-pushed refresh | Spec finalization + folding-range tool existing |
+| FR-004 | WHEN LSP 3.18 finalizes Multiple Range Formatting THE SYSTEM MAY extend the existing single-range format tool to accept multiple ranges in one request | Spec finalization |
+| FR-005 | WHEN LSP 3.18 finalizes WorkspaceEdit snippet support and metadata THE SYSTEM MAY surface snippet placeholders and edit metadata through whatever tool applies workspace edits | Spec finalization |
+| FR-006 | WHEN the `lsp-types`/`ls-types` dependency exposes a nullable `activeParameter` on `SignatureHelp`/`SignatureInformation` THE SYSTEM MAY propagate `null` (rather than defaulting to `0`) through `get_signature_help` once that tool is implemented (issue #116) | `ls-types` migration ([[lsp/003-lsp-types-unmaintained-migration/spec\|spec lsp/003]]) + issue #116 resolution |
+| FR-007 | WHEN LSP 3.18 finalizes Code Action `kind` documentation and Command tooltip support THE SYSTEM MAY surface tooltip text through any future code-action tool | Spec finalization + code-action tool existing |
+| FR-008 | WHEN LSP 3.18 finalizes the CompletionList `applyKind` property THE SYSTEM MAY surface it through any future completion tool | Spec finalization + completion tool existing |
+| FR-009 | WHEN LSP 3.18 finalizes relative pattern support in document/notebook filters THE SYSTEM MAY use relative patterns internally for document-filter matching, if mcpls's server-discovery heuristics in `config/` are extended to consume LSP-native filters | Spec finalization + internal filter-matching redesign |
+
+## 4. Non-Functional Requirements
+
+> [!note] Not applicable at research stage
+> No implementation is planned, so no performance, security, or accessibility targets apply yet.
+> Once any FR above is promoted to an implementation spec, that spec must define its own NFRs
+> (following the pattern in [[lsp/002-lsp317-missing-tools/spec|spec lsp/002]] and
+> [[runtime/001-log-json-bool-env-parsing/spec|spec runtime/001]]).
+
+## 5. Data Model
+
+Not applicable — this is a tracking/research spec, not an implementation spec. No new domain
+entities are introduced.
+
+## 6. Edge Cases and Error Handling
+
+Not applicable — no code changes result from this spec.
+
+## 7. Success Criteria
+
+| ID | Metric | Target |
+|----|--------|--------|
+| SC-001 | This spec is re-reviewed in each future competitive-parity research cycle | Reviewed at least once per cycle that scans LSP spec / reference-project activity |
+| SC-002 | An FR is promoted to its own implementation spec | Promotion happens only when its gating condition (spec finalization and/or reference-project/user-demand signal) is met — not before |
+| SC-003 | This spec's priority is re-assessed if the LSP 3.18 spec finalizes or either reference project adopts a listed capability | Priority bumped from P4 in the cycle immediately following the trigger event |
+
+## 8. Agent Boundaries
+
+### Always (without asking)
+- Re-check this spec's premises (draft status, reference-project adoption) during future
+  competitive-parity research cycles
+- Keep this spec's FRs marked speculative until their gating condition is met
+
+### Ask First
+- Promoting any FR from this spec into a dedicated implementation spec (new `.local/specs/NNN-*`
+  directory), even after a gating condition appears to be met
+
+### Never
+- Implement any capability listed in Functional Requirements while this spec's status remains
+  `draft` and the LSP 3.18 spec remains a draft
+- Add a dependency on `ls-types`'s `proposed` feature flag to consume 3.18 draft types before the
+  spec finalizes — draft-flagged upstream types are not a stable contract to build against
+
+## 9. Open Questions
+
+- [NEEDS CLARIFICATION: LSP 3.18 is still a draft; requirements may change before finalization]
+- [NEEDS CLARIFICATION: Should this spec be re-filed (new number) each time the LSP working group
+  cuts a new draft revision, or should it be edited in place with a changelog note at the top?
+  Recommend editing in place and relying on git history, consistent with how issue #116 is
+  amended rather than re-filed as new tracked gaps are found.]
+- [NEEDS CLARIFICATION: Once `ls-types` migration ([[lsp/003-lsp-types-unmaintained-migration/spec|spec lsp/003]])
+  lands, should the `proposed`/3.18-draft feature flag be enabled at all before 3.18 finalizes, or
+  only the stable 3.17 surface? Recommend keeping the `proposed` flag off until 3.18 finalizes, to
+  avoid depending on an upstream draft-flagged, potentially-breaking API surface.]
+
+## 10. See Also
+
+- [LSP 3.18 draft specification](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.18/specification/)
+- [ls-types README (notes the 3.18 `proposed` feature flag)](https://github.com/tower-lsp-community/ls-types)
+- [[lsp/002-lsp317-missing-tools/spec|spec lsp/002]] / issue #116 — existing tracked gap of unimplemented LSP 3.17-era tools (`get_signature_help`, `go_to_implementation`, `go_to_type_definition`, `get_inlay_hints`, `prepare_type_hierarchy`)
+- issue #290 — negotiated LSP position encoding not consumed by position conversion (P2, open)
+- [[lsp/003-lsp-types-unmaintained-migration/spec|spec lsp/003]] — companion finding on the unmaintained `lsp-types` dependency; prerequisite for adopting any 3.18 draft type
+- [[constitution]] — project principles (not yet created for this project)
+- [[MOC-specs]] — all specifications

--- a/specs/mcp/001-mcp-tool-surface-and-routing/spec.md
+++ b/specs/mcp/001-mcp-tool-surface-and-routing/spec.md
@@ -1,0 +1,243 @@
+---
+aliases:
+  - MCP tool surface
+  - Multi-server tool routing
+  - ToolRouter
+tags:
+  - sdd
+  - spec
+  - mcp
+  - config
+  - bridge
+created: 2026-08-05
+status: implemented
+related:
+  - "[[constitution]]"
+  - "[[config/001-config-discovery-and-heuristics/spec]]"
+  - "[[lsp/001-lsp-server-lifecycle-and-respawn/spec]]"
+---
+
+# Feature: MCP Tool Surface and Multi-Server Request Routing
+
+> [!info] Cross-block note
+> This spec is filed under `mcp` (the tool-dispatch surface it documents is an MCP-facing
+> concern), but its core data structure (`ToolRouter`/`ToolKind`/`ServerId`) physically lives in
+> `crates/mcpls-core/src/config/routing.rs` — see [[config/001-config-discovery-and-heuristics/spec|config/001]]
+> for the configuration layer it is built from, and [[lsp/001-lsp-server-lifecycle-and-respawn/spec|lsp/001]]
+> for the server respawn mechanics FR-010 depends on.
+
+> [!info] Metadata
+> **Author**: retroactive spec, authored during the `.local/specs/` → `specs/` migration and gap
+> analysis (no single originating commit/PR — this documents already-shipped, working
+> functionality; the explicit per-tool routing layer specifically references #174 in its own
+> source doc comment as the feature that introduced it)
+> **Type**: core subsystem
+> **Priority**: P1 (retroactive — reflects centrality, not an open defect)
+
+> [!success] Resolution
+> This is a retroactive spec: `crates/mcpls-core/src/mcp/server.rs` (20 `#[tool]` handlers plus
+> the `resources/*` handlers), `crates/mcpls-core/src/mcp/tools.rs` (parameter schemas),
+> `crates/mcpls-core/src/config/routing.rs` (`ToolRouter`, `ServerId`, `ToolKind`), and
+> `crates/mcpls-core/src/bridge/translator/routing.rs` (`get_client_for_file`,
+> `resolve_client_for_file`, path validation) already implement everything described below.
+> [[mcp/002-mcp-resources-diagnostics/spec|spec mcp/002]] already covers the `resources/*` MCP surface in
+> detail; this spec covers the *tool* surface (the 20 `#[tool]` handlers) and the request-routing
+> layer beneath both, which spec mcp/002 references but does not itself specify.
+
+## 1. Overview
+
+### Problem Statement
+
+mcpls exposes 20 MCP tools spanning navigation (hover, definition, type definition,
+implementation, references), mutation-proposing operations (rename, format, code actions — all of
+which return a *proposed* edit rather than writing to disk), symbol search (document and
+workspace-wide), diagnostics (both pull and cache-only), call hierarchy (prepare/incoming/
+outgoing as a linked trio), and cache-only introspection (server logs, server messages,
+inlay hints, signature help). Each tool call must be dispatched to the correct LSP server for the
+target file's detected language — but "correct server" is not always a 1:1 language→server
+mapping: since #174, a single language can have *multiple* configured servers, each explicitly
+claiming a disjoint subset of tools (e.g. pyright for hover/definition, a separate linter LSP for
+diagnostics only), with at most one implicit catch-all server per language for whatever no server
+explicitly claims.
+
+Without an explicit routing layer, two servers configured for the same language would either
+silently overwrite each other in every map keyed by server identity, or require every caller to
+duplicate "which server handles this tool for this language" logic. Separately, every tool
+handler needs consistent path validation (a requested file must be inside a configured workspace
+root) and a consistent MCP-response shape (bridge-layer errors mapped to `McpError`), which must
+not be duplicated 20 times.
+
+### Goal
+
+Every MCP tool call is dispatched to the single correct LSP server for its target file's language
+and the specific tool being invoked (respecting explicit multi-server-per-language routing where
+configured), with consistent path validation and error mapping shared across all 20 tool handlers,
+and with a server that failed to spawn or crashed never silently receiving a request it cannot
+serve.
+
+### Out of Scope
+
+- The `resources/*` (list/read/subscribe/unsubscribe) MCP surface — already
+  [[mcp/002-mcp-resources-diagnostics/spec|spec mcp/002]].
+- LSP server spawn/initialize/respawn mechanics themselves —
+  [[lsp/001-lsp-server-lifecycle-and-respawn/spec|spec lsp/001]].
+- Position/range conversion inside each handler — [[bridge/001-position-encoding-layer/spec|spec bridge/001]].
+- Adding new MCP tools — this spec documents the routing/dispatch architecture the existing 20
+  tools already use, not a proposal for new tools (see
+  [[lsp/002-lsp317-missing-tools/spec|spec lsp/002]] for that history).
+
+## 2. User Stories
+
+### US-001: A tool call reaches the one server explicitly configured to handle it
+
+AS A developer running two LSP servers for one language, each explicitly claiming a disjoint set
+of tools via `handles`
+I WANT each tool call routed to exactly the server that claims it, with the other server never
+receiving that tool's requests
+SO THAT I can split responsibilities across servers (e.g. a fast linter for diagnostics, a
+full-featured server for everything else) without either server seeing requests it declined
+
+**Acceptance criteria:**
+```
+GIVEN server A claims `handles = ["hover"]` and server B has no `handles` (catch-all) for the
+     same language
+WHEN a hover tool call arrives for a file in that language
+THEN it is routed to server A
+
+WHEN a definition tool call arrives for the same file
+THEN it is routed to server B (the catch-all), since A did not claim `definition`
+```
+
+### US-002: A tool call for an unclaimed, no-catch-all combination fails clearly, not silently
+
+AS A developer who configured a narrowly-scoped server with no catch-all sibling for its language
+I WANT a tool call for a tool nobody claims to fail with a clear "no server for this tool" error
+SO THAT I understand my configuration has a gap, rather than the request being silently forwarded
+to a server that explicitly declined it
+
+**Acceptance criteria:**
+```
+GIVEN a single server for a language, explicitly claiming only `handles = ["hover"]`
+WHEN a definition tool call arrives for that language
+THEN the response reports no server available for that tool/language combination, rather than
+     being silently forwarded to the hover-only server
+```
+
+### US-003: A tool request for a file outside the workspace is rejected consistently
+
+AS A mcpls operator
+I WANT every one of the 20 tool handlers to reject a request for a file outside configured
+workspace roots the same way
+SO THAT path validation can't accidentally be skipped or duplicated inconsistently across handlers
+
+**Acceptance criteria:**
+```
+GIVEN configured workspace roots that do not include /etc
+WHEN any position- or file-based tool is called with file_path = "/etc/passwd"
+THEN the request is rejected with the same PathOutsideWorkspace error regardless of which of the
+     20 tools was called
+```
+
+## 3. Functional Requirements
+
+| ID | Requirement | Priority |
+|----|------------|----------|
+| FR-001 | THE SYSTEM SHALL expose 20 MCP tools covering hover, definition, type definition, implementation, references, diagnostics (pull + cached), rename, completions, signature help, document symbols, workspace symbol search, format document, code actions, call hierarchy (prepare/incoming/outgoing), inlay hints, server logs, and server messages | must |
+| FR-002 | THE SYSTEM SHALL resolve, for every routable tool call, the server that should handle it via `ToolRouter`: an explicit `handles` claim wins over a language's catch-all server; if neither exists, the request fails naming the language and tool | must |
+| FR-003 | THE SYSTEM SHALL reject a workspace whose applicable server configs contain two servers sharing one `ServerId` (name defaulting to `language_id`), two catch-all servers for one language, or two servers explicitly claiming the same tool for one language, at workspace-scoped validation time (`ToolRouter::from_configs`), distinct from and later than `ServerConfig::validate`'s workspace-independent checks | must |
+| FR-004 | WHEN a server fails to spawn or is dropped from the registered set THE SYSTEM SHALL rebind any route pointing at it to that language's live catch-all if one exists, or drop the route entirely (reporting no server available) if not — never silently conscripting a narrowly-scoped live server outside its declared `handles` | must |
+| FR-005 | FOR a workspace-wide tool with no per-file language to route by (e.g. `workspace_symbol_search`) THE SYSTEM SHALL resolve in two tiers, in config declaration order: first the first server explicitly claiming the tool, else the first catch-all server — never falling back to "the first server at all" if neither tier matches | must |
+| FR-006 | THE SYSTEM SHALL resolve a file's server via its detected language first, falling back to its React base language (`.tsx`→`typescriptreact`→`typescript`, `.jsx`→`javascriptreact`→`javascript`) only if the language itself has no route, so an explicit `typescriptreact` server still wins over a `typescript` fallback when both are configured | must |
+| FR-007 | THE SYSTEM SHALL validate every tool-handler's `file_path` against configured workspace roots via one shared function, used by every handler that takes a file path, rather than each handler duplicating validation logic | must |
+| FR-008 | THE SYSTEM SHALL map every bridge-layer `Result<T, Error>` to the MCP tool response shape via one shared function, so error formatting stays consistent across all 20 tool handlers | must |
+| FR-009 | THE SYSTEM SHALL classify all 20 tools as read-only (`ToolAnnotations`) at the router level, once, rather than repeating an identical annotation block on every `#[tool]` attribute, since every mcpls tool is a query or a proposed-edit generator that never itself writes to disk | must |
+| FR-010 | WHEN a tool call resolves to a server whose process has died THE SYSTEM SHALL attempt to respawn it (per [[lsp/001-lsp-server-lifecycle-and-respawn/spec|spec lsp/001]]) before the request is treated as failed | must |
+
+## 4. Non-Functional Requirements
+
+| ID | Category | Requirement |
+|----|----------|-------------|
+| NFR-001 | Consistency | Every tool handler must use the same path-validation and error-mapping helpers — no handler may implement its own divergent validation logic |
+| NFR-002 | Extensibility | Adding a new routable MCP tool must require only extending `ToolKind::ALL` and adding one `#[tool]` handler, not restructuring `ToolRouter` itself |
+| NFR-003 | Diagnosability | A workspace-configuration routing conflict (duplicate `ServerId`, two catch-alls, duplicate tool claim) must be reported with enough detail (command, args, or other distinguishing fields) to identify which two `[[lsp_servers]]` entries collided, even when neither has an explicit `name` |
+| NFR-004 | Determinism | `resolve_any`'s two-tier resolution (explicit claimer, then catch-all) must be deterministic across repeated calls with the same configuration — driven by config declaration order, not map iteration order |
+
+## 5. Data Model
+
+| Entity | Description | Key Attributes |
+|--------|-------------|-----------------|
+| `ToolKind` | Every routable MCP tool (excludes cache-only tools that never reach a specific server: `get_cached_diagnostics`, `get_server_logs`, `get_server_messages`) | 15 variants, `ALL: [Self; 15]`, `as_str()` snake_case name |
+| `ServerId` | Unique routing identity of a configured server within a workspace | Wraps `String`; a server's explicit `name` if set, else its `language_id` |
+| `ToolRouter` | Resolves `(language, tool)` → `ServerId` | Built via `from_configs` (post-heuristics applicable configs), rebound via `rebind_to_registered` (post-spawn registered set) |
+| `NoServerReason` | Why `resolve_any` found no server for a workspace-wide tool | `NothingRegistered`, `NoClaimant` |
+| `BridgeContext` (`mcp/handlers.rs`) | Shared state every `#[tool]` handler dispatches through | `translator`, `notification_cache`, `workspace_roots`, `subscriptions`, `project_config_ignored`, `mcp` (presentation overrides) |
+
+## 6. Edge Cases and Error Handling
+
+| Scenario | Expected Behavior |
+|----------|--------------------|
+| Two servers for one language, one explicit claimer + one catch-all | Explicit claim wins for its claimed tools; catch-all serves everything else for that language |
+| One narrowly-scoped server, no catch-all, tool not claimed | `NoServerReason::NoClaimant` — not silently forwarded to the narrow server |
+| No server registered at all for a language | `NoServerReason::NothingRegistered` |
+| A workspace-wide tool (e.g. `workspace_symbol_search`) with only a narrowly-scoped server configured (no catch-all anywhere) | `resolve_any` returns `NoClaimant`, never falls back to an arbitrary configured server |
+| Two `[[lsp_servers]]` entries collide on `ServerId` with neither setting `name` | Error message names both entries by `command`/`args`, not a positional index (which would usually name the wrong array position, since `from_configs` only sees the post-heuristics applicable subset) |
+| A server explicitly claiming a tool fails to spawn, and a catch-all sibling is live | That tool's route rebinds to the live catch-all; a warning is logged naming the dead server and the rebind target |
+| A server explicitly claiming a tool fails to spawn, no catch-all sibling | The route is dropped entirely (not rebound to some other unrelated server); that tool reports no server available for the language |
+| A `.tsx` file with only a plain `typescript` server configured (no dedicated `typescriptreact` server) | Falls back to the `typescript` server via the React base-language fallback |
+| A `.tsx` file with both `typescriptreact` and `typescript` servers configured | Routes to the `typescriptreact` server — the exact-match language wins over the fallback |
+| A tool call for a file outside every configured workspace root | Rejected with `PathOutsideWorkspace`, identically regardless of which of the 20 tools was called |
+
+## 7. Success Criteria
+
+| ID | Metric | Target |
+|----|--------|--------|
+| SC-001 | `cargo nextest run -E 'package(mcpls-core) and (test(routing) or test(server))'` | All existing `ToolRouter` and MCP tool-handler unit/integration tests pass |
+| SC-002 | A workspace configuring two servers per language across several languages, with a mix of explicit `handles` and catch-alls | Every one of the 20 tools resolves to the correct server per FR-002/FR-005/FR-006 |
+| SC-003 | A deliberately conflicting config (duplicate `ServerId`, two catch-alls, or duplicate tool claim) | `ToolRouter::from_configs` rejects it with a message identifying the colliding entries |
+
+## 8. Agent Boundaries
+
+### Always (without asking)
+- Extend `ToolKind::ALL` and add a corresponding `#[tool]` handler together when adding a new
+  routable MCP tool — never let the two drift out of sync
+- Route every new file-path-taking tool handler through the shared path-validation helper
+  (NFR-001)
+- Preserve the "explicit claim wins over catch-all, never fall back to an arbitrary server" rule
+  in any change to `resolve`/`resolve_any`
+
+### Ask First
+- Changing the React-variant fallback order (FR-006) — an explicit `typescriptreact`/
+  `javascriptreact` server must continue to win over the plain-language fallback
+- Adding a workspace-wide tool that needs a *different* resolution strategy than the existing
+  two-tier (explicit claimer, then catch-all) approach
+
+### Never
+- Let `rebind_to_registered` conscript a narrowly-scoped live server for a tool outside its
+  declared `handles` — this would silently violate that server's explicit configuration
+- Duplicate path-validation or error-mapping logic inside an individual `#[tool]` handler instead
+  of using the shared helpers (NFR-001)
+
+## 9. Open Questions
+
+None — this is a retroactive spec documenting stable, already-shipped, well-tested behavior.
+
+## 10. See Also
+
+- [[constitution]] — project principles (not yet created for this project)
+- [[MOC-specs]] — all specifications
+- [[mcp/002-mcp-resources-diagnostics/spec|spec mcp/002]] — the `resources/*` MCP surface, a sibling
+  concern this spec does not duplicate
+- [[lsp/002-lsp317-missing-tools/spec|spec lsp/002]] — history of 4 of the 20 tools this spec documents
+  (`get_signature_help`, `go_to_implementation`, `go_to_type_definition`, `get_inlay_hints`)
+- [[config/001-config-discovery-and-heuristics/spec|spec config/001]] — `LspServerConfig`/`ServerId` this
+  spec's `ToolRouter` is built from
+- [[lsp/001-lsp-server-lifecycle-and-respawn/spec|spec lsp/001]] — respawn mechanics triggered when a
+  routed-to server has crashed (FR-010)
+- `crates/mcpls-core/src/mcp/server.rs` — the 20 `#[tool]` handlers, `to_tool_result`,
+  `declared_tool_router`
+- `crates/mcpls-core/src/mcp/tools.rs` — MCP tool parameter schemas
+- `crates/mcpls-core/src/mcp/handlers.rs` — `BridgeContext`
+- `crates/mcpls-core/src/config/routing.rs` — `ToolRouter`, `ServerId`, `ToolKind`,
+  `NoServerReason`
+- `crates/mcpls-core/src/bridge/translator/routing.rs` — `get_client_for_file`,
+  `resolve_client_for_file`, `validate_path_against_roots`

--- a/specs/mcp/002-mcp-resources-diagnostics/spec.md
+++ b/specs/mcp/002-mcp-resources-diagnostics/spec.md
@@ -1,0 +1,51 @@
+# Spec mcp/002: Expose LSP Diagnostics as MCP Resources with Subscriptions
+
+**Type**: enhancement
+**Priority**: P3
+**Status**: draft
+
+## Problem Statement
+
+mcpls currently exposes LSP diagnostics only as polling tools (`get_diagnostics`,
+`get_cached_diagnostics`). The MCP 2025-11-25 specification introduces first-class
+**Resources** with **subscriptions** — clients can subscribe to a resource URI and receive
+`notifications/resources/updated` push events when the resource changes.
+
+Competing implementations already use this pattern:
+- **Tritlo/lsp-mcp** (Haskell) exposes `lsp-diagnostics://` as a subscribable resource with
+  real-time updates when files change.
+
+mcpls's current diagnostics model is a pull-based cache (`NotificationCache`) populated by
+the LSP push pump. This is already the right data structure — the gap is surfacing it through
+the MCP resource/subscription interface instead of (or in addition to) tool calls.
+
+## User Stories
+
+- As an AI agent editing a file, I want to receive a notification when new diagnostics arrive
+  rather than polling `get_diagnostics` repeatedly.
+- As an MCP client, I want to subscribe to `lsp-diagnostics://path/to/file` and receive
+  updates without issuing repeated tool calls.
+
+## Functional Requirements
+
+1. mcpls must declare `resources` capability with `subscribe: true` in its `ServerInfo`.
+2. mcpls must implement `resources/list` returning URIs of the form
+   `lsp-diagnostics://<absolute-path>` for each open document.
+3. mcpls must implement `resources/read` for `lsp-diagnostics://` URIs, returning the current
+   `NotificationCache` contents for that path as JSON.
+4. mcpls must implement `resources/subscribe` — when a client subscribes, the notification
+   pump must emit `notifications/resources/updated` whenever the diagnostics cache for that
+   path changes.
+5. Existing `get_cached_diagnostics` tool must remain for clients that do not support resources.
+
+## Non-Functional Requirements
+
+- Zero extra LSP round-trips: use the existing notification pump output.
+- rmcp crate must expose resource registration and `notifications/resources/updated` send API
+  — verify before implementation (rmcp 1.5.0 currently used).
+
+## See Also
+
+- MCP 2025-11-25 resources spec: https://modelcontextprotocol.io/specification/2025-11-25/server/resources
+- Tritlo/lsp-mcp: https://github.com/Tritlo/lsp-mcp
+- mcpls NotificationCache: `crates/mcpls-core/src/bridge/notifications.rs`

--- a/specs/mcp/003-mcp-2026-stateless-adoption/spec.md
+++ b/specs/mcp/003-mcp-2026-stateless-adoption/spec.md
@@ -1,0 +1,214 @@
+---
+aliases:
+  - MCP 2026-07-28 stateless spec tracking
+tags:
+  - sdd
+  - spec
+  - research
+  - mcp
+created: 2026-08-05
+status: draft
+related:
+  - "[[MOC-specs]]"
+---
+
+# Feature: Track MCP Specification 2026-07-28 (Stateless Revision) for Future mcpls Compatibility
+
+> [!info] Metadata
+> **Author**: k05h31
+> **Branch**: N/A (research finding, no branch yet)
+> **Type**: research
+> **Priority**: P3
+
+## 1. Overview
+
+### Problem Statement
+
+The Model Context Protocol specification advanced from `2025-11-25` — the
+version mcpls's own project rules cite as the "authoritative protocol
+reference" in [`.claude/rules/continuous-improvement.md`](../../../.claude/rules/continuous-improvement.md)
+— to `2026-07-28`, described by the MCP maintainers as the largest protocol
+revision since launch. The revision removes the `initialize` /
+`notifications/initialized` handshake entirely and makes MCP fully stateless:
+every request must instead carry protocol version and client capabilities via
+`_meta` fields.
+
+mcpls's MCP server surface (`crates/mcpls-core/src/mcp/`, built on the `rmcp`
+crate, currently pinned to `rmcp = "3.0.0"` in the workspace
+`Cargo.toml`) implements `get_info()` / `ServerCapabilities` on top of rmcp's
+current stateful `initialize` model. If the removal of `initialize` becomes a
+hard protocol requirement, mcpls's MCP-facing capability negotiation surface
+will need a migration path.
+
+> [!warning] Two distinct handshakes — do not conflate them
+> mcpls has **two independent `initialize` handshakes** and this finding
+> concerns only one of them:
+> 1. **MCP-side** (client ↔ mcpls, via `rmcp`, `crates/mcpls-core/src/mcp/server.rs`) —
+>    this is the handshake the 2026-07-28 spec removes. In scope here.
+> 2. **LSP-side** (mcpls ↔ language server, `crates/mcpls-core/src/lsp/lifecycle.rs`) —
+>    this is the handshake recently touched by commit `bc95b89` (`position_encodings`
+>    negotiation, PR #289). It is unrelated to the MCP spec revision and speaks
+>    LSP 3.17, not MCP. It is **out of scope** for this finding but mentioned
+>    because the original research prompt referenced it; no LSP-side change is
+>    implied or required by MCP 2026-07-28.
+
+The upstream Rust SDK (`rmcp`) released v3.1.0 on 2026-07-31 with only
+*initial* conformance work toward 2026-07-28 (strict stateless metadata
+validation, SEP-2260 stream-based request association, honoring
+`supported_protocol_versions` during negotiation) — explicitly framed as a
+phased, Tier-based rollout, not a finished implementation. mcpls therefore
+cannot adopt the new model yet; this spec exists to **track** the change and
+define what mcpls will need to do once `rmcp` reaches conformance, not to
+implement it now.
+
+### Goal
+
+mcpls has a documented, discoverable plan for migrating its MCP-side
+capability negotiation away from the `initialize`/`notifications/initialized`
+handshake once `rmcp` ships full 2026-07-28 conformance — so the transition,
+when it happens, is a scoped implementation task rather than a surprise
+breaking change discovered at an `rmcp` major-version bump.
+
+### Out of Scope
+
+- Implementing any stateless-protocol code changes now — `rmcp` conformance
+  is incomplete (Tier 1 in progress as of v3.1.0)
+- Changing the LSP-side `initialize` handshake (`lsp/lifecycle.rs`,
+  `bc95b89`/#289) — that speaks LSP 3.17 and is unaffected by this MCP spec
+  revision
+- Implementing Streamable HTTP transport changes (`Mcp-Session-Id` removal) —
+  mcpls's primary transport is stdio; HTTP transport itself is tracked
+  separately in issue #122
+- Implementing the redesigned Tasks extension — tracked separately in issue #119
+- Implementing `subscriptions/listen` replacing `resources/subscribe` /
+  `resources/unsubscribe` — resource subscriptions were added in
+  [[mcp/002-mcp-resources-diagnostics/spec|Spec mcp/002]] under the 2025-11-25 model;
+  re-scoping them is a future spec once the MRTR/subscriptions API stabilizes
+  upstream in `rmcp`
+- Updating `.claude/rules/continuous-improvement.md`'s reference spec version —
+  premature until `rmcp` and mcpls actually target 2026-07-28
+
+## 2. User Stories
+
+### US-001: Maintainer plans ahead of a breaking rmcp upgrade
+
+AS A mcpls maintainer
+I WANT a written record of what changes in MCP 2026-07-28 and which parts of
+`crates/mcpls-core/src/mcp/` they touch
+SO THAT when `rmcp` ships full conformance (a likely future breaking semver
+bump), I can scope the migration instead of reverse-engineering the diff
+between spec versions under time pressure.
+
+**Acceptance criteria:**
+```
+GIVEN this spec exists in .local/specs/mcp/003-mcp-2026-stateless-adoption/
+WHEN a maintainer next reviews rmcp's release notes for a version that claims
+     2026-07-28 conformance
+THEN this spec's Functional Requirements table gives them a checklist of the
+     mcpls-side surfaces that need review before upgrading
+```
+
+### US-002: mcpls avoids being surprised by initialize removal
+
+AS A mcpls maintainer
+I WANT the MCP-side `initialize` handshake dependency in
+`crates/mcpls-core/src/mcp/server.rs` explicitly flagged as at-risk
+SO THAT a future `rmcp` major bump that drops stateful `initialize` doesn't
+silently break mcpls's capability negotiation or client compatibility.
+
+**Acceptance criteria:**
+```
+GIVEN mcpls-core/src/mcp/server.rs implements get_info() / ServerCapabilities
+      against rmcp's current initialize-based API
+WHEN rmcp releases a version implementing the 2026-07-28 stateless model as
+     the default/only mode
+THEN mcpls has a pre-identified list (FR-001..FR-004 below) of what must
+     change, rather than starting discovery from zero
+```
+
+## 3. Functional Requirements
+
+These are tracking/planning requirements, not implementation directives —
+this finding is P3 research, and `rmcp` conformance work is incomplete.
+
+| ID | Requirement | Priority |
+|----|------------|----------|
+| FR-001 | WHEN `rmcp` publishes a release claiming 2026-07-28 conformance THE SYSTEM'S maintainers SHALL re-review `crates/mcpls-core/src/mcp/server.rs`'s `get_info()`/`ServerCapabilities` implementation for compatibility with per-request `_meta` protocol-version/capability fields replacing `initialize` | must |
+| FR-002 | mcpls's MCP-side capability negotiation SHALL have a documented migration path away from the `initialize`/`notifications/initialized` handshake before upgrading to an `rmcp` version that removes stateful `initialize` as a supported mode | must |
+| FR-003 | IF `rmcp` retains a backward-compatible/dual-mode `initialize` path during its deprecation window (Roots/Sampling/Logging carry a 12-month deprecation per the spec) THEN mcpls SHOULD defer the stateless migration until that window's expiry is imminent, to avoid churn on an unstable upstream API | should |
+| FR-004 | WHEN mcpls does migrate, THE SYSTEM SHALL re-audit `notifications.rs`'s push-based diagnostics caching against the `subscriptions/listen` replacement for `resources/subscribe`/`resources/unsubscribe`, since [[mcp/002-mcp-resources-diagnostics/spec|Spec mcp/002]]'s design assumes the 2025-11-25 subscribe/unsubscribe API | should |
+| FR-005 | THE SYSTEM'S issue tracker SHALL retain a link between this spec, issue #119 (tasks extension redesign), and issue #122 (Streamable HTTP parity), since all three are touched by different facets of the same MCP spec revision | must |
+
+## 4. Non-Functional Requirements
+
+| ID | Category | Requirement |
+|----|----------|-------------|
+| NFR-001 | Backward compatibility | mcpls SHALL NOT upgrade its `rmcp` dependency to a version that makes the stateless (no-`initialize`) model the *only* supported mode until `rmcp`'s own Tier rollout (per its roadmap) reaches a stage the maintainers judge stable — avoids adopting an unstable protocol surface mid-rollout |
+| NFR-002 | Compatibility window | Given Roots, Sampling, and Logging carry a 12-month deprecation window in 2026-07-28, mcpls's migration timeline SHOULD align with that window rather than rushing ahead of it, since mcpls does not currently implement Sampling or Elicitation (Roots/Logging usage should be confirmed — `[NEEDS CLARIFICATION: does mcpls currently use MCP Roots or Logging features from crates/mcpls-core/src/mcp/, and if so, are they exposed to clients today?]`) |
+| NFR-003 | Traceability | This spec SHALL be discoverable from `.local/specs/MOC-specs.md` and cross-linked with issues #119 and #122 so a future continuous-improvement cycle surfaces it automatically when scanning open research items |
+| NFR-004 | No premature action | No source code under `crates/` SHALL be modified as a result of this spec — it is a tracking/planning artifact only, consistent with its P3/research classification |
+
+## 5. Data Model
+
+Not applicable — this is a protocol-compatibility tracking spec with no new
+mcpls data entities. The relevant "entities" are external protocol constructs
+that mcpls's MCP layer will eventually need to represent:
+
+| Entity | Description | Key Attributes |
+|--------|-------------|----------------|
+| Request `_meta` protocol fields | Replaces `initialize`-negotiated state; carried per-request in 2026-07-28 | `io.modelcontextprotocol/protocolVersion`, `io.modelcontextprotocol/clientCapabilities` |
+| `server/discover` response | New mandatory RPC servers must answer, advertising identity/capabilities without a prior handshake | supported protocol versions, capabilities, server identity |
+| `InputRequiredResult` | Replaces server-initiated `roots/list`/`sampling/createMessage`/`elicitation/create` requests under the MRTR pattern | `resultType`, retry payload |
+
+## 6. Edge Cases and Error Handling
+
+| Scenario | Expected Behavior |
+|----------|-------------------|
+| `rmcp` ships a version that supports 2026-07-28 as opt-in alongside legacy `initialize` | mcpls should stay on the legacy path until this spec is revisited and superseded by an implementation spec |
+| `rmcp` ships a version that drops legacy `initialize` support entirely (breaking) | mcpls's `Cargo.toml` `rmcp` version pin acts as the safety net — do not bump past that version until the migration described here is actually implemented |
+| A future MCP client sends 2026-07-28-style per-request `_meta` fields to a pre-migration mcpls server | Current `rmcp = "3.0.0"`-based server does not understand these fields; behavior depends on `rmcp`'s own backward-compatibility handling, not mcpls code — `[NEEDS CLARIFICATION: does rmcp 3.0.0 reject or silently ignore unrecognized _meta fields from newer clients?]` |
+| Position-encoding negotiation (`bc95b89`, LSP-side) is mistaken for MCP-side handshake work in a future PR | Reviewers should point to this spec's Overview callout distinguishing the two handshakes |
+
+## 7. Success Criteria
+
+| ID | Metric | Target |
+|----|--------|--------|
+| SC-001 | Spec discoverability | Spec is linked from `.local/specs/MOC-specs.md` and readable without additional context |
+| SC-002 | Issue cross-linking | Issues #119 and #122 (or their successors) reference this spec, or this spec is referenced from a future issue tracking the actual migration |
+| SC-003 | No premature implementation | Zero commits to `crates/` reference this spec as their justification until `rmcp` conformance is confirmed by a maintainer |
+
+## 8. Agent Boundaries
+
+### Always (without asking)
+- Treat this spec as read-only tracking documentation
+- Re-check `rmcp`'s changelog against FR-001 whenever a dependency-update
+  cycle touches `rmcp`
+
+### Ask First
+- Opening an implementation spec/PR based on this tracking spec
+- Bumping the `rmcp` version past one that changes `initialize` semantics
+
+### Never
+- Modify `crates/mcpls-core/src/mcp/` or `crates/mcpls-core/src/lsp/` source
+  code as a direct result of this spec
+- Update `.claude/rules/continuous-improvement.md`'s cited spec version
+  without a maintainer decision — that reference documents current behavior,
+  not aspirational future behavior
+
+## 9. Open Questions
+
+- [NEEDS CLARIFICATION: What is mcpls's actual timeline trigger for revisiting this — a specific `rmcp` version, a calendar date, or "when issue #119/#122 work resumes"?]
+- [NEEDS CLARIFICATION: Does mcpls currently use MCP Roots or Logging features (`crates/mcpls-core/src/mcp/`), which are formally deprecated in 2026-07-28 with a 12-month window?]
+- [NEEDS CLARIFICATION: Does `rmcp` 3.0.0 (mcpls's current pin) reject or silently ignore unrecognized 2026-07-28-style `_meta` fields sent by a forward-compatible client?]
+- [NEEDS CLARIFICATION: Should this spec be re-filed as a GitHub issue (P3, `research` label) per the project's issue-filing protocol, or does the spec artifact alone satisfy tracking for now?]
+
+## 10. See Also
+
+- [[MOC-specs]] — all specifications
+- [MCP Specification 2026-07-28 changelog](https://modelcontextprotocol.io/specification/2026-07-28/changelog)
+- [MCP 2026-07-28 release candidate announcement](https://blog.modelcontextprotocol.io/posts/2026-07-28-release-candidate/)
+- [rmcp v3.1.0 release notes](https://github.com/modelcontextprotocol/rust-sdk/releases/tag/rmcp-v3.1.0)
+- [MCP Specification 2025-11-25](https://modelcontextprotocol.io/specification/2025-11-25/) — mcpls's current cited reference in `.claude/rules/continuous-improvement.md`, superseded by 2026-07-28 above
+- [GitHub issue bug-ops/mcpls#119](https://github.com/bug-ops/mcpls/issues/119) — "support MCP 2025-11-25 tasks/call" (P4), directly affected by the Tasks extension redesign in 2026-07-28
+- [GitHub issue bug-ops/mcpls#122](https://github.com/bug-ops/mcpls/issues/122) — competitive-parity playbook / Streamable HTTP transport, affected by session-header removal in 2026-07-28
+- Commit `bc95b89` — LSP-side `position_encodings` handshake fix (PR #289); referenced only to clarify it is a *different* handshake from the one this spec tracks

--- a/specs/runtime/001-log-json-bool-env-parsing/spec.md
+++ b/specs/runtime/001-log-json-bool-env-parsing/spec.md
@@ -1,0 +1,224 @@
+---
+aliases:
+  - log-json bool env parsing
+  - MCPLS_LOG_JSON parsing bug
+tags:
+  - sdd
+  - spec
+  - cli
+  - bug
+created: 2026-08-05
+status: implemented
+related:
+  - "[[constitution]]"
+---
+
+# Feature: Accept common boolean conventions for `--log-json`/`MCPLS_LOG_JSON` and `MCPLS_TRUST_PROJECT_CONFIG`
+
+> [!info] Metadata
+> **Author**: rust-ci-analyst (filed from live-testing evidence)
+> **Branch**: fix/log-json-bool-env-parsing
+> **Related PR**: #285 (commit c25d756) — introduced the regression by wiring `MCPLS_LOG_JSON` into `logging::init`
+> **Related issue**: #279 (original request for `--log-json` support)
+
+> [!success] Resolution
+> Implemented by commit `5d9b871` (PR #314), closing #295. `crates/mcpls-cli/src/args.rs`
+> now has a shared `parse_bool_flag` value parser applied to both `log_json` and
+> `trust_project_config` via `#[arg(value_parser = parse_bool_flag)]`, matching FR-001–FR-008:
+> accepts `true`/`false`, `1`/`0`, `yes`/`no` case-insensitively, rejects everything else with a
+> named-accepted-values error, and keeps both defaults at `false`. Resolves all Open Questions in
+> Section 9 in favor of the minimal-dependency custom `value_parser` approach (no new crate, no
+> newtype). Test coverage added in `args.rs`'s existing `mod tests`
+> (`test_parse_bool_flag_accepts_truthy_spellings`, `test_parse_bool_flag_accepts_falsy_spellings`,
+> `test_parse_bool_flag_rejects_invalid_values`), per NFR-005.
+
+## 1. Overview
+
+### Problem Statement
+
+`crates/mcpls-cli/src/args.rs` declares `log_json` and `trust_project_config` as plain `bool` fields with clap's `env` attribute:
+
+```rust
+#[arg(long, env = "MCPLS_TRUST_PROJECT_CONFIG")]
+pub trust_project_config: bool,
+
+#[arg(long, default_value = "false", env = "MCPLS_LOG_JSON")]
+pub log_json: bool,
+```
+
+For a `bool`-typed field, clap derives its value parser from `str::parse::<bool>()`, which accepts **only** the exact lowercase literals `"true"` and `"false"`. Every other common boolean-env-var convention — `1`/`0`, `yes`/`no`, `TRUE`/`True`, `YES`, etc. — is rejected with a hard clap parse error, and the process exits immediately before starting. No LSP servers spawn, no MCP server starts, and nothing is logged in any format (not even JSON), because the failure happens during argument parsing, before `logging::init` ever runs.
+
+This is a regression risk specifically because PR #285's entire purpose was to make `MCPLS_LOG_JSON` a real, production-facing observability control (closing #279). Operators wiring env vars via Docker, Kubernetes, or systemd unit files very commonly use `1`/`0` or `yes`/`no` conventions rather than the literal word `true`/`false`, and any case variation (`TRUE`, `True`) also fails today. The same narrow-parsing defect applies identically to `MCPLS_TRUST_PROJECT_CONFIG`, which has the identical `bool` + `env` declaration.
+
+A secondary consequence: PR #285 also promised that "a crash stays JSON-parseable on stderr when `--log-json` is set." That guarantee does not hold for this failure mode — clap's own error is printed via its default, non-JSON, non-tracing error formatter, so a misconfigured `MCPLS_LOG_JSON` value produces exactly the kind of unstructured stderr output the flag exists to eliminate.
+
+### Goal
+
+Setting `MCPLS_LOG_JSON`/`--log-json` or `MCPLS_TRUST_PROJECT_CONFIG` to any of the common boolean-env-var conventions (`true`/`false`, `1`/`0`, `yes`/`no`, case-insensitive) is accepted and behaves predictably, without the process refusing to start.
+
+### Out of Scope
+
+- Changing the `MCPLS_LOG` / `--log-level` parsing (already permissive — validated later, not at parse time; see `test_log_level_case_sensitive`)
+- Adding boolean-convention parsing to any other config surface (e.g. `mcpls.toml` fields) — this spec covers only the two CLI/env flags named above
+- Redesigning `logging::init` or the crash-path JSON guarantee itself (only the arg-parsing entry point that gates it)
+- Introducing a general-purpose "flexible bool" crate dependency without evaluating the custom-parser alternative first (see Open Questions)
+
+## 2. User Stories
+
+### US-001: Operator sets `MCPLS_LOG_JSON` via a `1`/`0` env convention
+AS A platform operator deploying mcpls in Docker/Kubernetes/systemd
+I WANT `MCPLS_LOG_JSON=1` (or `0`) to be accepted the same way `true`/`false` is
+SO THAT I don't need to special-case mcpls's env var format against my organization's standard boolean-env-var convention
+
+**Acceptance criteria:**
+```
+GIVEN the environment variable MCPLS_LOG_JSON=1
+WHEN mcpls starts
+THEN it starts successfully with JSON-formatted logging enabled (equivalent to MCPLS_LOG_JSON=true)
+
+GIVEN the environment variable MCPLS_LOG_JSON=0
+WHEN mcpls starts
+THEN it starts successfully with compact (non-JSON) logging (equivalent to MCPLS_LOG_JSON=false)
+```
+
+### US-002: Operator sets `MCPLS_LOG_JSON` via a `yes`/`no` env convention
+AS A platform operator
+I WANT `MCPLS_LOG_JSON=yes` / `MCPLS_LOG_JSON=no` to be accepted
+SO THAT common human-readable boolean conventions work without consulting mcpls-specific documentation
+
+**Acceptance criteria:**
+```
+GIVEN the environment variable MCPLS_LOG_JSON=yes
+WHEN mcpls starts
+THEN it starts successfully with JSON-formatted logging enabled
+
+GIVEN the environment variable MCPLS_LOG_JSON=no
+WHEN mcpls starts
+THEN it starts successfully with compact logging
+```
+
+### US-003: Operator sets a boolean env var with unexpected case
+AS A platform operator whose env-file tooling uppercases values (e.g. `TRUE`, `True`)
+I WANT case-insensitive matching for `true`/`false`/`1`/`0`/`yes`/`no`
+SO THAT casing conventions from my env management tooling don't break startup
+
+**Acceptance criteria:**
+```
+GIVEN the environment variable MCPLS_LOG_JSON=TRUE (or True, or YES, etc.)
+WHEN mcpls starts
+THEN it starts successfully with JSON-formatted logging enabled
+```
+
+### US-004: `MCPLS_TRUST_PROJECT_CONFIG` receives the same fix
+AS A platform operator who also configures MCPLS_TRUST_PROJECT_CONFIG
+I WANT the same accepted value set and case-insensitivity as MCPLS_LOG_JSON
+SO THAT the two boolean-env flags behave consistently and I don't hit the same class of bug twice
+
+**Acceptance criteria:**
+```
+GIVEN the environment variable MCPLS_TRUST_PROJECT_CONFIG=1
+WHEN mcpls starts
+THEN it starts successfully with project-local config trust enabled (equivalent to MCPLS_TRUST_PROJECT_CONFIG=true)
+```
+
+### US-005: Truly invalid value still fails clearly
+AS A platform operator who mistypes a boolean env var (e.g. `MCPLS_LOG_JSON=maybe`)
+I WANT a clear, actionable error message naming the accepted values
+SO THAT I can fix the typo quickly instead of guessing why startup failed
+
+**Acceptance criteria:**
+```
+GIVEN the environment variable MCPLS_LOG_JSON=maybe
+WHEN mcpls starts
+THEN the process exits nonzero with an error message that lists the accepted values (true/false, 1/0, yes/no, case-insensitive)
+```
+
+## 3. Functional Requirements
+
+Use EARS notation. Prefix with FR-NNN.
+
+| ID | Requirement | Priority |
+|----|------------|----------|
+| FR-001 | WHEN `--log-json` or `MCPLS_LOG_JSON` is set to `true`, `1`, or `yes` (any case) THE SYSTEM SHALL enable JSON-formatted logging | must |
+| FR-002 | WHEN `--log-json` or `MCPLS_LOG_JSON` is set to `false`, `0`, or `no` (any case) THE SYSTEM SHALL enable compact (non-JSON) logging | must |
+| FR-003 | WHEN `--trust-project-config` or `MCPLS_TRUST_PROJECT_CONFIG` is set to `true`, `1`, or `yes` (any case) THE SYSTEM SHALL trust and load a project-local `mcpls.toml` | must |
+| FR-004 | WHEN `--trust-project-config` or `MCPLS_TRUST_PROJECT_CONFIG` is set to `false`, `0`, or `no` (any case) THE SYSTEM SHALL NOT trust a project-local `mcpls.toml` | must |
+| FR-005 | WHEN `MCPLS_LOG_JSON` or `MCPLS_TRUST_PROJECT_CONFIG` is set to a value outside the accepted set THE SYSTEM SHALL reject startup with an error message naming the accepted values | must |
+| FR-006 | WHEN no value is supplied for `--log-json`/`MCPLS_LOG_JSON` THE SYSTEM SHALL default to JSON logging disabled (compact logging), preserving current default behavior | must |
+| FR-007 | WHEN no value is supplied for `--trust-project-config`/`MCPLS_TRUST_PROJECT_CONFIG` THE SYSTEM SHALL default to trust disabled, preserving current default behavior | must |
+| FR-008 | WHERE the fix changes argument parsing THE SYSTEM SHALL apply the identical accepted-value set and case-insensitivity to both `log_json` and `trust_project_config` (no divergence between the two flags) | must |
+
+## 4. Non-Functional Requirements
+
+| ID | Category | Requirement |
+|----|----------|-------------|
+| NFR-001 | Compatibility | `MCPLS_LOG_JSON=true` and `MCPLS_LOG_JSON=false` (today's only accepted values) continue to work exactly as before — no regression for existing operators |
+| NFR-002 | Compatibility | The bare `--log-json` / `--trust-project-config` flag (no `=value`, i.e. presence-implies-true CLI usage) continues to work exactly as before |
+| NFR-003 | Usability | Error output for an invalid boolean value is human-readable and enumerates the accepted values; it does not require reading source code to resolve |
+| NFR-004 | Maintainability | The parsing logic for both flags is not duplicated — implemented once and shared, or implemented via the same clap mechanism for both fields |
+| NFR-005 | Testability | Unit tests cover every accepted value (`true`/`false`, `1`/`0`, `yes`/`no`) in at least two case variants (lowercase and one non-lowercase variant) for both flags, plus at least one rejected value |
+
+## 5. Data Model
+
+No new domain entities. This is a parsing-behavior change on two existing CLI/env-backed fields.
+
+| Entity | Description | Key Attributes |
+|--------|-------------|----------------|
+| `Args::log_json` | CLI flag / env var controlling structured JSON logging | `bool`, sourced from `--log-json` or `MCPLS_LOG_JSON` |
+| `Args::trust_project_config` | CLI flag / env var controlling whether a project-local `mcpls.toml` is trusted | `bool`, sourced from `--trust-project-config` or `MCPLS_TRUST_PROJECT_CONFIG` |
+
+## 6. Edge Cases and Error Handling
+
+| Scenario | Expected Behavior |
+|----------|-------------------|
+| `MCPLS_LOG_JSON=1` | Accepted, equivalent to `true` (FR-001) |
+| `MCPLS_LOG_JSON=0` | Accepted, equivalent to `false` (FR-002) |
+| `MCPLS_LOG_JSON=yes` / `no` | Accepted per FR-001/FR-002 |
+| `MCPLS_LOG_JSON=TRUE` / `True` / `YES` | Accepted, case-insensitive (FR-001) |
+| `MCPLS_LOG_JSON=maybe` / empty string / `2` | Rejected with a clear, non-cryptic error naming accepted values (FR-005); process still exits nonzero before startup, same as today's fail-fast behavior — only the error clarity changes, not the fail-fast contract |
+| `--log-json` passed with no value (bare flag) | Continues to behave as `true` (unchanged, NFR-002) |
+| Both `--log-json` CLI flag and `MCPLS_LOG_JSON` env var set to conflicting values | Unchanged from current clap precedence rules (CLI flag wins over env var) — this spec does not alter precedence, only value parsing |
+| `MCPLS_TRUST_PROJECT_CONFIG` with any of the above values | Same behavior as `MCPLS_LOG_JSON`, mirrored per FR-003/FR-004/FR-008 |
+| A future third boolean-env flag is added to `args.rs` | Should reuse the same shared parser (NFR-004) rather than reintroducing plain `bool` + clap default parsing |
+
+## 7. Success Criteria
+
+| ID | Metric | Target |
+|----|--------|--------|
+| SC-001 | All reproduction cases from the filed issue (`TRUE`, `1`, `0`, `yes`, `no`) start mcpls successfully instead of erroring | 100% of listed cases pass |
+| SC-002 | Existing accepted values (`true`, `false`, bare flag, default/unset) continue to behave identically to pre-fix behavior | No regression in existing `args.rs` test suite |
+| SC-003 | New unit tests covering the accepted value matrix for both `log_json` and `trust_project_config` | All pass in `cargo nextest run --workspace --all-features` |
+| SC-004 | Invalid value error message is inspectable in a test and contains the accepted-value list | Verified by at least one negative test case |
+
+## 8. Agent Boundaries
+
+### Always (without asking)
+- Run `cargo +nightly fmt --all -- --check`, `cargo clippy --all-targets --all-features --workspace -- -D warnings`, and `cargo nextest run --workspace --all-features --lib --bins` before considering the fix complete
+- Preserve existing default values (`log_json` defaults to `false`, `trust_project_config` defaults to `false`)
+- Update `CHANGELOG.md` under `[Unreleased]`
+- Update or extend the existing test module in `crates/mcpls-cli/src/args.rs` (`mod tests`) rather than creating a parallel test file, following existing patterns (e.g. `test_log_json_default_false`, `test_trust_project_config_flag`)
+- Update the doc comments on `trust_project_config` (line 34-35) and `log_json` (line 45) to reflect the new accepted-value set, since the current doc comment explicitly (and now incorrectly) states "only the literal values `true`/`false` are accepted"
+
+### Ask First
+- Adding a new external crate dependency (e.g. a "flexible bool" parsing crate) if a custom `value_parser` function achieves the same result without one — prefer the zero-dependency approach per the project's Simplicity principle unless there's a strong reason
+- Changing clap CLI-vs-env precedence behavior (out of scope, but touching the same attributes might tempt this)
+
+### Never
+- Change the default value of either flag (both must remain `false` by default)
+- Silently swallow an invalid value instead of erroring (FR-005 requires a hard failure with a clear message — this is a parsing fix, not a "make everything permissive" change)
+- Modify `logging::init` itself or the crash-path JSON stderr guarantee logic (out of scope; this spec is about the arg-parsing gate in front of it)
+
+## 9. Open Questions
+
+- [NEEDS CLARIFICATION: Should the fix use a custom clap `value_parser` function (e.g. `fn parse_bool_env(s: &str) -> Result<bool, String>`) applied via `#[arg(value_parser = parse_bool_env, ...)]`, keeping the field type as `bool`? This is the minimal-dependency approach consistent with the project's Simplicity principle and requires no new crate.]
+- [NEEDS CLARIFICATION: Alternatively, should the project adopt a small typed wrapper (e.g. a local `EnvBool` newtype implementing `FromStr`) shared by both fields, to satisfy NFR-004 (no duplicated parsing logic) more explicitly than two separate `value_parser` attributes pointing at the same function? A single shared free function passed to both `#[arg(value_parser = ...)]` attributes likely satisfies NFR-004 without needing a newtype — recommend the free-function approach unless a third boolean-env flag appears in the near future.]
+- [NEEDS CLARIFICATION: Exact wording of the rejected-value error message — should it match clap's existing error format style (`error: invalid value '<value>' for '--log-json'`) with an appended hint listing accepted values, or fully replace clap's default formatter? Recommend appending a `value_parser`-returned `Err(String)` describing accepted values, since clap renders custom `value_parser` error strings as part of its standard error output — this keeps error UX consistent with the rest of the CLI without requiring changes to error formatting infrastructure.]
+- [NEEDS CLARIFICATION: Should `1`/`0`/`yes`/`no` also be documented in `--help` output (the `env = "MCPLS_LOG_JSON"` doc comment), or is updating the doc comment prose sufficient? Recommend updating the doc comment prose only, per the "Always" boundary above — clap's derive macro does not make it easy to inject a custom "possible values" list for a value_parser-backed bool field without additional attribute plumbing, and that plumbing is not required by any FR in this spec.]
+
+## 10. See Also
+
+- [[constitution]] — project principles (not yet created for this project)
+- [[MOC-specs]] — all specifications
+- PR #285 (commit c25d756) — introduced `MCPLS_LOG_JSON` wiring into `logging::init`, source of the regression
+- Issue #279 — original request for `--log-json` support
+- `crates/mcpls-cli/src/args.rs` — file containing both affected fields (`log_json` line 46-47, `trust_project_config` line 36-37)

--- a/specs/runtime/002-sigterm-stdin-blocking-pool-hang/spec.md
+++ b/specs/runtime/002-sigterm-stdin-blocking-pool-hang/spec.md
@@ -1,0 +1,169 @@
+---
+aliases:
+  - SIGTERM stdio shutdown hang
+  - tokio blocking-pool stdin hang
+tags:
+  - sdd
+  - spec
+  - transport
+  - lsp
+  - bug
+created: 2026-08-05
+status: implemented
+related:
+  - "[[constitution]]"
+  - "[[lsp/001-lsp-server-lifecycle-and-respawn/spec]]"
+---
+
+# Feature: mcpls process actually exits on SIGTERM/SIGINT while a stdio client is still connected
+
+> [!info] Metadata
+> **Author**: rust-live-tester (filed from live-testing evidence, cycle 013)
+> **Related PR**: #270 (commit ec67fa4) — added `wait_for_shutdown_signal` / `run_stdio` signal handling, closed #241
+> **Related issue**: #241 (original "no SIGINT/SIGTERM handling, orphans LSP processes")
+
+> [!success] Resolution
+> Implemented by commit `8c3e172` (PR #321), closing #308: `crates/mcpls-cli/src/main.rs` now
+> calls `std::process::exit` as its final step instead of returning normally, resolving Open
+> Question 1 (Section 9) in favor of the `std::process::exit(0)` approach — scoped to the CLI
+> binary only, so `mcpls-core`'s `serve`/`serve_with`/`shutdown`/`run_stdio` keep their normal
+> `Result`-returning semantics for library embedders (satisfying FR-002/NFR-002). The same PR
+> also fixed `await_lsp_init_handle`'s timeout branch, which called `JoinHandle::abort()` without
+> re-awaiting it — a SIGTERM arriving mid-spawn could otherwise let `process::exit` run before the
+> aborted task's not-yet-registered LSP `Child` handles dropped, orphaning a process before
+> `kill_on_drop` could fire.
+>
+> Commit `9642857` (PR #328) followed up with a related hardening fix: `serve_with` previously
+> ran config validation, workspace-root heuristics, and background LSP spawning *before*
+> `run_stdio` ever registered a signal handler, and `run_stdio` itself only registered one after
+> the MCP `initialize` handshake resolved — a signal in that window fell through to the OS
+> default disposition (immediate termination, skipping `Translator::shutdown_servers`). A
+> `ShutdownSignal` is now constructed once, before any startup work, moved into whichever
+> transport runs, and reused for the whole process lifetime (previously `SIGINT` was
+> re-registered via a fresh `tokio::signal::ctrl_c()` listener on every wait, silently losing a
+> signal delivered while a different `select!` branch was being polled).
+>
+> Open Question 2 (cross-platform verification beyond macOS `sample`(1)) was not explicitly
+> addressed by either PR; the fix itself (`std::process::exit`) is platform-independent, but no
+> Linux-specific verification evidence was recorded in either commit.
+
+## 1. Overview
+
+### Problem Statement
+
+`run_stdio` (`crates/mcpls-core/src/transport.rs:189-211`) and `shutdown` (`crates/mcpls-core/src/lib.rs:646-659`) log a complete, correct shutdown sequence on `SIGTERM`/`SIGINT` — "shutdown signal received", "Shutting down LSP servers...", "LSP server shut down successfully", "MCPLS server shutting down", "mcpls shutdown complete" — and the spawned LSP child process (e.g. `rust-analyzer`) genuinely is killed. `run()` (`crates/mcpls-cli/src/main.rs:36-81`) then returns `Ok(())`, and `main()` returns `ExitCode::SUCCESS`.
+
+But if an MCP client is still connected over stdio (has not closed its write end of mcpls's stdin — the normal state for any live session, e.g. Claude Desktop/Code, a long-running agent), **the OS process itself does not exit**. It was confirmed still running and consuming a PID more than 30 minutes after its own log said shutdown was complete, and only a `SIGKILL` (or the client itself eventually closing stdin) ends it.
+
+Root cause, confirmed via `sample`(1) stack trace on macOS: the main thread is parked in `tokio::runtime::blocking::pool::BlockingPool::shutdown` → `Receiver::wait`, which is the `#[tokio::main]`-generated wrapper blocking on `Runtime::drop` after `main()`'s body returned. That drop waits for every outstanding `spawn_blocking` task to finish. One `tokio-rt-worker` thread is still executing `tokio::io::blocking::Blocking<std::io::Stdin>::poll_read` → `std::io::Stdin::read` → the raw `read()` syscall on the process's real stdin fd — a genuine blocking OS thread that `tokio::io::stdin()` uses internally (a well-documented tokio caveat: this thread cannot be cancelled and only returns when the fd sees more data or EOF). Since the client's write end is still open, that `read()` never returns, `BlockingPool::shutdown` never completes, and the process hangs indefinitely past the point where its own logs claim it already shut down.
+
+This directly contradicts the doc comment on `run_stdio` (`transport.rs:183-188`): "Returns as soon as either the stdio transport closes ... or a `SIGTERM`/`SIGINT` is received, so callers can run orderly cleanup ... before the process exits ... which is acceptable here since the process exits shortly after." The process does not exit shortly after — it exits only when the client disconnects, an event decoupled from the signal that was supposed to trigger shutdown.
+
+It also undermines the stated purpose of #270/#241: `wait_for_shutdown_signal`'s own doc comment says `SIGTERM` is "sent by containers and systemd." In that exact scenario — an orchestrator restarting/stopping the mcpls container while its MCP client is still attached — mcpls will not actually terminate within the orchestrator's grace period (commonly 10s for Docker/Kubernetes) and gets forcibly `SIGKILL`ed, which is precisely the "orphans processes / unclean shutdown" outcome #270 was written to prevent. In this specific hang, LSP child cleanup already completed correctly before the hang (no orphaned `rust-analyzer`), so the practical blast radius is a hung/unkillable-by-SIGTERM parent process and delayed container/pod termination, not orphaned LSP subprocesses — a narrower but still real regression of #270's goal.
+
+The HTTP transport (`run_http`) is not affected by this specific mechanism — it does not use `tokio::io::stdin()`.
+
+### Goal
+
+`mcpls` running the stdio transport actually terminates the OS process promptly after `SIGTERM`/`SIGINT`, regardless of whether the connected client has closed its end of stdin.
+
+### Out of Scope
+
+- HTTP transport shutdown (already bounded/verified correct — not affected by this mechanism)
+- The `panic = "abort"` cleanup-bypass limitation already documented as a known limitation on `Translator::shutdown_servers` (separate, already-acknowledged gap)
+- Redesigning the LSP-server graceful-shutdown handshake itself (`Translator::shutdown_servers` is confirmed working correctly)
+
+## 2. User Stories
+
+### US-001: Container orchestrator stops mcpls while a client is attached
+AS A platform operator running mcpls in Docker/Kubernetes with a long-lived MCP client connected
+I WANT `SIGTERM` to actually terminate the mcpls process within its normal shutdown logging window
+SO THAT rolling restarts/deploys don't rely on the orchestrator's `SIGKILL` fallback and don't delay pod/container termination
+
+**Acceptance criteria:**
+```
+GIVEN mcpls is running the stdio transport with an MCP client connected (client has not closed its stdin write end)
+WHEN mcpls receives SIGTERM
+THEN the OS process exits within a bounded, short time (comparable to today's logged shutdown duration, well under typical orchestrator grace periods)
+```
+
+### US-002: Existing SIGTERM log semantics stay truthful
+AS A developer relying on the shutdown log lines to know the process has stopped
+I WANT "mcpls shutdown complete" to mean the process is actually about to exit
+SO THAT monitoring/log-based automation isn't misled into thinking shutdown finished when the process is still alive
+
+**Acceptance criteria:**
+```
+GIVEN the "mcpls shutdown complete" log line has been emitted
+WHEN a caller checks process liveness immediately after
+THEN the process is gone or exits within a small fixed bound (not indefinitely blocked)
+```
+
+## 3. Functional Requirements
+
+| ID | Requirement | Priority |
+|----|------------|----------|
+| FR-001 | WHEN `SIGTERM`/`SIGINT` is received on the stdio transport THE SYSTEM SHALL terminate the OS process without waiting for the connected client to close its end of stdin | must |
+| FR-002 | WHEN the process terminates via FR-001 THE SYSTEM SHALL still have completed `Translator::shutdown_servers()` first (no orphaned LSP subprocesses — do not regress #241) | must |
+| FR-003 | WHERE the fix bypasses normal `Runtime::drop`/destructor semantics (e.g. via `std::process::exit`) THE SYSTEM SHALL flush all buffered log output before terminating | must |
+
+## 4. Non-Functional Requirements
+
+| ID | Category | Requirement |
+|----|----------|-------------|
+| NFR-001 | Compatibility | HTTP transport shutdown behavior is unchanged |
+| NFR-002 | Compatibility | Normal stdio-EOF shutdown (client disconnects first) continues to work exactly as today |
+| NFR-003 | Testability | A regression test can simulate "client stdin stays open across signal delivery" without relying on real process-level signals/timing (e.g. by exercising the `shutdown()` function directly and asserting it doesn't depend on stdin state) |
+
+## 5. Data Model
+
+No new domain entities — this is a process-lifecycle/shutdown-sequencing fix.
+
+## 6. Edge Cases and Error Handling
+
+| Scenario | Expected Behavior |
+|----------|-------------------|
+| Client closes stdin before SIGTERM arrives (today's already-working path) | Unaffected — process exits via existing stdio-EOF path |
+| Client stays connected, SIGTERM arrives | Process exits promptly anyway (this fix) |
+| `SIGKILL` sent instead of `SIGTERM` | Unaffected (already an immediate hard kill, out of scope) |
+| HTTP transport, any signal | Unaffected — does not use `tokio::io::stdin()` |
+| Panic under `panic = "abort"` | Unaffected — already a documented, separate known limitation |
+
+## 7. Success Criteria
+
+| ID | Metric | Target |
+|----|--------|--------|
+| SC-001 | Live repro: spawn mcpls, complete MCP `initialize`/`initialized` handshake, keep the client's stdin pipe open, send `SIGTERM` | Process (not just the logical shutdown sequence) exits within a few seconds |
+| SC-002 | No LSP subprocess left orphaned by the fix | `pgrep -P <mcpls_pid>` empty after shutdown, matching current (already-correct) behavior |
+| SC-003 | Existing shutdown/signal-handling unit and integration tests continue to pass | `cargo nextest run --workspace --all-features` green |
+
+## 8. Agent Boundaries
+
+### Always (without asking)
+- Verify the fix live: real `SIGTERM` sent to a running binary with an open client stdin pipe held by the test harness, confirming OS-level process exit (not just log output)
+- Preserve the already-correct LSP-server graceful shutdown (`Translator::shutdown_servers`) ordering — it must still run to completion before the process terminates
+- Run `cargo +nightly fmt --all -- --check`, `cargo clippy --all-targets --all-features --workspace -- -D warnings`, `cargo nextest run --workspace --all-features --lib --bins`
+- Update `CHANGELOG.md` under `[Unreleased]`
+
+### Ask First
+- Whether to call `std::process::exit()` directly in `main.rs` after the existing shutdown sequence (simplest, most common fix for this exact tokio caveat, but skips normal Rust destructors for anything constructed in `main`/`run` — confirm nothing relies on those running) vs. a more invasive restructuring (e.g. avoiding `tokio::io::stdin()` entirely in favor of a cancellable reader)
+
+### Never
+- Silently swallow the LSP-shutdown step to "speed up" exit — FR-002 requires it still runs
+- Change HTTP transport shutdown semantics as a side effect
+
+## 9. Open Questions
+
+- [NEEDS CLARIFICATION: Is `std::process::exit(0)` immediately after the existing "mcpls shutdown complete" log (with an explicit flush of the tracing writer first) an acceptable fix, or does the project want a more general solution that keeps `main`'s normal `ExitCode` return path (e.g. spawning `run_stdio`'s read loop in a way that's actually cancellable, or accepting the tokio `stdin()` limitation and documenting it instead of masking it)?]
+- [NEEDS CLARIFICATION: Should this be verified across platforms (Linux is the primary container/systemd deployment target; this was reproduced and stack-traced on macOS) before considering it fixed, given the root cause — tokio's internal stdin blocking-thread pool — is platform-independent but the `sample`(1) confirmation tooling used here is macOS-only? `lldb`/`gdb` + `/proc/<pid>/task/*/stack` would be the Linux equivalent.]
+
+## 10. See Also
+
+- [[constitution]] — project principles (not yet created for this project)
+- [[MOC-specs]] — all specifications
+- PR #270 (commit ec67fa4) — added the signal handling this bug affects, closed #241
+- Issue #241 — original "no SIGINT/SIGTERM handling" issue
+- `crates/mcpls-core/src/transport.rs:148-211` — `wait_for_shutdown_signal`, `run_stdio`
+- `crates/mcpls-core/src/lib.rs:633-659` — `shutdown()`
+- `crates/mcpls-cli/src/main.rs:15-34` — `#[tokio::main]` entry point whose generated `Runtime::drop` is where the hang occurs
+- tokio `io::stdin()` docs — documents the internal blocking-thread implementation this bug is rooted in

--- a/specs/testing/001-e2e-rust-analyzer-testing/_source.md
+++ b/specs/testing/001-e2e-rust-analyzer-testing/_source.md
@@ -1,0 +1,296 @@
+# Design: E2E Tests with Real rust-analyzer (Rev 2)
+
+**Status:** revised proposal
+**Owner:** architect
+**Date:** 2026-04-29
+**Scope:** crates/mcpls-core/tests/e2e
+**Supersedes:** Rev 1 (2026-04-29T16-30); responds to critic 2026-04-29T17-07-10
+
+## Changes from Rev 1
+
+- C1: switched from nextest-shared `OnceCell` (broken under process-per-test) to a **single driver test** model + an explicit `cargo test` carve-out for the e2e binary. Daemon variant kept as a documented fallback.
+- S1: readiness gate now subscribes to `$/progress` (`rustAnalyzer/Indexing`) with `rust-analyzer/serverStatus` as a secondary signal; hover-poll dropped.
+- S2: required-by-default; opt-out via `MCPLS_SKIP_RA=1`. Skip path returns a panic in the default policy and is only neutered for the documented MSRV/minimal job.
+- S4: each test binary copies the fixture into its own `TempDir` workspace.
+- S5: explicit mapping of **all 16** existing MCP tools (verified against `crates/mcpls-core/src/mcp/server.rs`); deferrals marked.
+- S3, M1–M8: addressed inline.
+
+## Goals
+
+1. Exercise the full MCP→mcpls→LSP→rust-analyzer path against a real language server.
+2. Cover **all 16 currently-implemented MCP tools** with at least one happy-path assertion each.
+3. Skip cleanly only in the documented MSRV/minimal CI job; default policy is "fail closed if rust-analyzer is missing".
+4. Pay rust-analyzer cold-start + index cost **once for the e2e suite**, not once per test.
+
+## Non-Goals
+
+- Replacing `MockLspServer` for protocol-level unit tests.
+- Performance benchmarks.
+- Multi-language coverage (Rust only).
+- New MCP tools (signature_help, type_definition, implementation, inlay_hint, etc. — not implemented in mcpls today; out of scope).
+
+---
+
+## 1. Process Model (resolves C1)
+
+### Problem
+
+cargo-nextest's default execution model is **process-per-test**: each `#[test]` runs in `<binary> --exact <name>`. A `static OnceCell` lives only for that single subprocess — meaning a per-binary harness re-spawns rust-analyzer for *every* test. Goal #4 cannot hold under nextest's default model.
+
+### Decision: dual-mode harness, default = single driver test
+
+The e2e suite is implemented as one `#[test] fn ra_e2e_suite()` in `tests/ra_e2e.rs` (a top-level integration test binary, *not* a nextest test_group case). It performs:
+
+1. Probe + spawn rust-analyzer once.
+2. Wait for indexing readiness (§3).
+3. Sequentially invoke a registry of sub-cases, each producing a structured `SubResult { name, outcome }`.
+4. After all sub-cases run, panic with an aggregated report iff any failed.
+
+This **preserves the cold-start amortization under both `cargo test` and `cargo nextest run`**: nextest sees one test, runs one process, harness lives for the whole suite.
+
+### Trade-offs accepted
+
+- **Loss of per-tool failure granularity in test output.** Mitigated by: (a) the aggregated failure report names every failed sub-case with its assertion message, (b) sub-cases continue past the first failure (collected, not propagated) so one regression doesn't mask others, (c) `MCPLS_RA_FILTER=<substring>` env var lets developers run a single sub-case locally.
+- Loss of nextest's per-test isolation. Acceptable because the only shared mutable state is rust-analyzer itself, and sub-cases avoid mutating fixture files — write tests use in-memory edits or per-case TempDir copies.
+- Cannot use nextest retry policy on individual sub-cases. Acceptable for a single-binary suite.
+
+### Rejected alternatives
+
+- **`cargo test` carve-out for the whole e2e binary.** Possible (`cargo test --test ra_e2e -- --test-threads=1`) but creates two divergent CI invocations; the single-driver design works under both runners and is preferred.
+- **Out-of-process rust-analyzer daemon keyed by `$CARGO_TARGET_TMPDIR/ra.lock`.** Most complex; defers no real benefit until we have >1 e2e binary. Documented as future option if the suite splits.
+- **`nextest` test-groups with `max-threads = 1`.** Still process-per-test — solves serialization, not amortization. Does not address C1.
+
+---
+
+## 2. Skip Policy (resolves S2)
+
+```rust
+// tests/common/ra_probe.rs
+pub enum Resolution { Found(PathBuf), Skipped(&'static str), Missing }
+
+pub fn resolve_rust_analyzer() -> Resolution {
+    if env::var_os("MCPLS_SKIP_RA").is_some_and(|v| v == "1") {
+        return Resolution::Skipped("MCPLS_SKIP_RA=1");
+    }
+    if let Some(p) = env::var_os("MCPLS_RUST_ANALYZER") {
+        return Resolution::Found(PathBuf::from(p));
+    }
+    match which::which("rust-analyzer") {
+        Ok(p) => Resolution::Found(p),
+        Err(_) => Resolution::Missing,
+    }
+}
+```
+
+Driver behavior:
+
+```rust
+match resolve_rust_analyzer() {
+    Found(p)   => run_suite(&p),
+    Skipped(r) => { println!("e2e suite skipped: {r}"); }   // visible under nextest --no-capture / cargo test default
+    Missing    => panic!("rust-analyzer not found; set MCPLS_SKIP_RA=1 to skip"),
+}
+```
+
+Notes:
+- `MCPLS_SKIP_RA=1` exact match — empty string does not skip (closes the `is_ok()` ambiguity).
+- Skip prints to stdout, not stderr — surfaces in the standard nextest summary.
+- MSRV/minimal CI job is the only place that sets `MCPLS_SKIP_RA=1`; default jobs install rust-analyzer (`rustup component add rust-analyzer`) and let a missing binary fail.
+
+---
+
+## 3. Readiness Gate (resolves S1)
+
+Hover-poll is rejected (cold rust-analyzer returns `null`, not a "loading" marker; result is indistinguishable from a real lookup miss).
+
+### Authoritative oracle
+
+Subscribe to LSP `$/progress` notifications during initialization. rust-analyzer reports indexing under the `rustAnalyzer/Indexing` (or `rust-analyzer/Indexing` on older versions) work-done token: `kind: "begin"` → ... → `kind: "end"`. Readiness = receipt of the `end` notification.
+
+Secondary fallback: rust-analyzer's experimental `rust-analyzer/serverStatus` notification (`{ health: "ok", quiescent: true }`).
+
+### Plumbing
+
+mcpls already caches LSP push notifications via `bridge/notifications.rs`. The harness reads them through `get_server_messages` (one of the existing 16 MCP tools — also exercised as a tool test). No new bridge code required.
+
+```rust
+pub async fn wait_until_indexed(client: &mut McpClient, deadline: Instant) -> Result<()> {
+    loop {
+        let msgs = client.call_tool("get_server_messages", json!({ "server": "rust-analyzer" }))?;
+        if has_progress_end(&msgs, "rustAnalyzer/Indexing")
+            || has_status_quiescent(&msgs)
+        {
+            return Ok(());
+        }
+        if Instant::now() > deadline {
+            bail!("rust-analyzer not quiescent within timeout; last messages: {msgs}");
+        }
+        tokio::time::sleep(Duration::from_millis(150)).await;
+    }
+}
+```
+
+Timeout default 60 s, override via `MCPLS_RA_INDEX_TIMEOUT_SECS`. The harness lock is **not** held across this wait (M3 fix): the readiness gate runs before sub-cases acquire the harness handle.
+
+### `WorkDoneProgress` initialization capability
+
+The harness's MCP `initialize` request must advertise `window.workDoneProgress = true`. Currently mcpls's MCP-side capabilities advertise it; verify in implementation. If absent, rust-analyzer omits progress notifications and the gate falls back to `serverStatus` only.
+
+---
+
+## 4. Fixture Isolation (resolves S4)
+
+Each suite run copies the committed `tests/fixtures/rust_workspace/` into a `TempDir` and points the generated `mcpls.toml` at the copy. Reasons:
+
+- Concurrent rust-analyzer instances (across this binary and any future e2e binary) would otherwise share `target/rust-analyzer/`, racing on RocksDB-style metadata.
+- Eliminates the `target/` and `Cargo.lock` pollution currently visible in `git status` (which prompted PR #120).
+- Lets diagnostic and rename sub-cases write modifications without touching the committed fixture.
+
+```rust
+fn stage_workspace() -> Result<TempDir> {
+    let src = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/rust_workspace");
+    let dst = TempDir::new()?;
+    fs_extra::dir::copy(&src, dst.path(), &copy_opts_overwrite_inside())?;
+    Ok(dst)
+}
+```
+
+Writable sub-cases (rename, format, code_action) operate on per-case file copies inside this TempDir.
+
+---
+
+## 5. Tool Coverage (resolves S5)
+
+The 16 implemented MCP tools, verified against `crates/mcpls-core/src/mcp/server.rs`:
+
+| # | MCP tool | Sub-case | Assertion |
+|---|----------|----------|-----------|
+| 1 | `get_hover` | hover over `add` decl | text contains `fn add` and the substring `i32` (≥3 occurrences); no exact label match (S3) |
+| 2 | `get_definition` | over `add` in `caller` | URI ends `/src/lib.rs`; line == decl line |
+| 3 | `get_references` | on `add` decl | ≥ 2 locations including decl + call site |
+| 4 | `get_diagnostics` | on per-case `broken.rs` (TempDir) — opens via tool call, debounces 1.5 s, then polls `get_cached_diagnostics` | severity Error; message matches regex `mismatched types\|expected.*found` |
+| 5 | `rename_symbol` | call `prepare_rename` first (M7), then rename `add` → `plus` | edit set covers decl + every call site; no edits outside `lib.rs` |
+| 6 | `get_completions` | inside `caller` after typing `ad` | candidate label `add` present |
+| 7 | `get_document_symbols` | `lib.rs` | symbol set ⊇ `{add, caller, Point}` with kinds Function/Function/Struct |
+| 8 | `format_document` | per-case copy of `bad_format.rs` (TempDir) | output equals committed golden file `tests/fixtures/golden/bad_format.fmt.rs`; rustfmt edition pinned via `rustfmt.toml` (S3) |
+| 9 | `workspace_symbol_search` | query `"add"` | non-empty; at least one entry has kind Function and name `add` |
+|10 | `get_code_actions` | at the diagnostic position from #4 | response contains an action whose `kind` starts with `quickfix` (S3 — narrowed from "≥1 action") |
+|11 | `prepare_call_hierarchy` | on `add` | exactly one item, name == `add` |
+|12 | `get_incoming_calls` | on the prepared item from #11 | ≥ 1 entry whose `from.name` == `caller` |
+|13 | `get_outgoing_calls` | on the prepared item from #11 | empty list (`add` calls nothing) |
+|14 | `get_cached_diagnostics` | after #4 has populated the cache | returns the same diagnostic as #4 (read path through cache only) |
+|15 | `get_server_logs` | after suite warmup | non-empty array; entries have `server: "rust-analyzer"` |
+|16 | `get_server_messages` | already exercised by readiness gate (§3) | progress-end or quiescent status observed |
+
+**Deferrals:** none. All 16 are covered. If implementation discovers a sub-case is unstable on rust-analyzer's pinned version, it must be marked with:
+
+```rust
+// TODO(critic): cover <tool> in e2e suite — see handoff 2026-04-29T17-07-10-critic.md
+```
+
+placed in `tests/ra_e2e.rs`, per the critic's deferral protocol.
+
+### Fixture surface (compilable as written) (M2 fix)
+
+```rust
+// tests/fixtures/rust_workspace/src/lib.rs
+use std::fmt;
+
+pub fn add(a: i32, b: i32) -> i32 { a + b }
+pub fn caller() -> i32 { add(1, 2) }
+
+pub struct Point { pub x: f64, pub y: f64 }
+
+impl fmt::Display for Point {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "({}, {})", self.x, self.y)
+    }
+}
+```
+
+`bad_format.rs` and `broken.rs` live in `tests/fixtures/rust_workspace/extras/` (excluded from the crate's mod tree by being in a non-mod path) and are copied into the per-case TempDir on demand.
+
+---
+
+## 6. Assertion Helpers
+
+`tests/common/assertions.rs` — plain functions:
+
+```rust
+pub fn assert_mcp_ok(resp: &Value) -> &Value;
+pub fn content_text(resp: &Value) -> String;
+pub fn assert_uri_ends_with(uri: &str, suffix: &str);
+pub fn assert_position(loc: &Value, line: u32, col: u32);
+pub fn assert_contains_symbol(symbols: &Value, name: &str, kind: i64);
+pub fn file_uri(p: &Path) -> String; // percent-encoded, scheme `file://`, handles macOS /var/folders (M1)
+```
+
+`file_uri` uses the `url` crate's `Url::from_file_path` which is already a transitive workspace dep — no new dependency required (verify before implementation).
+
+---
+
+## 7. Edge Cases
+
+| Case | Strategy |
+|------|----------|
+| Missing file URI | `get_hover` on `file:///does/not/exist.rs` → MCP error response (assert non-null `error`); harness does not panic. |
+| OOB position | Past EOF → empty MCP content (rust-analyzer returns `null` upstream). |
+| Empty workspace | Separate sub-case spawns a *second* rust-analyzer against a TempDir with only `Cargo.toml` + empty `src/lib.rs`; verifies init succeeds and `workspace_symbol_search("x")` returns empty. Pays a second cold start — accepted because it specifically validates the empty-workspace path. |
+| rust-analyzer crash | Driver wraps each sub-case in `AssertUnwindSafe + catch_unwind`; on transport error, all later sub-cases short-circuit to a "skipped — server dead" result; aggregated report still prints. |
+| Slow indexing | Readiness gate timeout via `MCPLS_RA_INDEX_TIMEOUT_SECS` (default 60). |
+| UTF-16 column (M6) | Sub-case uses a file with `let π = 1; π.checked_add(1)`; `get_hover` at the column of `.checked_add` must return a hover; assert that `bridge/encoding.rs` is converting UTF-16 columns by checking the response is non-null *and* that hovering one column earlier returns a hover for `π`, not `checked_add`. |
+| Diagnostic timing (M4) | After opening `broken.rs` via `get_hover` (forces `didOpen`), wait up to 5 s polling `get_cached_diagnostics` before asserting; diagnostics are debounced by rust-analyzer. |
+
+Concurrency tests remain out of scope here — covered in `integration/` against the translator-lock fix (issue #104).
+
+---
+
+## 8. CI Gating
+
+- **Default jobs:** `rustup component add rust-analyzer` in setup; no env vars needed; missing binary → suite panics.
+- **MSRV / minimal jobs:** set `MCPLS_SKIP_RA=1`; suite prints a skip line and returns success.
+- **Pinned-version job:** explicit `rust-analyzer-2026-NN-NN` install; the canonical signal.
+- **Nightly rust-analyzer job:** uses latest release; `continue-on-error: true`.
+- **Renovation:** Renovate (or Dependabot for actions) configured to bump the pinned RA version on a 2-week cadence. Documented in `CHANGELOG.md`.
+
+---
+
+## 9. File Layout
+
+```
+crates/mcpls-core/tests/
+├── common/
+│   ├── ra_probe.rs        (new)
+│   └── assertions.rs      (new)
+├── ra_e2e.rs              (new) — single-test driver binary; contains harness + sub-case registry
+└── fixtures/
+    ├── rust_workspace/
+    │   ├── src/lib.rs     (extend per §5)
+    │   └── extras/
+    │       ├── bad_format.rs   (new)
+    │       └── broken.rs       (new)
+    └── golden/
+        └── bad_format.fmt.rs   (new — pinned rustfmt edition)
+```
+
+`ra_e2e.rs` is a top-level integration test binary (separate from `e2e/` mod tree) so the single-driver model is unambiguous to nextest.
+
+---
+
+## 10. Open Questions for Implementer
+
+1. Verify mcpls advertises `window.workDoneProgress = true` in MCP→LSP `initialize`. If not, file a follow-up before merging the suite, since the readiness gate degrades to `serverStatus`-only.
+2. Verify `which` is already a workspace dev-dependency and its current MSRV ≤ project MSRV (M5). If not, pin a version that is.
+3. Confirm `url` crate is reachable as a non-dev dep for the `file_uri` helper, or add as `[dev-dependencies]`.
+4. Choose pinned rust-analyzer version for CI; current recommendation: `rust-analyzer 2026-04-21`.
+
+---
+
+## 11. Acceptance Criteria
+
+- `cargo nextest run --workspace --all-features` (default jobs) executes the e2e driver, exercises all 16 MCP tools, completes under 180 s wall clock, exits 0.
+- `cargo test --test ra_e2e` produces equivalent results.
+- Without rust-analyzer and without `MCPLS_SKIP_RA=1`, the suite fails (does not silently pass).
+- With `MCPLS_SKIP_RA=1`, the suite prints a skip line and exits 0.
+- Each suite invocation spawns rust-analyzer at most twice (main + empty-workspace edge case).
+- Suite output names every failing sub-case; no failure aborts later sub-cases.

--- a/specs/testing/001-e2e-rust-analyzer-testing/plan.md
+++ b/specs/testing/001-e2e-rust-analyzer-testing/plan.md
@@ -1,0 +1,172 @@
+---
+aliases:
+  - E2E rust-analyzer test suite plan
+tags:
+  - sdd
+  - plan
+  - testing
+  - lsp
+created: 2026-08-05
+status: implemented
+related:
+  - "[[spec]]"
+  - "[[constitution]]"
+---
+
+# Technical Plan: End-to-End MCP Tool Coverage Against a Real rust-analyzer
+
+> [!info] References
+> **Spec**: [[spec]]
+> **Original design doc**: `_source.md` (this directory) — "Design: E2E Tests with Real
+> rust-analyzer (Rev 2)", 2026-04-29, superseding a Rev 1 that a critic pass had rejected
+
+> [!important] What shipped vs. what was designed
+> This plan restates the Rev 2 design's architecture sections, each annotated with how the
+> shipped implementation (PRs #125, #126, #139, #225 — see spec.md's Resolution) matches or
+> deviates from it. The single largest deviation: **Section 2 (Skip Policy)** specified a
+> fail-closed *default* CI policy (every default job either installs rust-analyzer or explicitly
+> sets `MCPLS_SKIP_RA=1`); the shipped suite instead gates the whole test behind `#[ignore]`, so it
+> never runs under a default `cargo nextest run`/`cargo test` invocation at all — only under a
+> dedicated e2e job that passes `--ignored` (PR #126). The `MCPLS_SKIP_RA`/`MCPLS_RUST_ANALYZER`
+> mechanism itself shipped exactly as designed; it now only matters for that dedicated job's
+> internal MSRV/minimal variant, not for every default job as originally intended.
+
+## 1. Architecture
+
+### Process Model (resolves C1 from the original design)
+
+**Problem**: cargo-nextest's default execution model is process-per-test — each `#[test]` runs in
+its own `<binary> --exact <name>` subprocess. A per-binary harness re-spawning rust-analyzer for
+every test would make the suite's wall-clock cost scale with the number of tools covered.
+
+**Decision, as shipped**: one `#[test] fn ra_e2e_suite()` in `tests/ra_e2e.rs`, `#[ignore]`-gated.
+It:
+1. Probes + spawns rust-analyzer once (`common::ra_probe::resolve_rust_analyzer`).
+2. Waits for indexing readiness.
+3. Sequentially invokes a `sub_cases: &[SubCase]` registry, each producing a `SubResult { name,
+   outcome }`.
+4. After all sub-cases run, panics with an aggregated report iff any failed.
+
+This preserves cold-start amortization under both `cargo test -- --ignored` and `cargo nextest
+run -- --ignored`: nextest sees one test, runs one process, the harness lives for the whole suite.
+
+**Trade-offs accepted** (unchanged from the original design):
+- Loss of per-tool failure granularity in the nextest summary — mitigated by the aggregated
+  failure report naming every failed sub-case, sub-cases continuing past a first failure, and
+  `MCPLS_RA_FILTER`-style local filtering if a developer wants to isolate one case (verify exact
+  filtering mechanism against current `ra_e2e.rs` before relying on it in a follow-up).
+- Loss of nextest's per-test isolation — acceptable since the only shared mutable state is
+  rust-analyzer itself, and write sub-cases operate on a per-run `TempDir` copy.
+- No nextest retry policy on individual sub-cases — acceptable for a single-binary suite.
+
+**Rejected alternatives** (unchanged from the original design): a `cargo test` carve-out for the
+whole e2e binary (creates two divergent CI invocations); an out-of-process rust-analyzer daemon
+keyed by a lockfile (unnecessary complexity until a second e2e binary exists); nextest test-groups
+with `max-threads = 1` (solves serialization, not amortization — still process-per-test).
+
+### Skip Policy (resolves S2 — deviation noted above)
+
+```rust
+// tests/common/ra_probe.rs (as shipped)
+pub enum Resolution { Found(PathBuf), Skipped(&'static str), Missing }
+
+pub fn resolve_rust_analyzer() -> Resolution {
+    if env::var_os("MCPLS_SKIP_RA").is_some_and(|v| v == "1") {
+        return Resolution::Skipped("MCPLS_SKIP_RA=1");
+    }
+    if let Some(p) = env::var_os("MCPLS_RUST_ANALYZER") {
+        return Resolution::Found(PathBuf::from(p));
+    }
+    match which::which("rust-analyzer") {
+        Ok(p) => Resolution::Found(p),
+        Err(_) => Resolution::Missing,
+    }
+}
+```
+
+Driver behavior matches the original design (`Found` → run, `Skipped` → print + succeed,
+`Missing` → panic naming `MCPLS_SKIP_RA=1`). What changed is *when this code path is reached at
+all*: PR #126 added `#[ignore = "Requires rust-analyzer in PATH; set MCPLS_SKIP_RA=1 to skip or
+MCPLS_RUST_ANALYZER=<path> to override"]` directly on `ra_e2e_suite`, so a default invocation
+never calls `resolve_rust_analyzer` in the first place. The dedicated e2e CI job installs
+rust-analyzer and passes `--ignored`, making `Missing` effectively unreachable there too in
+practice; `MCPLS_SKIP_RA=1` remains available for any CI variant that explicitly wants to run the
+`--ignored` tests without rust-analyzer present (e.g. a hypothetical MSRV/minimal `--ignored` run).
+
+### Readiness Gate (resolves S1)
+
+Shipped as designed: subscribes to LSP `$/progress` (`rustAnalyzer/Indexing`), with
+`rust-analyzer/serverStatus` (`quiescent: true`) as a secondary signal, read through the existing
+`get_server_messages` MCP tool (no new bridge code required — `bridge/notifications.rs` already
+caches these). Hover-poll was rejected in the original design (cold rust-analyzer returns `null`,
+indistinguishable from a genuine miss) and was not revisited.
+
+### Fixture Isolation (resolves S4)
+
+Shipped as designed: each run copies the committed `tests/fixtures/rust_workspace/` into a fresh
+`TempDir` via `stage_workspace()`, so concurrent rust-analyzer instances never race on shared
+`target/` metadata, and write sub-cases (rename, format) never touch the committed fixture.
+
+### Tool Coverage (resolves S5 — grown since the original design)
+
+The original design enumerated all 16 MCP tools that existed as of 2026-04-29. Coverage has since
+grown alongside the tool surface: PR #139 added sub-cases for the four LSP 3.17-era tools
+(`get_signature_help`, `go_to_implementation`, `go_to_type_definition`, `get_inlay_hints` —
+[[lsp/002-lsp317-missing-tools/spec|spec lsp/002]]) and four MCP-resources sub-cases
+(`sc_list_resources`, `sc_read_resource`, `sc_subscribe_unsubscribe_resource`,
+`sc_subscribe_no_replay_without_cached_diagnostics` — [[mcp/002-mcp-resources-diagnostics/spec|spec
+002]]), bringing the registry to 24 sub-cases covering all 20 current MCP tools plus the resource
+protocol. See `tests/ra_e2e.rs`'s `sub_cases` registry for the authoritative, current list — do
+not rely on the original design doc's 16-row table as current.
+
+## 2. Project Structure
+
+```
+crates/mcpls-core/tests/
+├── common/
+│   ├── ra_probe.rs        # Resolution: Found/Skipped/Missing
+│   └── assertions.rs      # shared assertion helpers
+├── ra_e2e.rs              # single-test driver: harness + sub-case registry (1508 lines)
+└── fixtures/
+    └── rust_workspace/    # staged into a per-run TempDir by stage_workspace()
+```
+
+## 3. Testing Strategy
+
+| Level | Framework | What to Test | Coverage Target |
+|-------|-----------|---------------|-------------------|
+| E2E (this suite) | `cargo nextest`/`cargo test`, `--ignored` | Every MCP tool's real round trip through mcpls to rust-analyzer | 24/24 sub-cases pass with rust-analyzer installed |
+| Unit/integration (unchanged, out of scope here) | `MockLspServer` | Protocol-level translation logic in isolation | Existing coverage, not modified by this suite |
+
+## 4. CI Gating (as shipped, deviating from the original design's Section 8)
+
+- **Dedicated e2e job**: installs rust-analyzer, invokes with `--ignored`; this is the only job
+  that exercises `ra_e2e_suite` at all.
+- **All other jobs** (including MSRV/minimal): do not pass `--ignored`, so `ra_e2e_suite` never
+  runs — `MCPLS_SKIP_RA` is not needed for these to pass, unlike the original design's assumption
+  that MSRV/minimal would need to explicitly opt out of a fail-closed default.
+- **Renovation**: the original design's proposal to pin and periodically bump a specific
+  rust-analyzer release via Renovate/Dependabot was not confirmed as implemented — verify current
+  CI workflow configuration before relying on a specific pinned version being tracked.
+
+## 5. Rollout Plan (historical — already executed)
+
+1. PR #125: initial suite, 16 tools, single driver, fixture staging, skip policy.
+2. PR #126: `#[ignore]` gating + e2e CI job installs rust-analyzer (skip-policy deviation).
+3. PR #139: extended to LSP 3.17 tools + MCP resources (24 sub-cases).
+4. PR #225: fixed hover off-by-one and diagnostics-replay-on-subscribe bugs the suite itself
+   surfaced — the suite's first documented regression catch.
+
+## 6. Risks and Mitigations
+
+| Risk | Impact | Probability | Mitigation |
+|------|--------|--------------|-------------|
+| A new MCP tool is added without a corresponding `sc_*` sub-case | medium | medium | No automated enforcement exists; relies on spec.md's Agent Boundaries "Always" rule and PR review |
+| `#[ignore]`-gating means the suite doesn't run on every PR, only the dedicated e2e job | medium | low (job runs on every PR per current CI, verify before relying on this) | Tracked as an Open Question in spec.md; revisit if the dedicated job's trigger conditions ever narrow |
+| Pinned rust-analyzer version in the dedicated e2e job drifts stale | low | medium | Original design proposed a Renovate/Dependabot bump cadence; verify this is actually configured, not just proposed |
+
+## See Also
+
+- [[spec]] — feature specification
+- [[MOC-specs]] — all specifications
+- `_source.md` — original Rev 2 design doc, preserved verbatim

--- a/specs/testing/001-e2e-rust-analyzer-testing/spec.md
+++ b/specs/testing/001-e2e-rust-analyzer-testing/spec.md
@@ -1,0 +1,243 @@
+---
+aliases:
+  - E2E rust-analyzer test suite
+  - ra_e2e
+tags:
+  - sdd
+  - spec
+  - testing
+  - lsp
+created: 2026-08-05
+status: implemented
+related:
+  - "[[constitution]]"
+  - "[[mcp/001-mcp-tool-surface-and-routing/spec]]"
+  - "[[lsp/002-lsp317-missing-tools/spec]]"
+  - "[[mcp/002-mcp-resources-diagnostics/spec]]"
+---
+
+# Feature: End-to-End MCP Tool Coverage Against a Real rust-analyzer
+
+> [!info] Metadata
+> **Author**: architect (design doc `e2e-rust-analyzer.md`, Rev 2, 2026-04-29); folded into the
+> numbered spec package during the `.local/specs/` → `specs/` migration
+> **Branch**: originally implemented across several PRs (see Resolution)
+> **Source finding**: `MockLspServer`-based unit/integration tests exercise the MCP↔LSP
+> translation layer in isolation, but nothing in the test suite drives the full
+> MCP→mcpls→LSP→rust-analyzer path against a real language server, so a class of bugs
+> (encoding negotiation, capability mismatches, real diagnostic timing/debounce) was only
+> ever caught live, not in CI
+
+> [!success] Resolution
+> Implemented incrementally, starting from this doc's own Rev 2 design:
+> - PR #125 (commit `6cae0e1`) — initial `tests/ra_e2e.rs` single-driver suite covering all
+>   16 MCP tools that existed at the time, plus `tests/common/ra_probe.rs` (skip/found/missing
+>   resolution) and the staged-`TempDir` fixture workflow, matching this doc's Sections 1-6.
+> - PR #126 (commit `0f40608`) — added `#[ignore = "Requires rust-analyzer in PATH; ..."]` to
+>   `ra_e2e_suite` and installed rust-analyzer in the dedicated e2e CI job. This is a **deviation**
+>   from Section 2's designed default policy ("fail closed if rust-analyzer is missing" for
+>   default jobs): the shipped suite is opt-in via `cargo nextest run -- --ignored` (or
+>   `cargo test -- --ignored`) in every job, not merely skip-able via `MCPLS_SKIP_RA=1` in the
+>   MSRV/minimal job as originally designed. `MCPLS_SKIP_RA=1` and `MCPLS_RUST_ANALYZER=<path>`
+>   (Section 2's `resolve_rust_analyzer`) are both still implemented as documented, in
+>   `tests/common/ra_probe.rs`.
+> - PR #139 (commit `027da84`) — extended coverage from 16 to the LSP 3.17-era tools added since
+>   (`get_signature_help`, `go_to_implementation`, `go_to_type_definition`, `get_inlay_hints` —
+>   closing [[lsp/002-lsp317-missing-tools/spec|spec lsp/002]]/#116) and the MCP resources surface
+>   (`list_resources`, `read_resource`, `subscribe`/`unsubscribe` — closing
+>   [[mcp/002-mcp-resources-diagnostics/spec|spec mcp/002]]).
+> - PR #225 — fixed off-by-one hover positions and a diagnostics-replay-on-subscribe bug the
+>   suite itself surfaced, demonstrating the suite catching a real regression before release.
+>
+> As of this writing `tests/ra_e2e.rs` runs 24 sub-cases (`sc_*` functions in a `sub_cases`
+> registry) covering all 20 current MCP tools plus the four resource-protocol sub-cases, still
+> as the single `#[test] fn ra_e2e_suite()` driver this doc's Section 1 (C1) specified — cold-start
+> amortization holds under both `cargo test` and `cargo nextest run`, one rust-analyzer spawn per
+> full suite run (plus the documented second spawn for the empty-workspace edge case).
+>
+> The full original Rev 2 design (`_source.md` in this directory) is preserved verbatim as the
+> most detailed available account of the pre-implementation design rationale; this `spec.md`
+> restates it in the project's standard template, and [[plan|plan.md]] carries the architecture
+> sections forward with resolution notes against what actually shipped.
+
+## 1. Overview
+
+### Problem Statement
+
+Before this suite existed, mcpls's test coverage for the MCP→LSP bridge was entirely
+`MockLspServer`-based (protocol-level unit/integration tests under `tests/e2e/protocol_tests.rs`
+and `tests/integration/`). A mock server can only ever respond the way its own stub logic says
+it should — it cannot catch bugs in the *real* negotiation between mcpls and an actual language
+server: capability mismatches, encoding negotiation (`bridge/encoding.rs`'s non-UTF-16 paths),
+real diagnostic push/pull timing (rust-analyzer's flycheck debounce), or any assumption baked
+into mcpls's LSP client that happens to hold against the mock but not against genuine
+rust-analyzer behavior.
+
+`tests/integration/rust_analyzer_tests.rs` already exercises some real-rust-analyzer paths, but
+narrowly — not as a systematic, registry-driven walk of every MCP tool mcpls exposes.
+
+### Goal
+
+Every MCP tool mcpls exposes has at least one automated test exercising the full
+MCP→mcpls→LSP→rust-analyzer round trip against a real rust-analyzer binary, run as part of the
+project's normal CI (opt-in via `--ignored`, per the Resolution's noted deviation from the
+original fail-closed design), with rust-analyzer's cold-start/indexing cost paid at most twice
+per suite run regardless of how many tools are covered.
+
+### Out of Scope
+
+- Replacing `MockLspServer`-based protocol-level unit tests — those remain the fast, deterministic
+  first line of coverage; this suite is a complementary, slower, real-server layer.
+- Performance benchmarking of rust-analyzer itself.
+- Multi-language e2e coverage (pyright, typescript-language-server, gopls, clangd, zls) — this
+  suite is Rust/rust-analyzer only, per the original design's Non-Goals.
+- New MCP tools — this spec covers testing the tools that exist, not adding new ones.
+
+## 2. User Stories
+
+### US-001: A capability-negotiation regression is caught in CI, not live
+
+AS A mcpls maintainer changing `bridge/encoding.rs` or the `initialize` handshake
+I WANT an automated suite that drives every MCP tool against a real rust-analyzer
+SO THAT a regression in position-encoding negotiation or capability handling fails CI instead of
+surfacing only when a live user hits it
+
+**Acceptance criteria:**
+```
+GIVEN rust-analyzer is installed and MCPLS_SKIP_RA is unset
+WHEN `cargo nextest run --workspace --all-features -- --ignored` (or the dedicated e2e CI job) runs
+THEN every currently-implemented MCP tool is exercised against real rust-analyzer and the suite
+     fails if any sub-case's assertion does not hold
+```
+
+### US-002: The suite stays fast despite testing every tool
+
+AS A CI maintainer
+I WANT rust-analyzer's cold-start/indexing cost paid once per suite run, not once per tool
+SO THAT adding tool coverage does not make the e2e job's wall-clock time scale linearly with the
+number of MCP tools
+
+**Acceptance criteria:**
+```
+GIVEN the e2e suite covers N tools (N = 20 as of this writing)
+WHEN the suite runs under cargo nextest (process-per-test by default)
+THEN rust-analyzer is spawned at most twice for the whole run (main suite + the dedicated
+     empty-workspace edge case), not once per tool
+```
+
+### US-003: A missing rust-analyzer binary fails loudly in the dedicated e2e job, cleanly elsewhere
+
+AS A contributor running the default test suite locally without rust-analyzer installed
+I WANT the e2e suite to not run at all by default (opt-in via `--ignored`)
+SO THAT `cargo nextest run --workspace --all-features` succeeds without requiring rust-analyzer,
+while the dedicated e2e CI job (which does pass `--ignored` and does install rust-analyzer) still
+fails loudly if the binary is missing or `MCPLS_SKIP_RA`/`MCPLS_RUST_ANALYZER` are misconfigured
+
+**Acceptance criteria:**
+```
+GIVEN rust-analyzer is not installed and the caller does not pass `--ignored`
+WHEN `cargo nextest run --workspace --all-features` (the default, non-e2e invocation) runs
+THEN ra_e2e_suite does not execute and the run succeeds
+
+GIVEN the dedicated e2e CI job passes `--ignored` and rust-analyzer is missing, with
+     MCPLS_SKIP_RA unset
+WHEN that job runs
+THEN ra_e2e_suite panics with a message naming MCPLS_SKIP_RA=1 as the opt-out
+```
+
+## 3. Functional Requirements
+
+| ID | Requirement | Priority |
+|----|------------|----------|
+| FR-001 | THE SYSTEM SHALL provide one `#[test]` driver (`ra_e2e_suite`) that spawns rust-analyzer at most once for the main suite plus once for the documented empty-workspace edge case, regardless of the number of MCP tools covered | must |
+| FR-002 | THE SYSTEM SHALL cover every currently-implemented MCP tool with at least one sub-case exercising the real MCP→mcpls→LSP→rust-analyzer path | must |
+| FR-003 | WHEN `MCPLS_SKIP_RA=1` is set THE SYSTEM SHALL print a skip line and return success without attempting to spawn rust-analyzer | must |
+| FR-004 | WHEN `MCPLS_RUST_ANALYZER=<path>` is set THE SYSTEM SHALL use that binary instead of resolving `rust-analyzer` from `PATH` | must |
+| FR-005 | WHEN rust-analyzer cannot be resolved (not skipped, no override, not found in `PATH`) THE SYSTEM SHALL panic with a message naming `MCPLS_SKIP_RA=1` as the opt-out, rather than silently passing | must |
+| FR-006 | THE SYSTEM SHALL NOT run `ra_e2e_suite` under a default (non-`--ignored`) `cargo nextest run`/`cargo test` invocation, since the test is marked `#[ignore]` | must |
+| FR-007 | WHEN one sub-case fails THE SYSTEM SHALL continue running the remaining sub-cases and report every failure in one aggregated panic message, rather than aborting at the first failure | must |
+| FR-008 | THE SYSTEM SHALL stage the committed `tests/fixtures/rust_workspace/` fixture into a fresh `TempDir` per suite run, so writable sub-cases (rename, format) never mutate the committed fixture | must |
+
+## 4. Non-Functional Requirements
+
+| ID | Category | Requirement |
+|----|----------|-------------|
+| NFR-001 | Performance | Wall-clock time for the full suite (cold rust-analyzer start + indexing + all sub-cases) must stay practical for a dedicated CI job; the original design targeted under 180s |
+| NFR-002 | Isolation | Each suite run operates on its own `TempDir` copy of the fixture workspace, so concurrent CI runs (or a future second e2e binary) do not race on shared `target/`/index state |
+| NFR-003 | Determinism | Readiness (rust-analyzer finished indexing) must be detected via an authoritative signal (`$/progress`/`rustAnalyzer/Indexing` end, or `serverStatus` quiescent), not a fixed sleep or a hover-poll heuristic that cannot distinguish "still loading" from "genuine miss" |
+| NFR-004 | Maintainability | Adding a new MCP tool should require adding one `sc_*` sub-case function and one registry entry, not restructuring the driver |
+
+## 5. Data Model
+
+Not a data-model feature — the relevant "entities" are test-harness constructs:
+
+| Entity | Description | Key Attributes |
+|--------|-------------|-----------------|
+| `Resolution` (`tests/common/ra_probe.rs`) | Outcome of resolving which rust-analyzer binary (if any) to use | `Found(PathBuf)`, `Skipped(&'static str)`, `Missing` |
+| `SubCase` (`tests/ra_e2e.rs`) | One registry entry: a named sub-case function | `name: &'static str`, `run: fn(&mut McpClient, &Path) -> Result<(), String>` |
+| `SubResult` (`tests/ra_e2e.rs`) | Outcome of running one `SubCase` | `name`, `outcome` (pass/fail with message) |
+
+## 6. Edge Cases and Error Handling
+
+| Scenario | Expected Behavior |
+|----------|--------------------|
+| rust-analyzer missing, `MCPLS_SKIP_RA` unset, suite invoked via `--ignored` | Panics naming `MCPLS_SKIP_RA=1` as the opt-out (FR-005) |
+| rust-analyzer missing, `MCPLS_SKIP_RA=1` | Prints a skip line, suite returns success (FR-003) |
+| One sub-case fails (e.g. a hover assertion) | Suite continues through the remaining sub-cases; aggregated failure report names every failed sub-case (FR-007) |
+| Empty workspace (no source files beyond `Cargo.toml` + empty `src/lib.rs`) | Separate sub-case spawns a second rust-analyzer instance against a minimal `TempDir`, verifying init succeeds and `workspace_symbol_search` returns empty — the one sanctioned second spawn per suite run |
+| A future MCP tool is added without a corresponding `sc_*` sub-case | Not automatically caught by the test framework — relies on the Agent Boundaries "Always" rule below being followed at implementation time |
+
+## 7. Success Criteria
+
+| ID | Metric | Target |
+|----|--------|--------|
+| SC-001 | `cargo nextest run --workspace --all-features -- --ignored` (or the dedicated e2e CI job) with rust-analyzer installed | Suite runs, exercises all 20 current MCP tools + 4 resource sub-cases, exits 0 |
+| SC-002 | `cargo nextest run --workspace --all-features` (default, no `--ignored`) | `ra_e2e_suite` does not run; suite completes without requiring rust-analyzer |
+| SC-003 | rust-analyzer spawn count per full suite run | At most 2 (main suite + empty-workspace edge case) |
+| SC-004 | A deliberately broken sub-case assertion | Suite fails with a report naming the specific failed sub-case, not a generic failure |
+
+## 8. Agent Boundaries
+
+### Always (without asking)
+- Add a new `sc_*` sub-case (and registry entry) whenever a new MCP tool is added to
+  `crates/mcpls-core/src/mcp/server.rs`, so `ra_e2e.rs` coverage stays in step with the tool surface
+- Keep the single-driver-test model (`#[test] fn ra_e2e_suite()`) rather than splitting into
+  per-tool `#[test]` functions, to preserve the cold-start amortization this spec requires (FR-001)
+- Preserve the `MCPLS_SKIP_RA`/`MCPLS_RUST_ANALYZER` env-var contract exactly (FR-003/FR-004)
+
+### Ask First
+- Changing the suite from `#[ignore]`-gated (opt-in via `--ignored`) back toward the original
+  fail-closed-by-default design (Section 2 of the Rev 2 doc) — this is a CI-policy decision with
+  cost implications (every default CI run would then require rust-analyzer installed)
+- Adding a second e2e binary or splitting the suite — changes the cold-start amortization
+  guarantee and reintroduces the process-per-test problem this design exists to avoid
+
+### Never
+- Restructure `ra_e2e.rs` such that rust-analyzer is spawned once per tool/sub-case — defeats
+  the entire point of this design (NFR-001, FR-001)
+- Let a sub-case abort the whole suite on first failure — must collect and report all failures
+  (FR-007)
+
+## 9. Open Questions
+
+- [NEEDS CLARIFICATION: Should the suite eventually move off `#[ignore]`-gating toward the
+  original fail-closed default policy now that rust-analyzer installation is already automated in
+  the dedicated e2e CI job? The current opt-in-via-`--ignored` approach is a safer default for
+  contributors running the full suite locally without rust-analyzer, but it does mean a
+  regression only surfaces in the dedicated e2e job, not every CI run.]
+- [NEEDS CLARIFICATION: Should multi-language e2e coverage (pyright, gopls, clangd, etc.) be
+  added as a follow-up, given this suite's single-driver-test pattern generalizes per language
+  server? Out of scope for this spec, per the original Non-Goals, but worth tracking as a
+  potential future spec.]
+
+## 10. See Also
+
+- [[plan|plan.md]] — architecture and rollout of this suite, adapted from the original Rev 2 design doc
+- [[constitution]] — project principles (not yet created for this project)
+- [[MOC-specs]] — all specifications
+- [[mcp/002-mcp-resources-diagnostics/spec|spec mcp/002]] — MCP resources design this suite's `sc_list_resources`/`sc_read_resource`/`sc_subscribe_unsubscribe_resource` sub-cases exercise
+- [[lsp/002-lsp317-missing-tools/spec|spec lsp/002]] — LSP 3.17 tools this suite's `sc_get_signature_help`/`sc_go_to_implementation`/`sc_go_to_type_definition`/`sc_get_inlay_hints` sub-cases exercise
+- `crates/mcpls-core/tests/ra_e2e.rs` — the suite itself
+- `crates/mcpls-core/tests/common/ra_probe.rs` — rust-analyzer resolution (`Found`/`Skipped`/`Missing`)
+- `_source.md` (this directory) — the original Rev 2 design doc, preserved verbatim
+- PR #125 (commit `6cae0e1`), #126 (commit `0f40608`), #139 (commit `027da84`), #225 — implementation history


### PR DESCRIPTION
## Summary

- Relocates the SDD spec package from `.local/specs/` (gitignored, main checkout only) to a tracked, repo-root `specs/` directory.
- Reorganizes all specs into functional blocks matching the crate's own module boundaries: `config/`, `lsp/`, `mcp/`, `bridge/`, plus two cross-cutting blocks, `runtime` (CLI args, signal/transport shutdown) and `testing` (e2e infrastructure). Numbering is block-scoped, restarting at 001 per block.
- Folds the previously loose `e2e-rust-analyzer.md` design doc into a proper numbered spec (`testing/001-e2e-rust-analyzer-testing/`), preserving the original as `_source.md`.
- Adds five new retroactive specs documenting core subsystems that previously had no first-class spec, verified against the current source: `bridge/001-position-encoding-layer`, `config/001-config-discovery-and-heuristics`, `lsp/001-lsp-server-lifecycle-and-respawn`, `bridge/002-document-tracker-synchronization`, `mcp/001-mcp-tool-surface-and-routing`.
- Regenerates `specs/MOC-specs.md` as a block-grouped index with a rationale note for cross-block placement calls.
- Rewrites every internal wikilink/cross-reference to the new block-qualified paths.

## Known follow-ups (not addressed in this PR, out of scope for a migration/reorg pass)

- `lsp/002-lsp317-missing-tools` (formerly `003`) still carries a stale `status: draft` even though all four proposed tools are already implemented and covered by the `testing/001` e2e suite — flagged with a warning callout in `MOC-specs.md`; a follow-up should add a proper Resolution callout citing the implementing PR(s).
- `specs/bridge/003-rwlock-translator`, `specs/mcp/002-mcp-resources-diagnostics`, `specs/lsp/002-lsp317-missing-tools` (the original specs 001-003) still use an older lightweight template without YAML frontmatter — left as-is, only renumbered.
- No `constitution.md` was created — this was a relocation/reorganization pass, not a full `/sdd init`.
- The old `.local/specs/` directory in the main checkout is gitignored and untracked, so it isn't part of this diff; it should be removed manually once this PR merges to avoid a stale duplicate.

## Test plan

- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features --workspace -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --lib --bins` (729 passed, 1 skipped)
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`

Docs-only change; no source files under `crates/`, `scripts/`, or `.github/` were touched.