### PR TITLE
docs(specs): mark lsp/002 spec as implemented

### DIFF
--- a/specs/MOC-specs.md
+++ b/specs/MOC-specs.md
@@ -18,7 +18,7 @@ rather than one subsystem). Numbering restarts at 001 within each block.
 | # | Slug | Type | Priority | Status | Issue |
 |---|------|------|----------|--------|-------|
 | 001 | [[lsp/001-lsp-server-lifecycle-and-respawn/spec\|lsp-server-lifecycle-and-respawn]] | enhancement | P1 | implemented (retroactive) | — |
-| 002 | [[lsp/002-lsp317-missing-tools/spec\|lsp317-missing-tools]] | enhancement | P3 | draft (tools now implemented — see [[testing/001-e2e-rust-analyzer-testing/spec\|testing/001]]'s Resolution; this spec's own status is stale, see note below) | #116 |
+| 002 | [[lsp/002-lsp317-missing-tools/spec\|lsp317-missing-tools]] | enhancement | P3 | implemented (#124) | #116 |
 | 003 | [[lsp/003-lsp-types-unmaintained-migration/spec\|lsp-types-unmaintained-migration]] | research | P2 | draft | #297 |
 | 004 | [[lsp/004-lsp-318-draft-gaps/spec\|lsp-318-draft-gaps]] | research | P4 | draft | #299 (also #116; #290 resolved by #289/#291) |
 
@@ -80,13 +80,3 @@ subsystem.
 >
 > Numbers are **block-scoped**, not global: `bridge/001` and `lsp/001` are different, unrelated
 > specs. Always cite a spec with its block prefix (e.g. `bridge/001`, never bare `001`).
-
-> [!warning] Known staleness: lsp/002 (formerly 003) vs. shipped code
-> [[lsp/002-lsp317-missing-tools/spec|lsp/002]]'s own file still says `**Status**: draft`, but all
-> four tools it proposes (`get_signature_help`, `go_to_implementation`, `go_to_type_definition`,
-> `get_inlay_hints`) are already implemented in `crates/mcpls-core/src/mcp/server.rs` and exercised
-> by [[testing/001-e2e-rust-analyzer-testing/spec|testing/001]]'s e2e suite. This migration did not
-> rewrite lsp/002's content (out of scope for a migration/reorganization pass — see the migration
-> report), but a human reviewer should follow up with a proper Resolution callout identifying the
-> implementing PR(s), consistent with how `bridge/005`/`runtime/001`/`runtime/002` already document
-> their own resolutions.

--- a/specs/lsp/002-lsp317-missing-tools/spec.md
+++ b/specs/lsp/002-lsp317-missing-tools/spec.md
@@ -1,8 +1,37 @@
+---
+aliases:
+  - LSP 3.17 Tools
+  - Signature Help, Implementation, Type Definition, Inlay Hints
+tags:
+  - sdd
+  - spec
+  - lsp
+  - mcp
+created: 2026-08-05
+status: implemented
+related:
+  - "[[testing/001-e2e-rust-analyzer-testing/spec]]"
+  - "[[lsp/004-lsp-318-draft-gaps/spec]]"
+---
+
 # Spec lsp/002: Add Missing LSP 3.17 Tools (Inlay Hints, Type Hierarchy, Signature Help)
+
+> [!info] Metadata
+> **Author**: filed from #368 migration follow-up
+> **Branch**: fix/369-stale-lsp317-spec-status
+> **Related issue**: #369 (staleness report), #116 (original tool request)
 
 **Type**: enhancement
 **Priority**: P3
-**Status**: draft
+**Status**: implemented
+
+> [!success] Resolution
+> Implemented by commit `87166fc` (PR #124), closing #116 and #115. All four tools
+> (`get_signature_help`, `go_to_implementation`, `go_to_type_definition`, `get_inlay_hints`)
+> are present in `crates/mcpls-core/src/mcp/server.rs` and exercised end-to-end by
+> `crates/mcpls-core/tests/ra_e2e.rs` and `crates/mcpls-core/tests/e2e/protocol_tests.rs`.
+> Each tool follows the existing 1-based MCP position convention and degrades gracefully when
+> the LSP server does not support the capability.
 
 ## Problem Statement
 


### PR DESCRIPTION
## Summary
- Update `specs/lsp/002-lsp317-missing-tools/spec.md` status from `draft` to `implemented`, add frontmatter (matching the convention used by other retroactively-documented specs), and add a `> [!success] Resolution` callout citing PR #124 (commit `87166fc`), which shipped all four proposed tools (`get_signature_help`, `go_to_implementation`, `go_to_type_definition`, `get_inlay_hints`).
- Remove the now-resolved "Known staleness" warning callout from `specs/MOC-specs.md` and update its status column to `implemented (#124)`.

## Test plan
- [x] Verified commit `87166fc` / PR #124 implements all four cited tools (`git show --stat`, `gh pr view`)
- [x] Verified the cited test files (`crates/mcpls-core/tests/ra_e2e.rs`, `crates/mcpls-core/tests/e2e/protocol_tests.rs`) exercise all four tools (`grep`)
- [x] Verified frontmatter/callout format matches sibling specs (`bridge/005`, `runtime/001`)
- [x] No source code changes; docs-only diff

Closes #369