### PR TITLE
refactor(error)!: remove four never-constructed Error variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 - **`mcpls_core::mcp::{PositionParams, RangeParams, ReferencesParams, RenameParams, CompletionsParams, DocumentSymbolsParams, FormatDocumentParams, WorkspaceSymbolParams, CallHierarchyCallsParams, DiagnosticsParams}`** — Breaking change: `mcp::mod`'s `pub use tools::{...}` re-export block is removed entirely. This includes `PositionParams`, which a previous entry in this changelog (#302) told embedders to use directly after the position-only wrapper structs were collapsed into it — that guidance no longer applies. No in-tree caller ever named any of these types through `mcp::mod` (every tool handler in `server.rs` extracts them via `Parameters<T>` from `mcp::tools` directly), and MCP tool arguments are ordinary JSON matching each tool's published schema, not a Rust type a caller needs to name. No deprecation shim, per pre-1.0 policy. (#367)
+- **`mcpls_core::Error`** — Breaking change: removed four never-constructed variants (`Shutdown`, `Config`, `EncodingError`, `PartialServerInit`); their intent is already covered by `ServerTerminated`/`InvalidConfig`/`ConfigNotFound`/`AllServersFailedToInit`. No deprecation shim, per pre-1.0 policy.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 - **`mcpls_core::mcp::{PositionParams, RangeParams, ReferencesParams, RenameParams, CompletionsParams, DocumentSymbolsParams, FormatDocumentParams, WorkspaceSymbolParams, CallHierarchyCallsParams, DiagnosticsParams}`** — Breaking change: `mcp::mod`'s `pub use tools::{...}` re-export block is removed entirely. This includes `PositionParams`, which a previous entry in this changelog (#302) told embedders to use directly after the position-only wrapper structs were collapsed into it — that guidance no longer applies. No in-tree caller ever named any of these types through `mcp::mod` (every tool handler in `server.rs` extracts them via `Parameters<T>` from `mcp::tools` directly), and MCP tool arguments are ordinary JSON matching each tool's published schema, not a Rust type a caller needs to name. No deprecation shim, per pre-1.0 policy. (#367)
-- **`mcpls_core::Error`** — Breaking change: removed four never-constructed variants (`Shutdown`, `Config`, `EncodingError`, `PartialServerInit`); their intent is already covered by `ServerTerminated`/`InvalidConfig`/`ConfigNotFound`/`AllServersFailedToInit`. No deprecation shim, per pre-1.0 policy.
+- **`mcpls_core::Error`** — Breaking change: removed four never-constructed variants (`Shutdown`, `Config`, `EncodingError`, `PartialServerInit`); their intent is already covered by `ServerTerminated`/`InvalidConfig`/`ConfigNotFound`/`AllServersFailedToInit`. No deprecation shim, per pre-1.0 policy. (#373)
 
 ### Fixed
 

--- a/crates/mcpls-core/src/error.rs
+++ b/crates/mcpls-core/src/error.rs
@@ -113,10 +113,6 @@ pub enum Error {
         tool: ToolKind,
     },
 
-    /// Configuration error.
-    #[error("configuration error: {0}")]
-    Config(String),
-
     /// Configuration file not found.
     #[error("configuration file not found: {0}")]
     ConfigNotFound(PathBuf),
@@ -149,10 +145,6 @@ pub enum Error {
     #[error("request timed out after {0} seconds")]
     Timeout(u64),
 
-    /// Server shutdown requested.
-    #[error("server shutdown requested")]
-    Shutdown,
-
     /// LSP server failed to spawn.
     #[error("failed to spawn LSP server '{command}': {source}")]
     ServerSpawnFailed {
@@ -170,10 +162,6 @@ pub enum Error {
     /// Invalid URI format.
     #[error("invalid URI: {0}")]
     InvalidUri(String),
-
-    /// Position encoding error.
-    #[error("position encoding error: {0}")]
-    EncodingError(String),
 
     /// Server process terminated unexpectedly.
     #[error("LSP server process terminated unexpectedly")]
@@ -231,17 +219,6 @@ pub enum Error {
         size: u64,
         /// Maximum allowed size.
         max: u64,
-    },
-
-    /// Partial server initialization - some servers failed but at least one succeeded.
-    #[error("some LSP servers failed to initialize: {failed_count}/{total_count} servers")]
-    PartialServerInit {
-        /// Number of servers that failed.
-        failed_count: usize,
-        /// Total number of configured servers.
-        total_count: usize,
-        /// Details of each failure.
-        failures: Vec<ServerSpawnFailure>,
     },
 
     /// All configured LSP servers failed to initialize.
@@ -389,7 +366,7 @@ mod tests {
     #[test]
     fn test_result_type_alias() {
         fn _returns_error() -> Result<i32> {
-            Err(Error::Config("test error".to_string()))
+            Err(Error::InvalidConfig("test error".to_string()))
         }
 
         let result: Result<i32> = Ok(42);
@@ -454,19 +431,6 @@ mod tests {
     }
 
     #[test]
-    fn test_error_display_partial_server_init() {
-        let err = Error::PartialServerInit {
-            failed_count: 2,
-            total_count: 3,
-            failures: vec![],
-        };
-        assert_eq!(
-            err.to_string(),
-            "some LSP servers failed to initialize: 2/3 servers"
-        );
-    }
-
-    #[test]
     fn test_error_display_all_servers_failed_to_init() {
         let err = Error::AllServersFailedToInit {
             count: 2,
@@ -499,25 +463,6 @@ mod tests {
 
         assert!(err.to_string().contains("all LSP servers failed"));
         assert!(err.to_string().contains("2 configured"));
-    }
-
-    #[test]
-    fn test_error_partial_server_init_with_failures() {
-        let failures = vec![ServerSpawnFailure {
-            server_id: ServerId::from("python"),
-            language_id: "python".to_string(),
-            command: "pyright".to_string(),
-            message: "not found".to_string(),
-        }];
-
-        let err = Error::PartialServerInit {
-            failed_count: 1,
-            total_count: 2,
-            failures,
-        };
-
-        assert!(err.to_string().contains("some LSP servers failed"));
-        assert!(err.to_string().contains("1/2"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Remove `Error::Shutdown`, `Error::Config`, `Error::EncodingError`, and `Error::PartialServerInit` from `mcpls_core::Error` — all had zero construction sites in the crate, and their intent is already covered by `ServerTerminated`, `InvalidConfig`/`ConfigNotFound`, and `AllServersFailedToInit` respectively.
- Remove the two now-orphaned unit tests (`test_error_display_partial_server_init`, `test_error_partial_server_init_with_failures`) and repoint `test_result_type_alias` from `Error::Config` to `Error::InvalidConfig`.
- Add a `CHANGELOG.md` entry under `[Unreleased] > Removed`.

This is a breaking change: `#[non_exhaustive]` only forces downstream match wildcards, it does not prevent constructing or matching these variants by name. `mcpls-core` is publishable (0.4.0), so this is a genuine semver break — acceptable pre-1.0, no deprecation shim added.

Closes #306

## Test plan
- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features --workspace -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --lib --bins` (727 passed, 1 skipped)
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`