### PR TITLE
feat(mcp): add tool_prefix config to disambiguate multiple mcpls bridges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added end-to-end and TOML parse-error test coverage for `workspace.max_documents`/`max_file_size` resource-limit config. (#376)
+- `[mcp].tool_prefix` config option: prefixes every MCP tool name with `{tool_prefix}_`, letting a client tell apart tools from multiple concurrently running mcpls bridges. (#353)
 
 ### Changed
 
+- **`McpConfig`** — Breaking change: gained a `tool_prefix` field; exhaustive struct-literal construction of `McpConfig` no longer compiles. (#353)
 - Relocated the SDD spec package from `.local/specs/` to repo-root `specs/`, reorganized into functional blocks (config/lsp/mcp/bridge/runtime/testing) with block-scoped numbering, and added retroactive specs for previously undocumented core subsystems (position encoding, config discovery, LSP lifecycle, document tracker sync, MCP tool routing). (#368)
 - **`DocumentTracker::update`** — Breaking change: now `async`, serializing against `ensure_open` for the same path. (#363)
 - Bump rmcp from 3.1.4 to 3.2.0; an `initialize` request naming `protocolVersion: 2026-07-28` now receives the server's negotiated legacy version in response instead of an echo of the requested version (rmcp behavior change) (#364)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added end-to-end and TOML parse-error test coverage for `workspace.max_documents`/`max_file_size` resource-limit config. (#376)
-- `[mcp].tool_prefix` config option: prefixes every MCP tool name with `{tool_prefix}_`, letting a client tell apart tools from multiple concurrently running mcpls bridges. (#353)
+- `[mcp].tool_prefix` config option: prefixes every MCP tool name with `{tool_prefix}_`, letting a client tell apart tools from multiple concurrently running mcpls bridges. (#377)
 
 ### Changed
 
-- **`McpConfig`** — Breaking change: gained a `tool_prefix` field; exhaustive struct-literal construction of `McpConfig` no longer compiles. (#353)
+- **`McpConfig`** — Breaking change: gained a `tool_prefix` field; exhaustive struct-literal construction of `McpConfig` no longer compiles. (#377)
 - Relocated the SDD spec package from `.local/specs/` to repo-root `specs/`, reorganized into functional blocks (config/lsp/mcp/bridge/runtime/testing) with block-scoped numbering, and added retroactive specs for previously undocumented core subsystems (position encoding, config discovery, LSP lifecycle, document tracker sync, MCP tool routing). (#368)
 - **`DocumentTracker::update`** — Breaking change: now `async`, serializing against `ensure_open` for the same path. (#363)
 - Bump rmcp from 3.1.4 to 3.2.0; an `initialize` request naming `protocolVersion: 2026-07-28` now receives the server's negotiated legacy version in response instead of an echo of the requested version (rmcp behavior change) (#364)

--- a/README.md
+++ b/README.md
@@ -145,6 +145,9 @@ Claude: [get_references] Found 4 matches:
 
 ## MCP Tools
 
+Names below are the defaults; if the bridge is configured with `mcp.tool_prefix`, every tool
+name gains that prefix (`{tool_prefix}_{tool}`).
+
 <details>
 <summary><strong>Code Intelligence</strong></summary>
 
@@ -267,6 +270,7 @@ project_markers = ["Cargo.toml", "rust-toolchain.toml", ".rust-version"]
 title = "My Custom Bridge"
 description = "Internal LSP bridge for Acme Corp"
 instructions = "Use get_hover before get_definition."
+tool_prefix = "optics"
 
 [workspace]
 roots = ["/path/to/project"]
@@ -295,7 +299,7 @@ language_id = "nushell"
 ```
 
 > [!NOTE]
-> `[mcp]` is entirely optional — omitting it (or any of its three fields)
+> `[mcp]` is entirely optional — omitting it (or any of its four fields)
 > keeps mcpls's built-in `serverInfo`/`instructions` text unchanged. A
 > configured `instructions` **replaces** the built-in capability blurb
 > rather than appending to it.

--- a/crates/mcpls-core/src/config/mod.rs
+++ b/crates/mcpls-core/src/config/mod.rs
@@ -116,6 +116,13 @@ pub struct McpConfig {
     /// after this value when set.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub instructions: Option<String>,
+
+    /// Prefixes every MCP tool name with `{tool_prefix}_`, so an MCP client
+    /// running multiple mcpls bridges concurrently (one per project) can
+    /// tell their tools apart. Omit to keep the default, unprefixed tool
+    /// names.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tool_prefix: Option<ToolPrefix>,
 }
 
 /// Maximum byte length of a configured [`McpConfig::title`].
@@ -136,6 +143,139 @@ pub const MAX_MCP_DESCRIPTION_BYTES: usize = 1024;
 /// fixed-size built-in text and does not count against this budget. See
 /// [`MAX_MCP_TITLE_BYTES`].
 pub const MAX_MCP_INSTRUCTIONS_BYTES: usize = 4096;
+
+/// Maximum byte length of a configured [`McpConfig::tool_prefix`].
+///
+/// UTF-8 bytes, not chars -- but since [`ToolPrefix`]'s charset is
+/// ASCII-only, bytes and chars coincide here. Chosen well under rmcp's
+/// 128-byte `SHOULD`-level tool name limit (`joined = prefix + '_' +
+/// tool_name`), and conservatively under stricter tool-name limits some LLM
+/// client APIs have historically enforced (e.g. `^[a-zA-Z0-9_-]{1,64}$`),
+/// so a prefix accepted here is unlikely to be rejected downstream by the
+/// client. See `mcp::server::MAX_TOOL_NAME_BYTES` for the compile-time proof
+/// tying this constant to the longest currently-registered tool name.
+pub const MAX_MCP_TOOL_PREFIX_BYTES: usize = 32;
+
+/// A validated [`McpConfig::tool_prefix`] value.
+///
+/// Every mcpls tool name gains a `{prefix}_` prefix when this is configured,
+/// so an MCP client can tell apart tools exposed by multiple concurrently
+/// running mcpls bridges. A value must be non-empty, at most
+/// [`MAX_MCP_TOOL_PREFIX_BYTES`] bytes, contain only ASCII letters, digits,
+/// `_`, and `-`, and both start and end with an ASCII letter or digit --
+/// this last rule rejects (rather than silently strips) a trailing
+/// separator, so `"optics"` and `"optics_"` cannot become two spellings of
+/// the same configuration. The validator runs once, at construction, making
+/// an invalid prefix unrepresentable: there is no way to observe a
+/// `ToolPrefix` whose value doesn't already satisfy these rules.
+///
+/// This differs from `title`/`description`/`instructions`, whose invalid
+/// values surface as [`Error::InvalidConfig`] from [`ServerConfig::validate`]
+/// -- called explicitly, after loading. A malformed prefix is not merely
+/// cosmetic (it would put an invalid tool name on the wire, an MCP protocol
+/// violation), and [`McplsServer::new`](crate::mcp::McplsServer::new)
+/// is `pub` and infallible, so this type validates eagerly during
+/// deserialization instead and surfaces failures as [`Error::TomlDe`], which
+/// additionally carries the offending line from the TOML source.
+///
+/// # Examples
+///
+/// ```
+/// use mcpls_core::config::ToolPrefix;
+///
+/// let prefix: ToolPrefix = "optics".parse().unwrap();
+/// assert_eq!(prefix.as_str(), "optics");
+/// assert!("optics_".parse::<ToolPrefix>().is_err());
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ToolPrefix(String);
+
+impl ToolPrefix {
+    /// Returns the validated prefix as a string slice.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::fmt::Display for ToolPrefix {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl std::str::FromStr for ToolPrefix {
+    type Err = String;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        validate_tool_prefix(s)?;
+        Ok(Self(s.to_string()))
+    }
+}
+
+impl<'de> Deserialize<'de> for ToolPrefix {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let value = String::deserialize(deserializer)?;
+        value.parse().map_err(serde::de::Error::custom)
+    }
+}
+
+/// Shared validator behind [`ToolPrefix::from_str`] and its `Deserialize`
+/// impl, so a prefix constructed programmatically is held to the same rules
+/// as one loaded from TOML.
+fn validate_tool_prefix(value: &str) -> std::result::Result<(), String> {
+    if value.trim().is_empty() {
+        return Err(
+            "mcp.tool_prefix cannot be empty (omit `tool_prefix` from the `[mcp]` section to \
+             use unprefixed tool names)"
+                .to_string(),
+        );
+    }
+    let len = value.len();
+    if len > MAX_MCP_TOOL_PREFIX_BYTES {
+        return Err(format!(
+            "mcp.tool_prefix exceeds the maximum of {MAX_MCP_TOOL_PREFIX_BYTES} bytes ({len} \
+             given)"
+        ));
+    }
+    if let Some(bad) = value
+        .chars()
+        .find(|c| !(c.is_ascii_alphanumeric() || *c == '_' || *c == '-'))
+    {
+        return Err(format!(
+            // `{bad:?}` (not `'{bad}'`): `char`'s `Debug` quotes and escapes
+            // control characters (e.g. ESC becomes `'\u{1b}'`), so a TOML
+            // value smuggling a raw control/ANSI-escape byte can't be
+            // echoed verbatim into this message and onward into a
+            // terminal via `tracing`.
+            "mcp.tool_prefix contains an invalid character {bad:?} (allowed: ASCII letters, \
+             digits, '_', and '-')"
+        ));
+    }
+    // `value.trim().is_empty()` above already rejected the empty string, so
+    // `next()`/`next_back()` never actually fall back here -- kept as a
+    // defensive default rather than an `unwrap()`, since `clippy::unwrap_used`
+    // is a workspace-wide warn-as-error (mirrors `validate_mcp_field` above).
+    let first = value.chars().next().unwrap_or_default();
+    let last = value.chars().next_back().unwrap_or_default();
+    if !first.is_ascii_alphanumeric() {
+        return Err(format!(
+            "mcp.tool_prefix cannot start with '{first}' (must start with an ASCII letter or \
+             digit)"
+        ));
+    }
+    if !last.is_ascii_alphanumeric() {
+        return Err(format!(
+            "mcp.tool_prefix cannot end with '{last}' (the '_' separator between the prefix \
+             and each tool name is inserted automatically by mcpls -- remove the trailing \
+             separator character)"
+        ));
+    }
+    Ok(())
+}
 
 /// Workspace-level configuration.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -2452,10 +2592,7 @@ mod tests {
         let tmp_dir = TempDir::new().unwrap();
         let config_path = tmp_dir.path().join("config.toml");
 
-        // `tool_prefix` is deliberately not implemented yet (deferred
-        // follow-up); `deny_unknown_fields` must reject it rather than
-        // silently ignoring it.
-        fs::write(&config_path, "[mcp]\ntool_prefix = \"x\"\n").unwrap();
+        fs::write(&config_path, "[mcp]\nbogus_field = \"x\"\n").unwrap();
 
         let result = ServerConfig::load_from(&config_path);
         assert!(matches!(result, Err(Error::TomlDe(_))));
@@ -2676,5 +2813,148 @@ mod tests {
 
         let result = ServerConfig::load_from(&config_path);
         assert!(result.is_ok(), "expected Ok, got {result:?}");
+    }
+
+    // ------------------------------------------------------------------
+    // ToolPrefix tests
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn test_tool_prefix_accepts_valid_and_round_trips() {
+        let tmp_dir = TempDir::new().unwrap();
+        let config_path = tmp_dir.path().join("config.toml");
+        fs::write(&config_path, "[mcp]\ntool_prefix = \"optics\"\n").unwrap();
+
+        let config = ServerConfig::load_from(&config_path).unwrap();
+        assert_eq!(config.mcp.tool_prefix.as_ref().unwrap().as_str(), "optics");
+
+        let serialized = toml::to_string_pretty(&config).unwrap();
+        let round_tripped: ServerConfig = toml::from_str(&serialized).unwrap();
+        assert_eq!(round_tripped.mcp.tool_prefix, config.mcp.tool_prefix);
+    }
+
+    #[test]
+    fn test_tool_prefix_accepts_digits_and_mixed_case() {
+        let prefix: ToolPrefix = "Optics2".parse().unwrap();
+        assert_eq!(prefix.as_str(), "Optics2");
+    }
+
+    #[test]
+    fn test_tool_prefix_accepts_single_alphanumeric_char() {
+        assert!("x".parse::<ToolPrefix>().is_ok());
+        assert!("9".parse::<ToolPrefix>().is_ok());
+    }
+
+    #[test]
+    fn test_tool_prefix_rejects_empty() {
+        let err = "".parse::<ToolPrefix>().unwrap_err();
+        assert_eq!(
+            err,
+            "mcp.tool_prefix cannot be empty (omit `tool_prefix` from the `[mcp]` section to \
+             use unprefixed tool names)"
+        );
+    }
+
+    #[test]
+    fn test_tool_prefix_rejects_whitespace_only() {
+        let err = "   ".parse::<ToolPrefix>().unwrap_err();
+        assert!(err.contains("cannot be empty"));
+    }
+
+    #[test]
+    fn test_tool_prefix_rejects_leading_separator() {
+        for bad in ["_optics", "-optics"] {
+            let err = bad.parse::<ToolPrefix>().unwrap_err();
+            assert!(
+                err.contains("cannot start with"),
+                "for input {bad:?}: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_tool_prefix_rejects_trailing_separator() {
+        for bad in ["optics_", "optics-"] {
+            let err = bad.parse::<ToolPrefix>().unwrap_err();
+            assert!(err.contains("cannot end with"), "for input {bad:?}: {err}");
+            assert!(err.contains("inserted automatically"));
+        }
+    }
+
+    #[test]
+    fn test_tool_prefix_rejects_dot() {
+        let err = "op.tics".parse::<ToolPrefix>().unwrap_err();
+        assert!(err.contains("invalid character '.'"));
+    }
+
+    #[test]
+    fn test_tool_prefix_rejects_space() {
+        let err = "op tics".parse::<ToolPrefix>().unwrap_err();
+        assert!(err.contains("invalid character ' '"));
+    }
+
+    #[test]
+    fn test_tool_prefix_rejects_non_ascii_and_names_the_character() {
+        let err = "optiсs".parse::<ToolPrefix>().unwrap_err();
+        assert!(err.contains("invalid character 'с'"), "{err}");
+    }
+
+    #[test]
+    fn test_tool_prefix_rejects_over_length() {
+        let prefix = "a".repeat(MAX_MCP_TOOL_PREFIX_BYTES + 1);
+        let err = prefix.parse::<ToolPrefix>().unwrap_err();
+        assert!(err.contains(&format!(
+            "exceeds the maximum of {MAX_MCP_TOOL_PREFIX_BYTES} bytes"
+        )));
+    }
+
+    #[test]
+    fn test_tool_prefix_accepts_exact_length_cap() {
+        let prefix = "a".repeat(MAX_MCP_TOOL_PREFIX_BYTES);
+        assert!(prefix.parse::<ToolPrefix>().is_ok());
+    }
+
+    #[test]
+    fn test_tool_prefix_from_str_shares_config_validator() {
+        // Proves the programmatic path (`ToolPrefix::from_str`, used by
+        // `serve_with` callers that build `McpConfig` directly) is held to
+        // the same rules as the TOML deserialization path, not a separate,
+        // looser check.
+        assert!("optics_".parse::<ToolPrefix>().is_err());
+        let tmp_dir = TempDir::new().unwrap();
+        let config_path = tmp_dir.path().join("config.toml");
+        fs::write(&config_path, "[mcp]\ntool_prefix = \"optics_\"\n").unwrap();
+        assert!(matches!(
+            ServerConfig::load_from(&config_path),
+            Err(Error::TomlDe(_))
+        ));
+    }
+
+    /// Pins the actual behavior of a `serde::de::Error::custom` raised from
+    /// inside `ToolPrefix`'s hand-written `Deserialize` impl, since the
+    /// `toml` crate's line-reference attachment for such errors is not
+    /// guaranteed by its public API and must be verified empirically rather
+    /// than assumed (see [`ToolPrefix`]'s doc comment on the `Error::TomlDe`
+    /// vs `Error::InvalidConfig` trade-off).
+    #[test]
+    fn test_invalid_tool_prefix_error_names_field_and_offending_character() {
+        let tmp_dir = TempDir::new().unwrap();
+        let config_path = tmp_dir.path().join("config.toml");
+        fs::write(&config_path, "[mcp]\ntool_prefix = \"optics_\"\n").unwrap();
+
+        let result = ServerConfig::load_from(&config_path);
+        let Err(Error::TomlDe(err)) = result else {
+            panic!("Expected TomlDe error, got {result:?}");
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("mcp.tool_prefix"), "{msg}");
+        assert!(msg.contains("cannot end with"), "{msg}");
+        // Empirically confirmed (not merely assumed): `toml` attaches a
+        // "line N, column M" reference to a `serde::de::Error::custom`
+        // raised from within a field's `Deserialize` impl, giving this
+        // error strictly more location information than the sibling
+        // `Error::InvalidConfig` fields (`title`/`description`/
+        // `instructions`) get.
+        assert!(msg.contains("line 2"), "{msg}");
     }
 }

--- a/crates/mcpls-core/src/mcp/server.rs
+++ b/crates/mcpls-core/src/mcp/server.rs
@@ -3,6 +3,7 @@
 //! This module provides the MCP server that exposes LSP capabilities
 //! as MCP tools using the rmcp SDK.
 
+use std::borrow::Cow;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
@@ -29,7 +30,7 @@ use crate::bridge::{
     DiagnosticInfo, DiagnosticsResult, NotificationCache, Position, PositionEncoding,
     ResourceSubscriptions, Translator, validate_path_against_roots,
 };
-use crate::config::McpConfig;
+use crate::config::{McpConfig, ToolPrefix};
 
 /// Built-in `serverInfo.title`, used when `[mcp].title` is not configured.
 const DEFAULT_SERVER_TITLE: &str = "MCPLS - MCP to LSP Bridge";
@@ -46,6 +47,47 @@ const DEFAULT_INSTRUCTIONS: &str = concat!(
     "capabilities as MCP tools for semantic code intelligence. ",
     "Supports hover, definition, references, diagnostics, rename, ",
     "completions, symbols, and formatting."
+);
+
+/// Byte length of the longest tool name currently registered
+/// (`workspace_symbol_search`), used only to keep
+/// [`crate::config::MAX_MCP_TOOL_PREFIX_BYTES`] safe (see the compile-time
+/// assertion below). Bumping this when a longer tool name is added is
+/// always safe on its own; the assertion is what catches the case where
+/// that growth would no longer leave enough room for the configured prefix.
+const MAX_TOOL_NAME_BYTES: usize = 23;
+
+/// The stricter of the two ceilings a joined `{prefix}_{tool_name}` must fit
+/// under: not rmcp's own 128-byte `SHOULD`-level limit (see the second
+/// assertion below), but the tighter pattern some LLM client APIs have
+/// historically enforced for tool names (`^[a-zA-Z0-9_-]{1,64}$`). This is
+/// the actual binding constraint [`crate::config::MAX_MCP_TOOL_PREFIX_BYTES`]'s
+/// doc comment promises to stay under -- asserting against it, not just
+/// rmcp's 128, is what makes that promise machine-checked.
+const CLIENT_TOOL_NAME_BYTE_LIMIT: usize = 64;
+
+/// Ties [`crate::config::MAX_MCP_TOOL_PREFIX_BYTES`] to the longest
+/// currently-registered tool name and the stricter client-side tool name
+/// length ceiling ([`CLIENT_TOOL_NAME_BYTE_LIMIT`]). If a future tool name
+/// grows past what the current prefix budget allows, this fails to
+/// *compile* against `MAX_TOOL_NAME_BYTES`, not silently or at runtime
+/// against the user-facing, config-breaking `MAX_MCP_TOOL_PREFIX_BYTES`.
+const _: () = assert!(
+    crate::config::MAX_MCP_TOOL_PREFIX_BYTES + 1 + MAX_TOOL_NAME_BYTES
+        <= CLIENT_TOOL_NAME_BYTE_LIMIT,
+    "MAX_TOOL_NAME_BYTES has grown too large for the configured MAX_MCP_TOOL_PREFIX_BYTES \
+     budget under the stricter client-side tool name length limit"
+);
+
+/// Secondary check against rmcp's own tool name length ceiling (128 bytes,
+/// `SHOULD`-level per the MCP spec; see `tool_name_validation.rs` in the
+/// pinned rmcp version). Kept alongside the stricter assertion above so a
+/// future change to [`CLIENT_TOOL_NAME_BYTE_LIMIT`] can't accidentally drop
+/// below what rmcp itself requires.
+const _: () = assert!(
+    crate::config::MAX_MCP_TOOL_PREFIX_BYTES + 1 + MAX_TOOL_NAME_BYTES <= 128,
+    "MAX_TOOL_NAME_BYTES has grown too large for the configured MAX_MCP_TOOL_PREFIX_BYTES \
+     budget under rmcp's 128-byte tool name limit"
 );
 
 /// Response shape for the `get_cached_diagnostics` tool.
@@ -81,6 +123,14 @@ struct CachedDiagnosticsResponse {
 #[derive(Clone)]
 pub struct McplsServer {
     context: Arc<BridgeContext>,
+
+    /// `Arc`-wrapped so `Clone` stays an `Arc` bump (as it is today via
+    /// `context`) rather than a deep clone of every registered
+    /// `ToolRoute` on each new session (see `transport.rs`'s per-session
+    /// factory closure). `#[tool_handler(router = self.tool_router)]`'s
+    /// generated `self.tool_router.call(..)` auto-derefs through the `Arc`,
+    /// so this is transparent to the macro-generated code.
+    tool_router: Arc<ToolRouter<Self>>,
 }
 
 /// Map a bridge-layer result to the MCP tool response shape shared by every `#[tool]` handler.
@@ -237,6 +287,7 @@ impl McplsServer {
         project_config_ignored: bool,
         mcp: McpConfig,
     ) -> Self {
+        let tool_router = Arc::new(Self::build_tool_router(mcp.tool_prefix.as_ref()));
         let context = Arc::new(BridgeContext::new(
             translator,
             notification_cache,
@@ -245,10 +296,15 @@ impl McplsServer {
             project_config_ignored,
             mcp,
         ));
-        Self { context }
+        Self {
+            context,
+            tool_router,
+        }
     }
 
-    /// Router for every MCP tool, with the read-only classification applied.
+    /// Router for every MCP tool, with the read-only classification applied
+    /// and, when `prefix` is configured, every tool name rewritten to
+    /// `{prefix}_{name}`.
     ///
     /// Every mcpls tool is a read-only LSP query: `rename_symbol`,
     /// `format_document` and `get_code_actions` return a *proposed*
@@ -258,13 +314,36 @@ impl McplsServer {
     /// `test_tool_annotation_classifications_match_intent` forces a future
     /// mutating tool to write down an explicit classification rather than
     /// inherit this default silently.
-    fn tool_router() -> ToolRouter<Self> {
+    ///
+    /// With `prefix: None` this returns byte-for-byte what it always has --
+    /// `test_tool_surface_matches_golden_snapshot` pins that as the
+    /// backward-compatibility guarantee for the default, unprefixed surface.
+    ///
+    /// The rename re-keys `router.map` via [`ToolRouter::add_route`] rather
+    /// than inserting directly, so it goes through rmcp's own
+    /// `validate_and_warn_tool_name` for defence-in-depth. It does **not**
+    /// re-key `ToolRouter`'s private `disabled` set -- inert today (mcpls
+    /// never calls `disable_route`/`with_disabled`, pinned by
+    /// `test_no_route_is_ever_disabled` below), but a latent bug the moment
+    /// that changes: any future `disable_route` call must name the
+    /// already-prefixed tool name and must run strictly after this rename.
+    fn build_tool_router(prefix: Option<&ToolPrefix>) -> ToolRouter<Self> {
         let mut router = Self::declared_tool_router();
         for route in router.map.values_mut() {
             let title = route.attr.title.clone();
             route.attr.annotations.get_or_insert_with(|| {
                 ToolAnnotations::from_raw(title, Some(true), Some(false), Some(true), None)
             });
+        }
+        if let Some(prefix) = prefix {
+            debug_assert!(router.map.keys().all(|name| router.has_route(name)));
+            let unprefixed = std::mem::take(&mut router.map);
+            let entry_count = unprefixed.len();
+            for (_, mut route) in unprefixed {
+                route.attr.name = Cow::Owned(format!("{prefix}_{}", route.attr.name));
+                router.add_route(route);
+            }
+            debug_assert_eq!(router.map.len(), entry_count);
         }
         router
     }
@@ -556,7 +635,7 @@ impl McplsServer {
 
     /// Get cached diagnostics for a file.
     #[tool(
-        description = "Cached diagnostics from server notifications. Faster than get_diagnostics, no new analysis.",
+        description = "Cached diagnostics from server notifications. Faster than the pull-model diagnostics tool, no new analysis.",
         title = "Cached Diagnostics"
     )]
     async fn get_cached_diagnostics(
@@ -742,7 +821,7 @@ impl McplsServer {
 // requires `async fn`; `#[tool_handler]` also expands other trait methods without
 // `.await`, so the lint is suppressed for the whole impl block.
 #[allow(clippy::unused_async_trait_impl)]
-#[tool_handler]
+#[tool_handler(router = self.tool_router)]
 impl ServerHandler for McplsServer {
     async fn list_resources(
         &self,
@@ -1048,6 +1127,7 @@ mod tests {
             title: Some("Custom Title".to_string()),
             description: Some("Custom description".to_string()),
             instructions: Some("Custom instructions.".to_string()),
+            tool_prefix: None,
         };
         let server = create_test_server_with_mcp_config(false, mcp);
         let info = server.get_info();
@@ -1072,6 +1152,7 @@ mod tests {
             title: None,
             description: None,
             instructions: Some(instructions.clone()),
+            tool_prefix: None,
         };
         let server = create_test_server_with_mcp_config(true, mcp);
         let info = server.get_info();
@@ -1927,9 +2008,9 @@ sleep 0.3
     /// Every registered tool must carry `ToolAnnotations` (plus the current-spec
     /// `Tool.title`) so MCP clients can decide when to skip confirmation dialogs
     /// (read-only tools) or must prompt the user (destructive tools) without
-    /// invoking the tool first. Sourced from `tool_router().list_all()` (not a
-    /// hand-written list of tool names). This test alone does not catch a
-    /// future *mutating* tool that omits `annotations(...)`: `tool_router()`'s
+    /// invoking the tool first. Sourced from `build_tool_router(None).list_all()`
+    /// (not a hand-written list of tool names). This test alone does not catch a
+    /// future *mutating* tool that omits `annotations(...)`: `build_tool_router()`'s
     /// central pass (see its doc comment) blanket-labels any such tool
     /// read-only rather than leaving it `None`, so the hint assertions above
     /// always pass. `test_tool_annotation_classifications_match_intent` below
@@ -1937,7 +2018,7 @@ sleep 0.3
     /// though it does not verify that classification is truthful.
     #[test]
     fn test_all_tools_carry_annotations() {
-        let tools = McplsServer::tool_router().list_all();
+        let tools = McplsServer::build_tool_router(None).list_all();
         assert!(!tools.is_empty(), "no tools registered");
 
         for tool in &tools {
@@ -1979,7 +2060,7 @@ sleep 0.3
     /// checked against the actual registered count.
     #[test]
     fn test_tool_annotation_classifications_match_intent() {
-        let tools = McplsServer::tool_router().list_all();
+        let tools = McplsServer::build_tool_router(None).list_all();
         let by_name: std::collections::HashMap<&str, &rmcp::model::ToolAnnotations> = tools
             .iter()
             .map(|tool| {
@@ -2407,18 +2488,18 @@ sleep 0.3
     #[test]
     #[ignore = "run manually to (re)generate tool_surface.json"]
     fn dump_tool_surface() {
-        let tools = McplsServer::tool_router().list_all();
+        let tools = McplsServer::build_tool_router(None).list_all();
         println!("{}", serde_json::to_string_pretty(&tools).unwrap());
     }
 
     /// Pins the client-visible tool surface (name, description, title,
-    /// annotations, input schema) exposed by `tool_router().list_all()`.
+    /// annotations, input schema) exposed by `build_tool_router(None).list_all()`.
     /// `serde_json::Value` comparison, not string comparison, so key
     /// order/whitespace drift doesn't cause false failures -- only an actual
     /// change to what an MCP client sees does.
     #[test]
     fn test_tool_surface_matches_golden_snapshot() {
-        let tools = McplsServer::tool_router().list_all();
+        let tools = McplsServer::build_tool_router(None).list_all();
         let actual = serde_json::to_value(&tools).unwrap();
         let expected: serde_json::Value =
             serde_json::from_str(include_str!("tool_surface.json")).unwrap();
@@ -2427,5 +2508,97 @@ sleep 0.3
             "client-visible tool surface changed -- update tool_surface.json only if the \
              change is intentional"
         );
+    }
+
+    // ------------------------------------------------------------------
+    // tool_prefix tests
+    // ------------------------------------------------------------------
+
+    /// Pins that `ToolRouter::disable_route`/`with_disabled` are unreachable
+    /// today, which is what makes `build_tool_router`'s rename pass safe to
+    /// skip re-keying the private `disabled` set (see its doc comment). If
+    /// this ever fails, a `disable_route` call was added somewhere and the
+    /// rename pass needs to be updated to preserve disabled state across
+    /// the rekey.
+    #[test]
+    fn test_no_route_is_ever_disabled() {
+        let router = McplsServer::build_tool_router(None);
+        for name in router.map.keys() {
+            assert!(
+                !router.is_disabled(name),
+                "route {name} is unexpectedly disabled"
+            );
+        }
+    }
+
+    /// Every currently-registered tool name must fit within
+    /// `MAX_TOOL_NAME_BYTES`, the constant the `MAX_MCP_TOOL_PREFIX_BYTES`
+    /// safety margin is derived from (see the compile-time assertion next
+    /// to it). A future tool name that grows past this fails here, with a
+    /// clear pointer to `MAX_TOOL_NAME_BYTES`, rather than surfacing as a
+    /// confusing prefix-length failure far away in `config`.
+    #[test]
+    fn test_registered_tool_names_fit_max_tool_name_bytes() {
+        let router = McplsServer::build_tool_router(None);
+        for tool in router.list_all() {
+            assert!(
+                tool.name.len() <= MAX_TOOL_NAME_BYTES,
+                "tool `{}` is {} bytes, exceeding MAX_TOOL_NAME_BYTES ({MAX_TOOL_NAME_BYTES}); \
+                 bump MAX_TOOL_NAME_BYTES and re-check its compile-time assertion against \
+                 MAX_MCP_TOOL_PREFIX_BYTES",
+                tool.name,
+                tool.name.len()
+            );
+        }
+    }
+
+    /// A configured prefix rewrites only `name` -- every other field
+    /// (description, title, annotations, input schema) stays identical to
+    /// the unprefixed golden snapshot, and no route is gained or lost.
+    #[test]
+    fn test_build_tool_router_with_prefix_renames_only_name() {
+        let prefix: ToolPrefix = "optics".parse().unwrap();
+        let unprefixed = McplsServer::build_tool_router(None).list_all();
+        let prefixed = McplsServer::build_tool_router(Some(&prefix)).list_all();
+
+        assert_eq!(unprefixed.len(), prefixed.len());
+        for (before, after) in unprefixed.iter().zip(prefixed.iter()) {
+            assert_eq!(after.name, format!("optics_{}", before.name));
+            assert_eq!(after.description, before.description);
+            assert_eq!(after.title, before.title);
+            assert_eq!(after.annotations, before.annotations);
+            assert_eq!(after.input_schema, before.input_schema);
+        }
+    }
+
+    /// The map key for every route must equal its own `attr.name` --
+    /// `ToolRouter::call` dispatches by looking up `map` with the
+    /// requested name, so a mismatch here would silently break routing to
+    /// unreachable dead entries under their pre-rename key.
+    #[test]
+    fn test_build_tool_router_map_keys_match_route_names() {
+        let prefix: ToolPrefix = "optics".parse().unwrap();
+        let router = McplsServer::build_tool_router(Some(&prefix));
+        for (key, route) in &router.map {
+            assert_eq!(key.as_ref(), route.attr.name.as_ref());
+        }
+    }
+
+    /// The single test proving the prefix threads end-to-end from the
+    /// public `McplsServer::new` constructor, not just from calling
+    /// `build_tool_router` directly -- every other test above calls
+    /// `build_tool_router` in isolation, so this is the one that would
+    /// catch a wiring mistake in `new` (e.g. forgetting to read
+    /// `mcp.tool_prefix` before `mcp` is moved into `BridgeContext::new`).
+    #[tokio::test]
+    async fn test_new_threads_configured_tool_prefix_end_to_end() {
+        let mcp = McpConfig {
+            tool_prefix: Some("p".parse().unwrap()),
+            ..McpConfig::default()
+        };
+        let server = create_test_server_with_mcp_config(false, mcp);
+
+        assert!(server.get_tool("p_get_hover").is_some());
+        assert!(server.get_tool("get_hover").is_none());
     }
 }

--- a/crates/mcpls-core/src/mcp/tool_surface.json
+++ b/crates/mcpls-core/src/mcp/tool_surface.json
@@ -38,7 +38,7 @@
   {
     "name": "get_cached_diagnostics",
     "title": "Cached Diagnostics",
-    "description": "Cached diagnostics from server notifications. Faster than get_diagnostics, no new analysis.",
+    "description": "Cached diagnostics from server notifications. Faster than the pull-model diagnostics tool, no new analysis.",
     "inputSchema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "properties": {

--- a/crates/mcpls-core/tests/e2e/protocol_tests.rs
+++ b/crates/mcpls-core/tests/e2e/protocol_tests.rs
@@ -80,6 +80,75 @@ fn test_e2e_initialize_reflects_configured_mcp_title() -> Result<()> {
     Ok(())
 }
 
+/// Test that a configured `[mcp].tool_prefix` reaches the real wiring end to
+/// end (#353): `tools/list` exposes only prefixed names, a `tools/call`
+/// using the prefixed name reaches the handler, and the same call with the
+/// bare (unprefixed) name is rejected as unknown. Unit tests in
+/// `mcp::server` already cover the surface exhaustively via
+/// `McplsServer::build_tool_router`/`::new` directly -- this is the one
+/// test proving the config value actually traverses `serve_with` ->
+/// `McplsServer::new` -> the real `ToolRouter`.
+#[test]
+#[ignore = "Requires mcpls binary built"]
+fn test_e2e_tool_prefix_reaches_real_wiring() -> Result<()> {
+    let config_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures/mcp_tool_prefix.toml");
+
+    let mut client = McpClient::spawn_with_args(&[
+        "--config",
+        config_path
+            .to_str()
+            .ok_or_else(|| anyhow::anyhow!("Invalid config path"))?,
+    ])?;
+
+    client.initialize()?;
+
+    let list_response = client.list_tools()?;
+    let names: Vec<&str> = list_response["result"]["tools"]
+        .as_array()
+        .ok_or_else(|| anyhow::anyhow!("tools/list did not return an array"))?
+        .iter()
+        .filter_map(|tool| tool["name"].as_str())
+        .collect();
+
+    assert!(
+        names.contains(&"optics_get_cached_diagnostics"),
+        "tools/list should expose the configured prefix: {names:?}"
+    );
+    assert!(
+        !names.contains(&"get_cached_diagnostics"),
+        "tools/list should not expose the unprefixed name once a prefix is configured: {names:?}"
+    );
+
+    // `get_cached_diagnostics` still fails for a nonexistent path (a file
+    // I/O error resolving its URI), but that error is distinct from
+    // `ToolRouter`'s "tool not found" -- reaching it proves the prefixed
+    // name was dispatched to the real handler, not rejected by routing.
+    let prefixed_result = client.call_tool(
+        "optics_get_cached_diagnostics",
+        &json!({ "file_path": "/nonexistent/file.rs" }),
+    );
+    if let Err(e) = &prefixed_result {
+        assert!(
+            !e.to_string().contains("tool not found"),
+            "prefixed tool call should reach the handler: {e}"
+        );
+    }
+
+    let bare_result = client.call_tool(
+        "get_cached_diagnostics",
+        &json!({ "file_path": "/nonexistent/file.rs" }),
+    );
+    match bare_result {
+        Ok(value) => {
+            panic!("bare tool name should be rejected once a prefix is configured, got: {value:?}")
+        }
+        Err(err) => assert!(err.to_string().contains("tool not found"), "{err}"),
+    }
+
+    Ok(())
+}
+
 /// Test listing all available MCP tools.
 ///
 /// Validates that:

--- a/crates/mcpls-core/tests/fixtures/mcp_tool_prefix.toml
+++ b/crates/mcpls-core/tests/fixtures/mcp_tool_prefix.toml
@@ -1,0 +1,8 @@
+# Configuration for E2E testing of `[mcp].tool_prefix` (#353).
+# No LSP servers configured - tests protocol only.
+
+[mcp]
+tool_prefix = "optics"
+
+[workspace]
+roots = []

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -98,12 +98,14 @@ presentation text.
 | `mcp.title` | `serverInfo.title` | `"MCPLS - MCP to LSP Bridge"` | 128 bytes |
 | `mcp.description` | `serverInfo.description` | the crate's `Cargo.toml` description | 1024 bytes |
 | `mcp.instructions` | `ServerInfo.instructions` | built-in capability blurb | 4096 bytes |
+| `mcp.tool_prefix` | every tool name (`{tool_prefix}_{tool}`) | unprefixed tool names | 32 bytes |
 
 ```toml
 [mcp]
 title = "My Custom Bridge"
 description = "Internal LSP bridge for Acme Corp"
 instructions = "Use get_hover before get_definition."
+tool_prefix = "optics"
 ```
 
 > [!IMPORTANT]
@@ -117,7 +119,14 @@ instructions = "Use get_hover before get_definition."
 Every field's size limit is enforced in UTF-8 bytes, not characters. A
 whitespace-only value (e.g. `title = "   "`) is rejected as empty, the same
 as an actually-empty string — omit the field entirely to use the built-in
-default instead. `tool_prefix` is not implemented yet (tracked separately).
+default instead.
+
+`mcp.tool_prefix` prefixes every MCP tool name with `{tool_prefix}_`, useful
+when an MCP client runs multiple mcpls bridges concurrently (one per
+project) and needs to tell their tools apart. The prefix must contain only
+ASCII letters, digits, `_`, and `-`, and must start and end with a letter or
+digit — a trailing `_`/`-` is rejected rather than stripped, since the `_`
+separator before each tool name is inserted automatically by mcpls.
 
 ## Workspace Section
 

--- a/docs/user-guide/tools-reference.md
+++ b/docs/user-guide/tools-reference.md
@@ -6,6 +6,10 @@ Complete reference for all 20 MCP tools provided by mcpls.
 
 mcpls exposes semantic code intelligence from Language Server Protocol (LSP) servers as MCP tools. Each tool corresponds to one or more LSP methods and provides rich code information to AI agents.
 
+Names below are the defaults; if the bridge is configured with `mcp.tool_prefix` (see
+[Configuration Reference](configuration.md#mcp-section)), every tool name gains that prefix
+(`{tool_prefix}_{tool}`).
+
 ## Tool Index
 
 ### Code Intelligence Tools

--- a/examples/mcpls.toml
+++ b/examples/mcpls.toml
@@ -12,6 +12,7 @@
 # title = "My Custom Bridge"
 # description = "Internal LSP bridge for Acme Corp"
 # instructions = "Use get_hover before get_definition."
+# tool_prefix = "optics"
 
 # Workspace settings
 [workspace]

--- a/skills/mcpls/SKILL.md
+++ b/skills/mcpls/SKILL.md
@@ -30,6 +30,8 @@ This skill covers operating the **binary**: installing it, choosing CLI flags an
 environment variables, registering it with an MCP client, and writing `mcpls.toml`.
 It does not enumerate the 20 MCP tools themselves or their parameters — for that, see
 [Tools Reference](https://github.com/bug-ops/mcpls/blob/main/docs/user-guide/tools-reference.md).
+If the bridge is configured with `mcp.tool_prefix`, every tool name listed there gains
+that prefix (`{tool_prefix}_{tool}`).
 
 ## Prerequisites
 

--- a/skills/mcpls/references/configuration.md
+++ b/skills/mcpls/references/configuration.md
@@ -16,10 +16,11 @@ independent, defaulting to mcpls's built-in text when omitted. `serverInfo.name`
 | `title` | string | `"MCPLS - MCP to LSP Bridge"` | 128 bytes | Overrides `serverInfo.title`. |
 | `description` | string | crate's `Cargo.toml` description | 1024 bytes | Overrides `serverInfo.description`. |
 | `instructions` | string | built-in capability blurb | 4096 bytes | **Replaces** `ServerInfo.instructions` entirely — does not append to the built-in text. Read it at connection time instead of assuming the built-in blurb; see the note below. |
+| `tool_prefix` | string | unprefixed tool names | 32 bytes | Prefixes every tool name with `{tool_prefix}_`, so a client running multiple mcpls bridges can tell their tools apart. Charset `[A-Za-z0-9_-]`, must start/end with a letter or digit. |
 
 Limits are UTF-8 bytes, not characters, and apply to the raw configured string,
 including surrounding whitespace — a whitespace-only value is rejected as empty
-rather than checked against the byte cap. `tool_prefix` is not implemented yet.
+rather than checked against the byte cap.
 
 ## `[workspace]` fields
 


### PR DESCRIPTION
## Summary

- Adds an optional `[mcp].tool_prefix` TOML setting that prefixes every registered MCP tool name with `{tool_prefix}_`, so a client running several mcpls bridges concurrently (e.g. against different workspaces) can tell their tools apart (`optics_get_diagnostics` vs `get_diagnostics`).
- The tool router is now built once at `McplsServer` construction time (stored as `Arc<ToolRouter<Self>>`) instead of being rebuilt by rmcp's default `#[tool_handler]` expansion on every `call_tool`/`list_tools`/`get_tool` request — a net performance improvement independent of the prefix feature itself, since it eliminates a per-request 20-route table reconstruction.
- `ToolPrefix` is a validated newtype: charset `[A-Za-z0-9_-]`, no leading/trailing separator, capped at 32 bytes (safe under both rmcp's 128-byte tool name limit and stricter historical client-side limits such as the 64-byte pattern used by some LLM tool-calling APIs). Both the 128-byte and 64-byte bounds are enforced by dedicated compile-time assertions.
- `tool_prefix` is opt-in and default-off; with it unset, tool names and `tools/list` output are unchanged from current behavior (proven by keeping `tool_surface.json`'s golden snapshot byte-identical except for one authorized field, see below).

## Notable implementation details

- The rename pass re-keys the router via `mem::take` + `ToolRouter::add_route` per route (not direct map manipulation), which routes through rmcp's own name validation for defence-in-depth.
- `get_cached_diagnostics`'s tool description previously named `get_diagnostics` directly ("Faster than get_diagnostics..."), which would point an LLM at a name that no longer resolves once a prefix is configured. Reworded to not name the tool directly — this is the one intentional field change in `tool_surface.json`'s golden snapshot; everything else in that file is byte-identical to `main`.
- Fixed a terminal-injection-adjacent issue found during review: the invalid-character config error now renders the offending character via `{:?}` instead of interpolating it raw, so a TOML-escaped control character (e.g. ESC) can no longer be echoed unescaped to stderr.

## Test plan

- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features --workspace -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --lib --bins` (748 passed)
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`
- [x] `cargo test --doc --workspace --all-features` (15 passed, incl. new `ToolPrefix` example)
- [x] New `#[ignore]`-gated e2e test verifying a configured prefix reaches `tools/list` against the real built binary (runs in CI's ignored-only job)
- [x] Golden-snapshot test (`tool_surface.json`) confirms no unintended tool surface drift

Closes #353