### PR TITLE
test: cap nextest concurrency for subprocess-mock tests

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -13,6 +13,29 @@ fail-fast = false
 # Test threads configuration
 test-threads = "num-cpus"
 
+# `fake_lsp_client()`-style tests spawn real `cat`/`echo` child processes as
+# a loopback mock LSP server (bridge/translator/testing.rs, bridge/state.rs,
+# lsp/client.rs, lsp/lifecycle.rs); OS process contention from the
+# subprocess fan-out can either starve a test past nextest's 120s hard
+# timeout, or produce a spurious assertion failure that does not reproduce
+# on an isolated rerun (see #374). This mitigates by lowering collision
+# probability; it does not eliminate the underlying race (tracked as a
+# follow-up: replace the subprocess loopback with an in-memory
+# `tokio::io::duplex`, see #378). `max-threads` is set below the CI
+# matrix's smallest runner core count (3, macos-latest) — a cap at or
+# above the `test-threads` pool size never binds, since a test-group only
+# limits concurrency *within* the existing thread pool.
+[test-groups]
+subprocess-mock-pipe = { max-threads = 2 }
+
+[[profile.default.overrides]]
+filter = 'test(bridge::translator::) + test(bridge::state::) + test(lsp::client::) + test(lsp::lifecycle::)'
+test-group = 'subprocess-mock-pipe'
+
+[[profile.ci.overrides]]
+filter = 'test(bridge::translator::) + test(bridge::state::) + test(lsp::client::) + test(lsp::lifecycle::)'
+test-group = 'subprocess-mock-pipe'
+
 # Timeout settings
 [profile.default.junit]
 path = "target/nextest/default/junit.xml"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `document_symbols` no longer redundantly recomputes the same range twice for flat (`SymbolInformation`) responses. (#365)
 - HTTP transport now catches a repeat shutdown signal received during the connection-drain window and cuts the drain short instead of waiting out the full timeout. (#365)
 - Corrected a broken assertion in the ignored `test_diagnostics_with_error` integration test (test-only; no production behavior change). (#365)
-- Capped nextest concurrency for `fake_lsp_client()` subprocess-mock tests (`bridge::translator`, `bridge::state`, `lsp::client`, `lsp::lifecycle`) to reduce, though not eliminate, a rare 120s hard timeout / spurious test failure caused by OS process contention under full parallel load (test-only; no production behavior change). (#374)
+- Capped nextest concurrency for `fake_lsp_client()` subprocess-mock tests (`bridge::translator`, `bridge::state`, `lsp::client`, `lsp::lifecycle`) to reduce, though not eliminate, a rare 120s hard timeout / spurious test failure caused by OS process contention under full parallel load (test-only; no production behavior change). (#380)
 
 ## [0.4.0] - 2026-09-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `document_symbols` no longer redundantly recomputes the same range twice for flat (`SymbolInformation`) responses. (#365)
 - HTTP transport now catches a repeat shutdown signal received during the connection-drain window and cuts the drain short instead of waiting out the full timeout. (#365)
 - Corrected a broken assertion in the ignored `test_diagnostics_with_error` integration test (test-only; no production behavior change). (#365)
+- Capped nextest concurrency for `fake_lsp_client()` subprocess-mock tests (`bridge::translator`, `bridge::state`, `lsp::client`, `lsp::lifecycle`) to reduce, though not eliminate, a rare 120s hard timeout / spurious test failure caused by OS process contention under full parallel load (test-only; no production behavior change). (#374)
 
 ## [0.4.0] - 2026-09-05
 

--- a/crates/mcpls-core/src/bridge/translator/testing.rs
+++ b/crates/mcpls-core/src/bridge/translator/testing.rs
@@ -101,6 +101,10 @@ pub(super) struct FakeServer {
     pub(super) write_stdout: ChildStdout,
 }
 
+// Spawns real `cat` subprocesses as a loopback mock rather than an
+// in-memory stream, which ties test scheduling to OS process contention
+// (see #374, mitigated via a nextest test-group; tracked for removal in #378
+// via `tokio::io::duplex`).
 pub(super) fn fake_lsp_client() -> (LspClient, FakeServer) {
     let mut write_half = Command::new("cat")
         .stdin(Stdio::piped())


### PR DESCRIPTION
## Summary

`fake_lsp_client()` and equivalent test harnesses (`bridge::translator`, `bridge::state`, `lsp::client`, `lsp::lifecycle`) spawn real `cat`/`echo` child processes as a loopback mock LSP server. Under full nextest parallelism, OS process contention from this subprocess fan-out can rarely starve a test past nextest's hard 120s timeout, or produce a fast spurious assertion failure that does not reproduce in isolation.

This adds a nextest test-group (`subprocess-mock-pipe`, `max-threads = 2`) that caps concurrency across all four modules using this harness pattern (298 tests), applied to both the `default` and `ci` profiles. `max-threads = 2` is set below the smallest CI matrix runner's core count (3 vCPU, `macos-latest`).

This reduces, but does not eliminate, the underlying contention — confirmed by repeated empirical A/B testing during review. The proper fix (replacing the subprocess loopback with an in-memory `tokio::io::duplex`, which would also de-duplicate four verbatim harness copies) is tracked in #378.

No production source code changes — this is entirely test-infrastructure configuration, plus one explanatory code comment.

## Review history

This fix went through two implementation rounds and two rounds of adversarial critique before landing:
- Root cause diagnosed as OS/process scheduling contention, not an application bug (no deadlock, missing yield, or unbounded-channel issue found in the mock harness or LSP transport).
- First implementation (group scoped to `bridge::translator::` only, `max-threads=4`) was found insufficient: the cap didn't bind on public CI's 3-4 vCPU runners, and three more modules used the identical unthrottled harness.
- Reworked to `max-threads=2` and widened to cover all four affected modules.
- A causal-claim wording issue (attributing the failure specifically to constrained thread counts, which further testing didn't support) was caught in review and corrected in both the code comment and the CHANGELOG entry, and corrected on the public issue thread as well.

## Test plan

- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features --workspace -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --lib --bins` (784 passed, 1 skipped)
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`
- [x] Verified `cargo nextest show-config test-groups` and `cargo nextest list` match the intended 298-test coverage with no other `cat`/`echo`-spawning harness left uncovered

Closes #374