### PR TITLE
refactor: derive symbol-kind list from single source, drop diagnostic params workaround

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Replace unmaintained `lsp-types` (gluon-lang) dependency with `gen-lsp-types` 0.11.0 (pinned); `lsp_types::` import paths are unchanged. (#375)
 - **`Uri` parsing** — Breaking change: `Uri` no longer validates its input, so a malformed MCP-supplied URI in `get_incoming_calls`/`get_outgoing_calls` now surfaces as a file-not-found error instead of an invalid-parameter error. (#375)
 - **`search_workspace_symbols`**/**`rename_symbol`** — Breaking change: symbols without a location range are now dropped instead of given a fabricated placeholder range, and LSP-3.18 snippet-shaped rename edits are now dropped instead of their literal placeholder syntax (e.g. `${1:name}`) being written into the file. (#375)
+- `workspace/symbol` `kind_filter` validation now derives its accepted names from `SUPPORTED_SYMBOL_KINDS`, the same single source of truth used by the `initialize` handshake, instead of a separately hand-maintained string list. (#355)
+- Replaced the hand-rolled `DiagnosticRequestParams` workaround with upstream `lsp_types::DocumentDiagnosticParams` directly; wire format is unchanged. (#166)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,8 +25,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Replace unmaintained `lsp-types` (gluon-lang) dependency with `gen-lsp-types` 0.11.0 (pinned); `lsp_types::` import paths are unchanged. (#375)
 - **`Uri` parsing** — Breaking change: `Uri` no longer validates its input, so a malformed MCP-supplied URI in `get_incoming_calls`/`get_outgoing_calls` now surfaces as a file-not-found error instead of an invalid-parameter error. (#375)
 - **`search_workspace_symbols`**/**`rename_symbol`** — Breaking change: symbols without a location range are now dropped instead of given a fabricated placeholder range, and LSP-3.18 snippet-shaped rename edits are now dropped instead of their literal placeholder syntax (e.g. `${1:name}`) being written into the file. (#375)
-- `workspace/symbol` `kind_filter` validation now derives its accepted names from `SUPPORTED_SYMBOL_KINDS`, the same single source of truth used by the `initialize` handshake, instead of a separately hand-maintained string list. (#355)
-- Replaced the hand-rolled `DiagnosticRequestParams` workaround with upstream `lsp_types::DocumentDiagnosticParams` directly; wire format is unchanged. (#166)
+- `workspace/symbol` `kind_filter` validation now derives its accepted names from `SUPPORTED_SYMBOL_KINDS`, the same single source of truth used by the `initialize` handshake, instead of a separately hand-maintained string list. (#383)
+- Replaced the hand-rolled `DiagnosticRequestParams` workaround with upstream `lsp_types::DocumentDiagnosticParams` directly; wire format is unchanged. (#383)
 
 ### Removed
 

--- a/crates/mcpls-core/src/bridge/translator/diagnostics.rs
+++ b/crates/mcpls-core/src/bridge/translator/diagnostics.rs
@@ -4,8 +4,9 @@
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use lsp_types::{PartialResultParams, TextDocumentIdentifier, WorkDoneProgressParams};
-use serde::Serialize;
+use lsp_types::{
+    DocumentDiagnosticParams, PartialResultParams, TextDocumentIdentifier, WorkDoneProgressParams,
+};
 use tokio::sync::Mutex;
 
 use super::Translator;
@@ -20,30 +21,6 @@ use crate::bridge::notifications::message_as_str;
 use crate::bridge::{DiagnosticInfo, DocumentTracker, NotificationCache, path_to_uri};
 use crate::config::ToolKind;
 use crate::error::{Error, Result};
-
-#[derive(Debug, Serialize)]
-#[serde(rename_all = "camelCase")]
-struct DiagnosticRequestParams {
-    text_document: TextDocumentIdentifier,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    identifier: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    previous_result_id: Option<String>,
-    #[serde(flatten)]
-    work_done_progress_params: WorkDoneProgressParams,
-    #[serde(flatten)]
-    partial_result_params: PartialResultParams,
-}
-
-fn diagnostic_request_params(text_document: TextDocumentIdentifier) -> DiagnosticRequestParams {
-    DiagnosticRequestParams {
-        text_document,
-        identifier: None,
-        previous_result_id: None,
-        work_done_progress_params: WorkDoneProgressParams::default(),
-        partial_result_params: PartialResultParams::default(),
-    }
-}
 
 /// Hand-rolled union of `textDocument/diagnostic`'s two possible result
 /// shapes.
@@ -153,7 +130,13 @@ impl Translator {
             .await?;
         let ctx = self.encoding_ctx(&server_id);
 
-        let params = diagnostic_request_params(TextDocumentIdentifier { uri: uri.clone() });
+        let params = DocumentDiagnosticParams {
+            text_document: TextDocumentIdentifier { uri: uri.clone() },
+            identifier: None,
+            previous_result_id: None,
+            work_done_progress_params: WorkDoneProgressParams::default(),
+            partial_result_params: PartialResultParams::default(),
+        };
 
         let pull_response: Result<DocumentDiagnosticReportResult> = client
             .request("textDocument/diagnostic", params, client.request_timeout())
@@ -402,10 +385,21 @@ mod tests {
     use crate::bridge::translator::testing::*;
     use crate::config::{ServerId, ToolRouter};
 
+    /// Pins the upstream `lsp_types::DocumentDiagnosticParams` serde
+    /// attributes (`skip_serializing_if` on both optionals) across future
+    /// `gen-lsp-types` version bumps -- this behavior was previously
+    /// guaranteed by a hand-rolled `DiagnosticRequestParams` (see #166),
+    /// dropped in favor of direct construction once verified byte-identical.
     #[test]
-    fn test_diagnostic_request_params_omit_optional_null_fields() {
+    fn test_document_diagnostic_params_omit_optional_null_fields() {
         let uri = lsp_types::Uri::from("file:///test.ts");
-        let params = diagnostic_request_params(TextDocumentIdentifier { uri });
+        let params = DocumentDiagnosticParams {
+            text_document: TextDocumentIdentifier { uri },
+            identifier: None,
+            previous_result_id: None,
+            work_done_progress_params: WorkDoneProgressParams::default(),
+            partial_result_params: PartialResultParams::default(),
+        };
         let value = serde_json::to_value(params).unwrap();
 
         assert_eq!(value["textDocument"]["uri"], "file:///test.ts");

--- a/crates/mcpls-core/src/bridge/translator/symbols.rs
+++ b/crates/mcpls-core/src/bridge/translator/symbols.rs
@@ -11,38 +11,11 @@ use super::encoding_ctx::EncodingCtx;
 use crate::bridge::lock_std;
 use crate::config::{NoServerReason, ToolKind};
 use crate::error::{Error, Result};
+use crate::lsp::SUPPORTED_SYMBOL_KINDS;
 
 /// Validate parameters for `handle_workspace_symbol`.
 fn validate_workspace_symbol_params(query: &str, kind_filter: Option<&str>) -> Result<()> {
     const MAX_QUERY_LENGTH: usize = 1000;
-    const VALID_SYMBOL_KINDS: &[&str] = &[
-        "File",
-        "Module",
-        "Namespace",
-        "Package",
-        "Class",
-        "Method",
-        "Property",
-        "Field",
-        "Constructor",
-        "Enum",
-        "Interface",
-        "Function",
-        "Variable",
-        "Constant",
-        "String",
-        "Number",
-        "Boolean",
-        "Array",
-        "Object",
-        "Key",
-        "Null",
-        "EnumMember",
-        "Struct",
-        "Event",
-        "Operator",
-        "TypeParameter",
-    ];
 
     if query.len() > MAX_QUERY_LENGTH {
         return Err(Error::InvalidToolParams(format!(
@@ -52,12 +25,16 @@ fn validate_workspace_symbol_params(query: &str, kind_filter: Option<&str>) -> R
     }
 
     if let Some(kind) = kind_filter
-        && !VALID_SYMBOL_KINDS
+        && !SUPPORTED_SYMBOL_KINDS
             .iter()
-            .any(|k| k.eq_ignore_ascii_case(kind))
+            .any(|k| format!("{k:?}").eq_ignore_ascii_case(kind))
     {
+        let valid: Vec<String> = SUPPORTED_SYMBOL_KINDS
+            .iter()
+            .map(|k| format!("{k:?}"))
+            .collect();
         return Err(Error::InvalidToolParams(format!(
-            "Invalid kind_filter: '{kind}'. Valid values: {VALID_SYMBOL_KINDS:?}"
+            "Invalid kind_filter: '{kind}'. Valid values: {valid:?}"
         )));
     }
 
@@ -313,6 +290,31 @@ mod tests {
     use super::*;
     use crate::bridge::translator::testing::*;
     use crate::config::{ServerId, ToolRouter};
+
+    /// #355 regression: `validate_workspace_symbol_params` accepts/rejects
+    /// `kind_filter` values based on `SymbolKind`'s derived `Debug` output,
+    /// since `gen-lsp-types` provides no `as_str()`/`Display`. This pins that
+    /// assumption directly so a future `gen-lsp-types` bump that changes the
+    /// `Debug` rendering (e.g. back to a newtype) fails loudly here instead
+    /// of silently diverging from the DTO `kind` strings the responses emit.
+    #[test]
+    fn test_symbol_kind_debug_rendering_is_pinned() {
+        assert_eq!(
+            format!("{:?}", lsp_types::SymbolKind::EnumMember),
+            "EnumMember"
+        );
+    }
+
+    #[test]
+    fn test_validate_workspace_symbol_params_accepts_known_kind() {
+        assert!(validate_workspace_symbol_params("q", Some("EnumMember")).is_ok());
+    }
+
+    #[test]
+    fn test_validate_workspace_symbol_params_rejects_unknown_kind() {
+        let result = validate_workspace_symbol_params("q", Some("NotAKind"));
+        assert!(matches!(result, Err(Error::InvalidToolParams(_))));
+    }
 
     #[tokio::test]
     async fn test_handle_workspace_symbol_no_server() {

--- a/crates/mcpls-core/src/lsp/lifecycle.rs
+++ b/crates/mcpls-core/src/lsp/lifecycle.rs
@@ -47,7 +47,12 @@ const ENV_PASSTHROUGH: &[&str] = &["PATH", "HOME", "USERPROFILE", "TMPDIR", "TEM
 const CHILD_EXIT_GRACE: Duration = Duration::from_secs(3);
 
 /// Every symbol kind defined by LSP 3.17 and understood by mcpls.
-const SUPPORTED_SYMBOL_KINDS: [SymbolKind; 26] = [
+///
+/// Single source of truth for both the `initialize` request's
+/// `value_set` and the `workspace/symbol` `kind_filter` validation in
+/// [`crate::bridge::translator::symbols`] — the latter derives its accepted
+/// string names from this array via `format!("{:?}", kind)`.
+pub const SUPPORTED_SYMBOL_KINDS: [SymbolKind; 26] = [
     SymbolKind::File,
     SymbolKind::Module,
     SymbolKind::Namespace,

--- a/crates/mcpls-core/src/lsp/mod.rs
+++ b/crates/mcpls-core/src/lsp/mod.rs
@@ -9,6 +9,7 @@ mod transport;
 pub(crate) mod types;
 
 pub use client::LspClient;
+pub(crate) use lifecycle::SUPPORTED_SYMBOL_KINDS;
 #[cfg(test)]
 pub(crate) use lifecycle::fake_lsp_server;
 pub use lifecycle::{LspServer, ServerInitConfig, ServerInitResult, ServerState};


### PR DESCRIPTION
## Summary
- `SUPPORTED_SYMBOL_KINDS` (`lsp/lifecycle.rs`) is now the single source of truth for LSP symbol kinds; `VALID_SYMBOL_KINDS` in `bridge/translator/symbols.rs` is derived from it via `Debug` formatting instead of being hand-maintained separately, closing a latent accept/emit mismatch between `kind_filter` validation and DTO rendering.
- Removed the `DiagnosticRequestParams` workaround struct in `bridge/translator/diagnostics.rs`. It existed because the old `lsp-types` crate serialized `None` fields as JSON `null` instead of omitting them. `gen-lsp-types` 0.11.0 (pinned since #375) fixes this upstream, so the call site now constructs `lsp_types::DocumentDiagnosticParams` directly. Wire format is unchanged (verified field-by-field against upstream derive macros).
- The associated regression test was retargeted (not deleted) to assert the omit-on-null behavior against the upstream type directly, pinning it across future `gen-lsp-types` bumps.

Both changes are pure dedup/cleanup with no behavior change.

Closes #355
Closes #166

## Test plan
- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features --workspace -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --lib --bins` (787 passed, 1 skipped)
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`
- [x] Repo-wide grep confirms no remaining references to removed identifiers (`VALID_SYMBOL_KINDS`, `DiagnosticRequestParams`, `diagnostic_request_params`)