### PR TITLE
refactor(bridge): consolidate go-to-X handler boilerplate in navigation.rs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`search_workspace_symbols`**/**`rename_symbol`** — Breaking change: symbols without a location range are now dropped instead of given a fabricated placeholder range, and LSP-3.18 snippet-shaped rename edits are now dropped instead of their literal placeholder syntax (e.g. `${1:name}`) being written into the file. (#375)
 - `workspace/symbol` `kind_filter` validation now derives its accepted names from `SUPPORTED_SYMBOL_KINDS`, the same single source of truth used by the `initialize` handshake, instead of a separately hand-maintained string list. (#383)
 - Replaced the hand-rolled `DiagnosticRequestParams` workaround with upstream `lsp_types::DocumentDiagnosticParams` directly; wire format is unchanged. (#383)
+- Consolidated the duplicated `handle_definition`/`handle_implementation`/`handle_type_definition` go-to-X handlers and their response-flattening helpers in `bridge::translator::navigation` behind a shared generic path; behavior is unchanged. (#386)
 
 ### Removed
 

--- a/crates/mcpls-core/src/bridge/translator/navigation.rs
+++ b/crates/mcpls-core/src/bridge/translator/navigation.rs
@@ -43,15 +43,63 @@ async fn lsp_locations_to_mcp(locs: Vec<lsp_types::Location>, ctx: &EncodingCtx)
     locations
 }
 
-/// Normalize a `textDocument/definition` response into a flat list of MCP
-/// `Location` values.
-async fn definition_response_to_locations(
-    response: Option<lsp_types::DefinitionResponse>,
+/// The two response shapes shared by `textDocument/definition`,
+/// `textDocument/implementation`, and `textDocument/typeDefinition`: either a
+/// single `Definition` (`Location` or `Location[]`), or a `DefinitionLink[]`
+/// from clients that opted into `LinkSupport`.
+enum GotoKind {
+    /// A plain `Definition`, as returned to clients without `LinkSupport`.
+    Definition(lsp_types::Definition),
+    /// A `DefinitionLink[]`, as returned to clients with `LinkSupport`.
+    DefinitionLinkList(Vec<lsp_types::DefinitionLink>),
+}
+
+/// Implemented once per go-to-X response enum so [`goto_response_to_locations`]
+/// can normalize all three through one code path instead of three near-identical
+/// match arms.
+trait GotoResponse {
+    /// Reduce the response enum down to the two variants shared by every
+    /// go-to-X LSP response.
+    fn into_kind(self) -> GotoKind;
+}
+
+impl GotoResponse for lsp_types::DefinitionResponse {
+    fn into_kind(self) -> GotoKind {
+        match self {
+            Self::Definition(def) => GotoKind::Definition(def),
+            Self::DefinitionLinkList(links) => GotoKind::DefinitionLinkList(links),
+        }
+    }
+}
+
+impl GotoResponse for lsp_types::ImplementationResponse {
+    fn into_kind(self) -> GotoKind {
+        match self {
+            Self::Definition(def) => GotoKind::Definition(def),
+            Self::DefinitionLinkList(links) => GotoKind::DefinitionLinkList(links),
+        }
+    }
+}
+
+impl GotoResponse for lsp_types::TypeDefinitionResponse {
+    fn into_kind(self) -> GotoKind {
+        match self {
+            Self::Definition(def) => GotoKind::Definition(def),
+            Self::DefinitionLinkList(links) => GotoKind::DefinitionLinkList(links),
+        }
+    }
+}
+
+/// Normalize a go-to-X response (`textDocument/definition`,
+/// `textDocument/implementation`, or `textDocument/typeDefinition`) into a
+/// flat list of MCP `Location` values.
+async fn goto_response_to_locations<R: GotoResponse>(
+    response: Option<R>,
     ctx: &EncodingCtx,
 ) -> Vec<Location> {
-    let lsp_locs = match response {
-        Some(lsp_types::DefinitionResponse::Definition(def)) => definition_to_locations(def),
-        Some(lsp_types::DefinitionResponse::DefinitionLinkList(links)) => {
+    let lsp_locs = match response.map(GotoResponse::into_kind) {
+        Some(GotoKind::Definition(def)) => definition_to_locations(def),
+        Some(GotoKind::DefinitionLinkList(links)) => {
             links.into_iter().map(definition_link_to_location).collect()
         }
         None => vec![],
@@ -59,36 +107,43 @@ async fn definition_response_to_locations(
     lsp_locations_to_mcp(lsp_locs, ctx).await
 }
 
-/// Normalize a `textDocument/implementation` response into a flat list of
-/// MCP `Location` values.
-async fn implementation_response_to_locations(
-    response: Option<lsp_types::ImplementationResponse>,
-    ctx: &EncodingCtx,
-) -> Vec<Location> {
-    let lsp_locs = match response {
-        Some(lsp_types::ImplementationResponse::Definition(def)) => definition_to_locations(def),
-        Some(lsp_types::ImplementationResponse::DefinitionLinkList(links)) => {
-            links.into_iter().map(definition_link_to_location).collect()
-        }
-        None => vec![],
-    };
-    lsp_locations_to_mcp(lsp_locs, ctx).await
+/// Implemented once per go-to-X request params type so [`Translator::handle_goto`]
+/// can build request params generically instead of duplicating the
+/// `TextDocumentPositionParams` wiring per handler.
+trait GotoParams: Sized {
+    /// Build the request params from the resolved document position, filling
+    /// the remaining fields (work-done/partial-result progress) with defaults.
+    fn from_position(text_document_position_params: TextDocumentPositionParams) -> Self;
 }
 
-/// Normalize a `textDocument/typeDefinition` response into a flat list of
-/// MCP `Location` values.
-async fn type_definition_response_to_locations(
-    response: Option<lsp_types::TypeDefinitionResponse>,
-    ctx: &EncodingCtx,
-) -> Vec<Location> {
-    let lsp_locs = match response {
-        Some(lsp_types::TypeDefinitionResponse::Definition(def)) => definition_to_locations(def),
-        Some(lsp_types::TypeDefinitionResponse::DefinitionLinkList(links)) => {
-            links.into_iter().map(definition_link_to_location).collect()
+impl GotoParams for lsp_types::DefinitionParams {
+    fn from_position(text_document_position_params: TextDocumentPositionParams) -> Self {
+        Self {
+            text_document_position_params,
+            work_done_progress_params: WorkDoneProgressParams::default(),
+            partial_result_params: PartialResultParams::default(),
         }
-        None => vec![],
-    };
-    lsp_locations_to_mcp(lsp_locs, ctx).await
+    }
+}
+
+impl GotoParams for lsp_types::ImplementationParams {
+    fn from_position(text_document_position_params: TextDocumentPositionParams) -> Self {
+        Self {
+            text_document_position_params,
+            work_done_progress_params: WorkDoneProgressParams::default(),
+            partial_result_params: PartialResultParams::default(),
+        }
+    }
+}
+
+impl GotoParams for lsp_types::TypeDefinitionParams {
+    fn from_position(text_document_position_params: TextDocumentPositionParams) -> Self {
+        Self {
+            text_document_position_params,
+            work_done_progress_params: WorkDoneProgressParams::default(),
+            partial_result_params: PartialResultParams::default(),
+        }
+    }
 }
 
 /// Extracts hover contents as a plain string.
@@ -176,6 +231,49 @@ impl Translator {
         Ok(result)
     }
 
+    /// Shared implementation of the go-to-X handlers (`textDocument/definition`,
+    /// `textDocument/implementation`, `textDocument/typeDefinition`): gate on
+    /// the request's capability, translate the MCP position into LSP
+    /// coordinates, dispatch the LSP request, and flatten the response into
+    /// MCP locations. Each public handler supplies its request type via `R`
+    /// plus the capability key/predicate specific to it.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the LSP request fails, the file cannot be opened,
+    /// or the routed server does not advertise `capability` support.
+    async fn handle_goto<R, T>(
+        &self,
+        file_path: &str,
+        position: Position,
+        tool: ToolKind,
+        capability: &'static str,
+        supported: impl FnOnce(&lsp_types::ServerCapabilities) -> bool,
+    ) -> Result<Vec<Location>>
+    where
+        R: lsp_types::Request<Result = Option<T>>,
+        R::Params: GotoParams,
+        T: GotoResponse,
+    {
+        let Position { line, character } = position;
+        let (server_id, client, uri) = self
+            .prepare_gated_document(file_path, tool, capability, supported)
+            .await?;
+        let ctx = self.encoding_ctx(&server_id);
+        let lsp_position = ctx.to_lsp(&uri, line, character).await;
+
+        let params = R::Params::from_position(TextDocumentPositionParams {
+            text_document: TextDocumentIdentifier { uri },
+            position: lsp_position,
+        });
+
+        let response = client
+            .request_typed::<R>(params, client.request_timeout())
+            .await?;
+
+        Ok(goto_response_to_locations(response, &ctx).await)
+    }
+
     /// Handle definition request.
     ///
     /// # Errors
@@ -187,10 +285,10 @@ impl Translator {
         file_path: String,
         position: Position,
     ) -> Result<DefinitionResult> {
-        let Position { line, character } = position;
-        let (server_id, client, uri) = self
-            .prepare_gated_document(
+        let locations = self
+            .handle_goto::<lsp_types::DefinitionRequest, _>(
                 &file_path,
+                position,
                 ToolKind::Definition,
                 "definitionProvider",
                 |caps| {
@@ -204,27 +302,8 @@ impl Translator {
                 },
             )
             .await?;
-        let ctx = self.encoding_ctx(&server_id);
-        let lsp_position = ctx.to_lsp(&uri, line, character).await;
 
-        let params = lsp_types::DefinitionParams {
-            text_document_position_params: TextDocumentPositionParams {
-                text_document: TextDocumentIdentifier { uri },
-                position: lsp_position,
-            },
-            work_done_progress_params: WorkDoneProgressParams::default(),
-            partial_result_params: PartialResultParams::default(),
-        };
-
-        let response = client
-            .request_typed::<lsp_types::DefinitionRequest>(params, client.request_timeout())
-            .await?;
-
-        let result = DefinitionResult {
-            locations: definition_response_to_locations(response, &ctx).await,
-        };
-
-        Ok(result)
+        Ok(DefinitionResult { locations })
     }
 
     /// Handle references request.
@@ -304,10 +383,10 @@ impl Translator {
         file_path: String,
         position: Position,
     ) -> Result<LocationsResult> {
-        let Position { line, character } = position;
-        let (server_id, client, uri) = self
-            .prepare_gated_document(
+        let locations = self
+            .handle_goto::<lsp_types::ImplementationRequest, _>(
                 &file_path,
+                position,
                 ToolKind::Implementation,
                 "implementationProvider",
                 |caps| {
@@ -322,25 +401,8 @@ impl Translator {
                 },
             )
             .await?;
-        let ctx = self.encoding_ctx(&server_id);
-        let lsp_position = ctx.to_lsp(&uri, line, character).await;
 
-        let params = lsp_types::ImplementationParams {
-            text_document_position_params: TextDocumentPositionParams {
-                text_document: TextDocumentIdentifier { uri },
-                position: lsp_position,
-            },
-            work_done_progress_params: WorkDoneProgressParams::default(),
-            partial_result_params: PartialResultParams::default(),
-        };
-
-        let response = client
-            .request_typed::<lsp_types::ImplementationRequest>(params, client.request_timeout())
-            .await?;
-
-        Ok(LocationsResult {
-            locations: implementation_response_to_locations(response, &ctx).await,
-        })
+        Ok(LocationsResult { locations })
     }
 
     /// Handle go-to-type-definition request (`textDocument/typeDefinition`).
@@ -357,10 +419,10 @@ impl Translator {
         file_path: String,
         position: Position,
     ) -> Result<LocationsResult> {
-        let Position { line, character } = position;
-        let (server_id, client, uri) = self
-            .prepare_gated_document(
+        let locations = self
+            .handle_goto::<lsp_types::TypeDefinitionRequest, _>(
                 &file_path,
+                position,
                 ToolKind::TypeDefinition,
                 "typeDefinitionProvider",
                 |caps| {
@@ -375,32 +437,26 @@ impl Translator {
                 },
             )
             .await?;
-        let ctx = self.encoding_ctx(&server_id);
-        let lsp_position = ctx.to_lsp(&uri, line, character).await;
 
-        let params = lsp_types::TypeDefinitionParams {
-            text_document_position_params: TextDocumentPositionParams {
-                text_document: TextDocumentIdentifier { uri },
-                position: lsp_position,
-            },
-            work_done_progress_params: WorkDoneProgressParams::default(),
-            partial_result_params: PartialResultParams::default(),
-        };
-
-        let response = client
-            .request_typed::<lsp_types::TypeDefinitionRequest>(params, client.request_timeout())
-            .await?;
-
-        Ok(LocationsResult {
-            locations: type_definition_response_to_locations(response, &ctx).await,
-        })
+        Ok(LocationsResult { locations })
     }
 }
 
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used, deprecated)]
 mod tests {
+    use std::fs;
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    use tempfile::TempDir;
+    use tokio::io::BufReader;
+    use tokio::time::timeout;
+    use url::Url;
+
     use super::*;
+    use crate::bridge::translator::testing::*;
+    use crate::config::ServerId;
 
     #[test]
     fn test_extract_hover_contents_string() {
@@ -432,5 +488,220 @@ mod tests {
         let contents = lsp_types::Contents::MarkupContent(markup);
         let result = extract_hover_contents(contents);
         assert_eq!(result, "# Documentation");
+    }
+
+    /// Success-path coverage for `handle_definition` through the
+    /// `Definition::Location` -> `GotoKind::Definition` arm, pinning the
+    /// `GotoResponse` impl for `DefinitionResponse`.
+    #[tokio::test]
+    async fn test_handle_definition_flattens_single_location() {
+        let dir = TempDir::new().unwrap();
+        let server_id = ServerId::from("rust");
+        let caps = lsp_types::ServerCapabilities {
+            definition_provider: Some(lsp_types::DefinitionProvider::Bool(true)),
+            ..Default::default()
+        };
+        let (translator, mut server) = translator_with_capabilities(&dir, &server_id, caps);
+
+        let path = dir.path().join("main.rs");
+        fs::write(&path, "fn main() {}").unwrap();
+        let target_path = dir.path().join("target.rs");
+        fs::write(&target_path, "fn target() {}").unwrap();
+        let target_uri = Url::from_file_path(&target_path).unwrap().to_string();
+
+        let translator = Arc::new(translator);
+        let handle = {
+            let translator = Arc::clone(&translator);
+            let path = path.to_string_lossy().to_string();
+            tokio::spawn(async move {
+                translator
+                    .handle_definition(
+                        path,
+                        Position {
+                            line: 1,
+                            character: 1,
+                        },
+                    )
+                    .await
+            })
+        };
+
+        let mut wire = BufReader::new(&mut server.write_stdout);
+        let opened = read_framed_message(&mut wire).await;
+        assert_eq!(opened["method"], "textDocument/didOpen");
+        let request = read_framed_message(&mut wire).await;
+        assert_eq!(request["method"], "textDocument/definition");
+
+        write_response(
+            &mut server.read_half_stdin,
+            &request["id"],
+            serde_json::json!({
+                "uri": target_uri,
+                "range": {
+                    "start": {"line": 0, "character": 0},
+                    "end": {"line": 0, "character": 6}
+                }
+            }),
+        )
+        .await;
+
+        let result = timeout(Duration::from_secs(2), handle)
+            .await
+            .expect("handle_definition should not hang")
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(result.locations.len(), 1);
+        assert_eq!(result.locations[0].uri, target_uri);
+    }
+
+    /// Success-path coverage for `handle_implementation` through the
+    /// `Definition::LocationList` -> `GotoKind::Definition` arm, pinning the
+    /// `GotoResponse` impl for `ImplementationResponse`.
+    #[tokio::test]
+    async fn test_handle_implementation_flattens_location_list() {
+        let dir = TempDir::new().unwrap();
+        let server_id = ServerId::from("rust");
+        let caps = lsp_types::ServerCapabilities {
+            implementation_provider: Some(lsp_types::ImplementationProvider::Bool(true)),
+            ..Default::default()
+        };
+        let (translator, mut server) = translator_with_capabilities(&dir, &server_id, caps);
+
+        let path = dir.path().join("main.rs");
+        fs::write(&path, "fn main() {}").unwrap();
+        let first_impl_path = dir.path().join("impl_a.rs");
+        fs::write(&first_impl_path, "struct A;").unwrap();
+        let first_impl_uri = Url::from_file_path(&first_impl_path).unwrap().to_string();
+        let second_impl_path = dir.path().join("impl_b.rs");
+        fs::write(&second_impl_path, "struct B;").unwrap();
+        let second_impl_uri = Url::from_file_path(&second_impl_path).unwrap().to_string();
+
+        let translator = Arc::new(translator);
+        let handle = {
+            let translator = Arc::clone(&translator);
+            let path = path.to_string_lossy().to_string();
+            tokio::spawn(async move {
+                translator
+                    .handle_implementation(
+                        path,
+                        Position {
+                            line: 1,
+                            character: 1,
+                        },
+                    )
+                    .await
+            })
+        };
+
+        let mut wire = BufReader::new(&mut server.write_stdout);
+        let opened = read_framed_message(&mut wire).await;
+        assert_eq!(opened["method"], "textDocument/didOpen");
+        let request = read_framed_message(&mut wire).await;
+        assert_eq!(request["method"], "textDocument/implementation");
+
+        write_response(
+            &mut server.read_half_stdin,
+            &request["id"],
+            serde_json::json!([
+                {
+                    "uri": first_impl_uri,
+                    "range": {
+                        "start": {"line": 0, "character": 0},
+                        "end": {"line": 0, "character": 9}
+                    }
+                },
+                {
+                    "uri": second_impl_uri,
+                    "range": {
+                        "start": {"line": 0, "character": 0},
+                        "end": {"line": 0, "character": 9}
+                    }
+                }
+            ]),
+        )
+        .await;
+
+        let result = timeout(Duration::from_secs(2), handle)
+            .await
+            .expect("handle_implementation should not hang")
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(result.locations.len(), 2);
+        assert_eq!(result.locations[0].uri, first_impl_uri);
+        assert_eq!(result.locations[1].uri, second_impl_uri);
+    }
+
+    /// Success-path coverage for `handle_type_definition` through the
+    /// `DefinitionLinkList` -> `GotoKind::DefinitionLinkList` arm, pinning
+    /// the `GotoResponse` impl for `TypeDefinitionResponse` and the
+    /// `definition_link_to_location` mapping (`target_selection_range`, not
+    /// `target_range`).
+    #[tokio::test]
+    async fn test_handle_type_definition_flattens_definition_link_list() {
+        let dir = TempDir::new().unwrap();
+        let server_id = ServerId::from("rust");
+        let caps = lsp_types::ServerCapabilities {
+            type_definition_provider: Some(lsp_types::TypeDefinitionProvider::Bool(true)),
+            ..Default::default()
+        };
+        let (translator, mut server) = translator_with_capabilities(&dir, &server_id, caps);
+
+        let path = dir.path().join("main.rs");
+        fs::write(&path, "fn main() {}").unwrap();
+        let target_path = dir.path().join("target_type.rs");
+        fs::write(&target_path, "struct TargetType;").unwrap();
+        let target_uri = Url::from_file_path(&target_path).unwrap().to_string();
+
+        let translator = Arc::new(translator);
+        let handle = {
+            let translator = Arc::clone(&translator);
+            let path = path.to_string_lossy().to_string();
+            tokio::spawn(async move {
+                translator
+                    .handle_type_definition(
+                        path,
+                        Position {
+                            line: 1,
+                            character: 1,
+                        },
+                    )
+                    .await
+            })
+        };
+
+        let mut wire = BufReader::new(&mut server.write_stdout);
+        let opened = read_framed_message(&mut wire).await;
+        assert_eq!(opened["method"], "textDocument/didOpen");
+        let request = read_framed_message(&mut wire).await;
+        assert_eq!(request["method"], "textDocument/typeDefinition");
+
+        write_response(
+            &mut server.read_half_stdin,
+            &request["id"],
+            serde_json::json!([{
+                "targetUri": target_uri,
+                "targetRange": {
+                    "start": {"line": 0, "character": 0},
+                    "end": {"line": 0, "character": 18}
+                },
+                "targetSelectionRange": {
+                    "start": {"line": 0, "character": 7},
+                    "end": {"line": 0, "character": 17}
+                }
+            }]),
+        )
+        .await;
+
+        let result = timeout(Duration::from_secs(2), handle)
+            .await
+            .expect("handle_type_definition should not hang")
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(result.locations.len(), 1);
+        assert_eq!(result.locations[0].uri, target_uri);
+        assert_eq!(result.locations[0].range.start.character, 8);
     }
 }


### PR DESCRIPTION
## Summary
- Collapse `handle_definition`, `handle_implementation`, and `handle_type_definition` in `crates/mcpls-core/src/bridge/translator/navigation.rs` behind a single generic `handle_goto` helper, replacing three structurally identical ~35-line handlers.
- Replace the three duplicated `*_response_to_locations` functions with one generic `goto_response_to_locations`, backed by new `GotoParams`/`GotoResponse` traits (one impl per LSP request/response type) and a `GotoKind` enum.
- Public signatures, capability gating (per-handler capability key/predicate), position encoding, and error behavior are unchanged.
- Add one positive-path unit test per handler (covering both the `Definition` and `DefinitionLinkList` response-variant shapes) through the shared path, closing a coverage gap where only `handle_definition` had end-to-end coverage via an ignored, non-CI integration test.

## Test plan
- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features --workspace -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --lib --bins` (790 passed, 1 skipped)
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`

Closes #381