### PR TITLE
refactor(bridge): drop get_ prefix from internal accessor methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `workspace/symbol` `kind_filter` validation now derives its accepted names from `SUPPORTED_SYMBOL_KINDS`, the same single source of truth used by the `initialize` handshake, instead of a separately hand-maintained string list. (#383)
 - Replaced the hand-rolled `DiagnosticRequestParams` workaround with upstream `lsp_types::DocumentDiagnosticParams` directly; wire format is unchanged. (#383)
 - Consolidated the duplicated `handle_definition`/`handle_implementation`/`handle_type_definition` go-to-X handlers and their response-flattening helpers in `bridge::translator::navigation` behind a shared generic path; behavior is unchanged. (#386)
+- **`NotificationCache::get_diagnostics`/`Translator::get_client_for_file` renamed to `diagnostics`/`client_for_file`** — Breaking change: drops the redundant `get_` prefix per Rust API guidelines C-GETTER, revisiting a previous entry in this changelog (#293) that had left `get_diagnostics` unchanged as a keyed lookup rather than a plain accessor. (#384)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `workspace/symbol` `kind_filter` validation now derives its accepted names from `SUPPORTED_SYMBOL_KINDS`, the same single source of truth used by the `initialize` handshake, instead of a separately hand-maintained string list. (#383)
 - Replaced the hand-rolled `DiagnosticRequestParams` workaround with upstream `lsp_types::DocumentDiagnosticParams` directly; wire format is unchanged. (#383)
 - Consolidated the duplicated `handle_definition`/`handle_implementation`/`handle_type_definition` go-to-X handlers and their response-flattening helpers in `bridge::translator::navigation` behind a shared generic path; behavior is unchanged. (#386)
-- **`NotificationCache::get_diagnostics`/`Translator::get_client_for_file` renamed to `diagnostics`/`client_for_file`** — Breaking change: drops the redundant `get_` prefix per Rust API guidelines C-GETTER, revisiting a previous entry in this changelog (#293) that had left `get_diagnostics` unchanged as a keyed lookup rather than a plain accessor. (#384)
+- **`NotificationCache::get_diagnostics`/`Translator::get_client_for_file` renamed to `diagnostics`/`client_for_file`** — Breaking change: drops the redundant `get_` prefix per Rust API guidelines C-GETTER, revisiting a previous entry in this changelog (#293) that had left `get_diagnostics` unchanged as a keyed lookup rather than a plain accessor. (#387)
 
 ### Removed
 

--- a/crates/mcpls-core/src/bridge/notifications.rs
+++ b/crates/mcpls-core/src/bridge/notifications.rs
@@ -733,7 +733,7 @@ impl NotificationCache {
     /// serialized bytes, before storing (#311). When that bound requires
     /// dropping diagnostics, the *survivors* come back sorted by severity
     /// (`diagnostic_severity_rank`: `ERROR` first), not in the original
-    /// publish/file-position order -- see [`Self::get_diagnostics`].
+    /// publish/file-position order -- see [`Self::diagnostics`].
     ///
     /// If diagnostics already exist for the URI, they are replaced and the
     /// entry is repositioned to the back of its owner's eviction order, so
@@ -766,7 +766,7 @@ impl NotificationCache {
     /// let server: ServerId = "rust-analyzer".into();
     /// let uri: Uri = Uri::from("file:///main.rs");
     /// cache.store_diagnostics(&server, &uri, Some(1), vec![]);
-    /// assert!(cache.get_diagnostics(uri.as_ref()).is_some());
+    /// assert!(cache.diagnostics(uri.as_ref()).is_some());
     /// ```
     pub fn store_diagnostics(
         &mut self,
@@ -898,7 +898,7 @@ impl NotificationCache {
     /// it after a cap-triggered truncation.
     #[inline]
     #[must_use]
-    pub fn get_diagnostics(&self, uri: &str) -> Option<&DiagnosticInfo> {
+    pub fn diagnostics(&self, uri: &str) -> Option<&DiagnosticInfo> {
         self.diagnostics.get(uri_cache_key(uri).as_ref())
     }
 
@@ -970,8 +970,8 @@ impl NotificationCache {
     ///
     /// cache.clear_server_diagnostics(&crashed);
     ///
-    /// assert!(cache.get_diagnostics(crashed_uri.as_ref()).is_none());
-    /// assert!(cache.get_diagnostics(healthy_uri.as_ref()).is_some());
+    /// assert!(cache.diagnostics(crashed_uri.as_ref()).is_none());
+    /// assert!(cache.diagnostics(healthy_uri.as_ref()).is_some());
     /// ```
     pub fn clear_server_diagnostics(&mut self, server_id: &ServerId) {
         let Some(order) = self.diagnostic_order.remove(server_id) else {
@@ -1085,7 +1085,7 @@ mod tests {
     }
 
     #[test]
-    fn test_store_and_get_diagnostics() {
+    fn test_store_and_diagnostics() {
         let mut cache = NotificationCache::new();
         let uri: Uri = Uri::from("file:///test.rs");
 
@@ -1112,7 +1112,7 @@ mod tests {
 
         cache.store_diagnostics(&test_server(), &uri, Some(1), vec![diagnostic]);
 
-        let stored = cache.get_diagnostics(uri.as_ref()).unwrap();
+        let stored = cache.diagnostics(uri.as_ref()).unwrap();
         assert_eq!(stored.uri, uri);
         assert_eq!(stored.version, Some(1));
         assert_eq!(stored.diagnostics.len(), 1);
@@ -1153,7 +1153,7 @@ mod tests {
 
         cache.store_diagnostics(&test_server(), &uri, Some(1), vec![diagnostic]);
 
-        let stored = cache.get_diagnostics(uri.as_ref()).unwrap();
+        let stored = cache.diagnostics(uri.as_ref()).unwrap();
         let stored = message_as_str(&stored.diagnostics[0].message);
         assert!(stored.len() < oversized.len());
         assert!(stored.ends_with("... (truncated)"));
@@ -1207,7 +1207,7 @@ mod tests {
 
         cache.store_diagnostics(&test_server(), &uri, Some(1), diagnostics);
 
-        let stored = &cache.get_diagnostics(uri.as_ref()).unwrap().diagnostics;
+        let stored = &cache.diagnostics(uri.as_ref()).unwrap().diagnostics;
         assert!(
             stored.len() < original_count,
             "aggregate cap must trim the list, kept {} of {original_count}",
@@ -1238,7 +1238,7 @@ mod tests {
 
         cache.store_diagnostics(&test_server(), &uri, Some(1), diagnostics);
 
-        let stored = &cache.get_diagnostics(uri.as_ref()).unwrap().diagnostics;
+        let stored = &cache.diagnostics(uri.as_ref()).unwrap().diagnostics;
         assert!(
             stored.len() > 2600,
             "largest-fitting-prefix search must keep far more than half, kept {}",
@@ -1281,7 +1281,7 @@ mod tests {
 
         cache.store_diagnostics(&test_server(), &uri, Some(1), diagnostics);
 
-        let stored = &cache.get_diagnostics(uri.as_ref()).unwrap().diagnostics;
+        let stored = &cache.diagnostics(uri.as_ref()).unwrap().diagnostics;
         assert!(
             stored
                 .iter()
@@ -1391,7 +1391,7 @@ mod tests {
 
         cache.store_diagnostics(&test_server(), &uri, Some(1), vec![diagnostic]);
 
-        let stored = &cache.get_diagnostics(uri.as_ref()).unwrap().diagnostics;
+        let stored = &cache.diagnostics(uri.as_ref()).unwrap().diagnostics;
         assert_eq!(stored.len(), 1);
         assert_eq!(
             stored[0].message,
@@ -1422,7 +1422,7 @@ mod tests {
 
         cache.store_diagnostics(&test_server(), &uri, Some(1), vec![diagnostic]);
 
-        let stored = &cache.get_diagnostics(uri.as_ref()).unwrap().diagnostics;
+        let stored = &cache.diagnostics(uri.as_ref()).unwrap().diagnostics;
         assert_eq!(stored.len(), 1);
         assert_eq!(
             stored[0].message,
@@ -1470,7 +1470,7 @@ mod tests {
 
         cache.store_diagnostics(&test_server(), &uri, Some(1), vec![diagnostic]);
 
-        let stored = &cache.get_diagnostics(uri.as_ref()).unwrap().diagnostics;
+        let stored = &cache.diagnostics(uri.as_ref()).unwrap().diagnostics;
         assert_eq!(stored.len(), 1);
         let serialized_len = serde_json::to_vec(stored).unwrap().len();
         assert!(
@@ -1524,7 +1524,7 @@ mod tests {
 
         cache.store_diagnostics(&test_server(), &uri, Some(1), vec![diagnostic]);
 
-        let stored = &cache.get_diagnostics(uri.as_ref()).unwrap().diagnostics;
+        let stored = &cache.diagnostics(uri.as_ref()).unwrap().diagnostics;
         assert_eq!(stored.len(), 1);
         assert_eq!(
             stored[0].message,
@@ -1554,7 +1554,7 @@ mod tests {
 
         cache.store_diagnostics(&test_server(), &uri, Some(1), diagnostics);
 
-        let stored = &cache.get_diagnostics(uri.as_ref()).unwrap().diagnostics;
+        let stored = &cache.diagnostics(uri.as_ref()).unwrap().diagnostics;
         let serialized_len = serde_json::to_vec(stored).unwrap().len();
         assert!(
             serialized_len <= MAX_DIAGNOSTICS_ENTRY_BYTES,
@@ -1574,7 +1574,7 @@ mod tests {
         cache.store_diagnostics(&test_server(), &uri, Some(2), vec![]);
         assert_eq!(cache.diagnostics_count(), 1);
 
-        let stored = cache.get_diagnostics(uri.as_ref()).unwrap();
+        let stored = cache.diagnostics(uri.as_ref()).unwrap();
         assert_eq!(stored.version, Some(2));
     }
 
@@ -1805,16 +1805,12 @@ mod tests {
 
         cache.store_diagnostics(&test_server(), &uri, Some(1), vec![diagnostic]);
         assert_eq!(
-            cache
-                .get_diagnostics(uri.as_ref())
-                .unwrap()
-                .diagnostics
-                .len(),
+            cache.diagnostics(uri.as_ref()).unwrap().diagnostics.len(),
             1
         );
 
         cache.store_diagnostics(&test_server(), &uri, Some(2), vec![]);
-        let stored = cache.get_diagnostics(uri.as_ref()).unwrap();
+        let stored = cache.diagnostics(uri.as_ref()).unwrap();
         assert_eq!(stored.diagnostics.len(), 0);
         assert_eq!(stored.version, Some(2));
     }
@@ -1849,7 +1845,7 @@ mod tests {
 
         cache.store_diagnostics(&test_server(), &uri, Some(1), diagnostics);
 
-        let stored = cache.get_diagnostics(uri.as_ref()).unwrap();
+        let stored = cache.diagnostics(uri.as_ref()).unwrap();
         assert_eq!(stored.diagnostics.len(), 100);
     }
 
@@ -1894,9 +1890,9 @@ mod tests {
 
         // Oldest entries should be evicted (FIFO).
         let evicted: Uri = Uri::from("file:///test0.rs");
-        assert!(cache.get_diagnostics(evicted.as_ref()).is_none());
+        assert!(cache.diagnostics(evicted.as_ref()).is_none());
         let newest: Uri = Uri::from(format!("file:///test{}.rs", MAX_DIAGNOSTIC_ENTRIES + 9));
-        assert!(cache.get_diagnostics(newest.as_ref()).is_some());
+        assert!(cache.diagnostics(newest.as_ref()).is_some());
     }
 
     #[test]
@@ -1913,7 +1909,7 @@ mod tests {
             );
         }
         assert_eq!(cache.diagnostics_count(), 1);
-        assert!(cache.get_diagnostics(uri.as_ref()).is_some());
+        assert!(cache.diagnostics(uri.as_ref()).is_some());
     }
 
     #[test]
@@ -1943,15 +1939,15 @@ mod tests {
         cache.store_diagnostics(&test_server(), &overflow, Some(1), vec![]);
 
         assert!(
-            cache.get_diagnostics(actively_edited.as_ref()).is_some(),
+            cache.diagnostics(actively_edited.as_ref()).is_some(),
             "republished entry must survive eviction after being refreshed"
         );
         let oldest_untouched: Uri = Uri::from("file:///untouched0.rs");
         assert!(
-            cache.get_diagnostics(oldest_untouched.as_ref()).is_none(),
+            cache.diagnostics(oldest_untouched.as_ref()).is_none(),
             "the oldest never-republished entry must be evicted instead"
         );
-        assert!(cache.get_diagnostics(overflow.as_ref()).is_some());
+        assert!(cache.diagnostics(overflow.as_ref()).is_some());
     }
 
     #[test]
@@ -1971,7 +1967,7 @@ mod tests {
         // clear must not have left a stale `diagnostic_order` entry that
         // causes a premature eviction here.
         let first_of_batch: Uri = Uri::from("file:///test0.rs");
-        assert!(cache.get_diagnostics(first_of_batch.as_ref()).is_some());
+        assert!(cache.diagnostics(first_of_batch.as_ref()).is_some());
     }
 
     #[test]
@@ -1987,7 +1983,7 @@ mod tests {
         let uri: Uri = Uri::from("file:///test.rs");
 
         cache.store_diagnostics(&test_server(), &uri, None, vec![]);
-        let stored = cache.get_diagnostics(uri.as_ref()).unwrap();
+        let stored = cache.diagnostics(uri.as_ref()).unwrap();
         assert_eq!(stored.version, None);
     }
 
@@ -2017,13 +2013,13 @@ mod tests {
 
         assert_eq!(cache.diagnostics_count(), MAX_DIAGNOSTIC_ENTRIES);
         assert!(
-            cache.get_diagnostics(quiet_uri.as_ref()).is_some(),
+            cache.diagnostics(quiet_uri.as_ref()).is_some(),
             "quiet server's only entry must survive the noisy server's overflow"
         );
 
         let noisy_first: Uri = Uri::from("file:///noisy/file0.rs");
         assert!(
-            cache.get_diagnostics(noisy_first.as_ref()).is_none(),
+            cache.diagnostics(noisy_first.as_ref()).is_none(),
             "noisy server's own oldest entries must be evicted once the aggregate cache is full"
         );
     }
@@ -2131,18 +2127,18 @@ mod tests {
             MAX_DIAGNOSTIC_ENTRIES,
             "the aggregate cap must still be enforced even when every existing server is within share"
         );
-        assert!(cache.get_diagnostics(new_uri.as_ref()).is_some());
+        assert!(cache.diagnostics(new_uri.as_ref()).is_some());
 
         // `a` and `b` are tied at 500 entries each; the deterministic
         // tie-break in `server_to_evict_from` picks `b`, so `b`'s oldest
         // entry is the one evicted, not `a`'s.
         let b_oldest: Uri = Uri::from("file:///b/file0.rs");
         assert!(
-            cache.get_diagnostics(b_oldest.as_ref()).is_none(),
+            cache.diagnostics(b_oldest.as_ref()).is_none(),
             "the largest in-share server (tie-broken to b) must lose its oldest entry"
         );
         assert!(
-            cache.get_diagnostics("file:///a/file0.rs").is_some(),
+            cache.diagnostics("file:///a/file0.rs").is_some(),
             "the other in-share server must be untouched"
         );
     }
@@ -2161,7 +2157,7 @@ mod tests {
         }
 
         assert_eq!(cache.diagnostics_count(), 1);
-        let stored = cache.get_diagnostics(uri.as_ref()).unwrap();
+        let stored = cache.diagnostics(uri.as_ref()).unwrap();
         assert_eq!(stored.version, Some(max_version - 1));
     }
 
@@ -2179,7 +2175,7 @@ mod tests {
         cache.store_diagnostics(&new_owner, &uri, Some(2), vec![]);
 
         assert_eq!(cache.diagnostics_count(), 1);
-        let stored = cache.get_diagnostics(uri.as_ref()).unwrap();
+        let stored = cache.diagnostics(uri.as_ref()).unwrap();
         assert_eq!(stored.version, Some(2));
 
         // The old owner's order map must no longer reference this URI:
@@ -2189,7 +2185,7 @@ mod tests {
             let other: Uri = Uri::from(format!("file:///old/file{i}.rs"));
             cache.store_diagnostics(&old_owner, &other, Some(1), vec![]);
         }
-        assert!(cache.get_diagnostics(uri.as_ref()).is_some());
+        assert!(cache.diagnostics(uri.as_ref()).is_some());
     }
 
     /// #290: `diagnostics_owner` is what a cache-only read (e.g.
@@ -2248,8 +2244,8 @@ mod tests {
 
         cache.clear_server_diagnostics(&crashed);
 
-        assert!(cache.get_diagnostics(crashed_uri.as_ref()).is_none());
-        assert!(cache.get_diagnostics(healthy_uri.as_ref()).is_some());
+        assert!(cache.diagnostics(crashed_uri.as_ref()).is_none());
+        assert!(cache.diagnostics(healthy_uri.as_ref()).is_some());
         assert_eq!(cache.diagnostics_count(), 1);
 
         // Idempotent / no-op for a server with no (or no longer any) entries.
@@ -2314,10 +2310,10 @@ mod tests {
         cache.store_diagnostics(&other, &new_uri, Some(1), vec![]);
 
         assert_eq!(cache.diagnostics_count(), MAX_DIAGNOSTIC_ENTRIES);
-        assert!(cache.get_diagnostics(new_uri.as_ref()).is_some());
+        assert!(cache.diagnostics(new_uri.as_ref()).is_some());
         let server_oldest: Uri = Uri::from("file:///file0.rs");
         assert!(
-            cache.get_diagnostics(server_oldest.as_ref()).is_none(),
+            cache.diagnostics(server_oldest.as_ref()).is_none(),
             "the pre-existing server's oldest entry, now far over its shrunk share, must be evicted"
         );
     }
@@ -2344,13 +2340,13 @@ mod tests {
 
         assert_eq!(cache.diagnostics_count(), MAX_DIAGNOSTIC_ENTRIES);
         assert!(
-            cache.get_diagnostics(quiet_uri.as_ref()).is_some(),
+            cache.diagnostics(quiet_uri.as_ref()).is_some(),
             "quiet server's only entry must survive even without ever calling \
              set_diagnostics_route_count"
         );
         let noisy_first: Uri = Uri::from("file:///noisy/file0.rs");
         assert!(
-            cache.get_diagnostics(noisy_first.as_ref()).is_none(),
+            cache.diagnostics(noisy_first.as_ref()).is_none(),
             "the noisy server, now auto-derived as one of two servers sharing the budget, \
              must still lose its own oldest entries once over its fair share"
         );
@@ -2407,15 +2403,15 @@ mod tests {
         cache.store_diagnostics(&server, &overflow, Some(1), vec![]);
 
         assert!(
-            cache.get_diagnostics(important.as_ref()).is_some(),
+            cache.diagnostics(important.as_ref()).is_some(),
             "a non-empty entry must survive eviction over empty entries, even though it is older"
         );
         let oldest_clean: Uri = Uri::from("file:///clean0.rs");
         assert!(
-            cache.get_diagnostics(oldest_clean.as_ref()).is_none(),
+            cache.diagnostics(oldest_clean.as_ref()).is_none(),
             "the oldest empty entry must be evicted instead of the older non-empty one"
         );
-        assert!(cache.get_diagnostics(overflow.as_ref()).is_some());
+        assert!(cache.diagnostics(overflow.as_ref()).is_some());
     }
 
     /// #284: storing an empty diagnostics list must still create a fully
@@ -2432,7 +2428,7 @@ mod tests {
 
         cache.store_diagnostics(&test_server(), &uri, Some(1), vec![]);
 
-        let stored = cache.get_diagnostics(uri.as_ref());
+        let stored = cache.diagnostics(uri.as_ref());
         assert!(
             stored.is_some(),
             "an empty-diagnostics entry must still be tracked"
@@ -2487,17 +2483,17 @@ mod tests {
         for i in 0..500 {
             let uri: Uri = Uri::from(format!("file:///a/file{i}.rs"));
             assert!(
-                cache.get_diagnostics(uri.as_ref()).is_some(),
+                cache.diagnostics(uri.as_ref()).is_some(),
                 "server a's real diagnostics must all survive; b has an empty entry to lose \
                  instead"
             );
         }
         let b_oldest: Uri = Uri::from("file:///b/file0.rs");
         assert!(
-            cache.get_diagnostics(b_oldest.as_ref()).is_none(),
+            cache.diagnostics(b_oldest.as_ref()).is_none(),
             "b's oldest empty entry must be evicted instead of a's real diagnostics"
         );
-        assert!(cache.get_diagnostics(overflow.as_ref()).is_some());
+        assert!(cache.diagnostics(overflow.as_ref()).is_some());
     }
 
     /// #284: a URI that transitions non-empty -> empty -> non-empty must not
@@ -2536,7 +2532,7 @@ mod tests {
         let overflow: Uri = Uri::from("file:///overflow.rs");
         cache.store_diagnostics(&server, &overflow, Some(1), vec![]);
 
-        let stored = cache.get_diagnostics(uri.as_ref());
+        let stored = cache.diagnostics(uri.as_ref());
         assert!(
             stored.is_some_and(|info| info.diagnostics.len() == 1),
             "the re-dirtied entry must survive and keep its real diagnostic, not be mistaken \

--- a/crates/mcpls-core/src/bridge/translator/diagnostics.rs
+++ b/crates/mcpls-core/src/bridge/translator/diagnostics.rs
@@ -144,7 +144,7 @@ impl Translator {
 
         let diag_info = {
             let cache = notification_cache.lock().await;
-            cache.get_diagnostics(uri.as_ref()).cloned()
+            cache.diagnostics(uri.as_ref()).cloned()
         };
 
         match pull_response {
@@ -416,7 +416,7 @@ mod tests {
 
         let cache_key =
             Translator::cached_diagnostics_uri(&[], test_file.to_str().unwrap()).unwrap();
-        let diag_info = cache.get_diagnostics(&cache_key).cloned();
+        let diag_info = cache.diagnostics(&cache_key).cloned();
         let diags = Translator::diagnostics_from_cache_entry(
             diag_info.as_ref(),
             PositionEncoding::Utf16,
@@ -529,7 +529,7 @@ mod tests {
 
         let cache_key =
             Translator::cached_diagnostics_uri(&[], test_file.to_str().unwrap()).unwrap();
-        let diag_info = cache.get_diagnostics(&cache_key).cloned();
+        let diag_info = cache.diagnostics(&cache_key).cloned();
         let diags = Translator::diagnostics_from_cache_entry(
             diag_info.as_ref(),
             PositionEncoding::Utf16,
@@ -645,7 +645,7 @@ mod tests {
 
         let cache_key =
             Translator::cached_diagnostics_uri(&[], test_file.to_str().unwrap()).unwrap();
-        let diag_info = cache.get_diagnostics(&cache_key).cloned();
+        let diag_info = cache.diagnostics(&cache_key).cloned();
         let diags = Translator::diagnostics_from_cache_entry(
             diag_info.as_ref(),
             PositionEncoding::Utf16,
@@ -706,7 +706,7 @@ mod tests {
 
         let cache_key =
             Translator::cached_diagnostics_uri(&[], test_file.to_str().unwrap()).unwrap();
-        let diag_info = cache.get_diagnostics(&cache_key).cloned();
+        let diag_info = cache.diagnostics(&cache_key).cloned();
         let diags = Translator::diagnostics_from_cache_entry(
             diag_info.as_ref(),
             PositionEncoding::Utf16,

--- a/crates/mcpls-core/src/bridge/translator/mod.rs
+++ b/crates/mcpls-core/src/bridge/translator/mod.rs
@@ -524,7 +524,7 @@ mod tests {
         translator.clear_expected_servers();
 
         let err = translator
-            .get_client_for_file(&path, ToolKind::Hover)
+            .client_for_file(&path, ToolKind::Hover)
             .unwrap_err();
         assert!(matches!(err, Error::NoServerForLanguage(_)));
     }

--- a/crates/mcpls-core/src/bridge/translator/respawn.rs
+++ b/crates/mcpls-core/src/bridge/translator/respawn.rs
@@ -841,17 +841,17 @@ fi
 
             let guard = cache.lock().await;
             assert!(
-                guard.get_diagnostics(synced_uri.as_ref()).is_none(),
+                guard.diagnostics(synced_uri.as_ref()).is_none(),
                 "diagnostics attributed to the crashed connection must be \
                  invalidated on respawn, not served as current"
             );
             assert!(
-                guard.get_diagnostics(never_opened_uri.as_ref()).is_none(),
+                guard.diagnostics(never_opened_uri.as_ref()).is_none(),
                 "workspace-wide diagnostics for a file mcpls never opened \
                  must also be invalidated, not just synced documents"
             );
             assert!(
-                guard.get_diagnostics(other_language_uri.as_ref()).is_some(),
+                guard.diagnostics(other_language_uri.as_ref()).is_some(),
                 "a different diagnostics-route server's entries must survive \
                  an unrelated server's respawn-triggered cache clear"
             );
@@ -948,7 +948,7 @@ fi
                 cache
                     .lock()
                     .await
-                    .get_diagnostics(owned_by_healthy_server.as_ref())
+                    .diagnostics(owned_by_healthy_server.as_ref())
                     .is_some(),
                 "respawning a non-diagnostics-route server must not clear \
                  the diagnostics-route server's cache entries"

--- a/crates/mcpls-core/src/bridge/translator/routing.rs
+++ b/crates/mcpls-core/src/bridge/translator/routing.rs
@@ -64,7 +64,7 @@ impl Translator {
     /// resolved server a chance to be respawned first if its process has
     /// died.
     ///
-    /// Thin async wrapper around [`Self::get_client_for_file`] (kept
+    /// Thin async wrapper around [`Self::client_for_file`] (kept
     /// synchronous so its existing unit tests don't need a runtime): this is
     /// the entry point async handlers call instead, so a dead server is
     /// transparently replaced before its stale client is handed back.
@@ -73,7 +73,7 @@ impl Translator {
         path: &Path,
         tool: ToolKind,
     ) -> Result<(ServerId, LspClient)> {
-        let (id, client) = self.get_client_for_file(path, tool)?;
+        let (id, client) = self.client_for_file(path, tool)?;
         self.respawn_if_dead(&id).await?;
         let client = lock_std(&self.lsp_clients)
             .get(&id)
@@ -94,7 +94,7 @@ impl Translator {
     /// Locks `router`, `lsp_clients`, and (on the not-yet-registered path)
     /// `expected_servers` only for their respective lookups — every guard is
     /// dropped before this method returns.
-    pub(super) fn get_client_for_file(
+    pub(super) fn client_for_file(
         &self,
         path: &Path,
         tool: ToolKind,
@@ -153,7 +153,7 @@ impl Translator {
     /// `path`'s detected language, without requiring that server to be
     /// currently registered.
     ///
-    /// Mirrors [`Self::get_client_for_file`]'s language-candidate order (the
+    /// Mirrors [`Self::client_for_file`]'s language-candidate order (the
     /// detected language, then its React base language) but only queries the
     /// router: a cache-only caller (`get_cached_diagnostics`) has no LSP
     /// round trip to gate a resolved server's registration on, and only
@@ -365,7 +365,7 @@ mod tests {
     type JsonValue = serde_json::Value;
 
     #[test]
-    fn test_get_client_for_file_server_initializing_when_expected() {
+    fn test_client_for_file_server_initializing_when_expected() {
         // A configured/applicable language whose LSP client has not registered
         // yet (large solution still loading via OmniSharp) must surface
         // ServerInitializing — "wait and retry" — not NoServerForLanguage.
@@ -379,13 +379,13 @@ mod tests {
         translator.set_expected_servers(expected);
 
         let err = translator
-            .get_client_for_file(&path, ToolKind::Hover)
+            .client_for_file(&path, ToolKind::Hover)
             .unwrap_err();
         assert!(matches!(err, Error::ServerInitializing { server_id } if server_id == id));
     }
 
     #[test]
-    fn test_get_client_for_file_no_server_when_not_expected() {
+    fn test_client_for_file_no_server_when_not_expected() {
         // When no route is configured for the language at all, the error
         // stays NoServerForLanguage.
         let translator = Translator::new();
@@ -393,7 +393,7 @@ mod tests {
         let lang = detect_language(&path, &translator.extension_map);
 
         let err = translator
-            .get_client_for_file(&path, ToolKind::Hover)
+            .client_for_file(&path, ToolKind::Hover)
             .unwrap_err();
         assert!(matches!(err, Error::NoServerForLanguage(ref l) if *l == lang));
     }
@@ -464,7 +464,7 @@ mod tests {
     }
 
     #[test]
-    fn test_get_client_for_file_uses_custom_extension() {
+    fn test_client_for_file_uses_custom_extension() {
         let temp_dir = TempDir::new().unwrap();
         let test_file = temp_dir.path().join("script.nu");
         fs::write(&test_file, "echo hello").unwrap();
@@ -474,7 +474,7 @@ mod tests {
 
         let translator = Translator::new().with_extensions(extension_map);
 
-        let result = translator.get_client_for_file(&test_file, ToolKind::Hover);
+        let result = translator.client_for_file(&test_file, ToolKind::Hover);
 
         assert!(result.is_err());
         if let Err(Error::NoServerForLanguage(lang)) = result {
@@ -485,7 +485,7 @@ mod tests {
     }
 
     #[test]
-    fn test_get_client_for_file_falls_back_to_default() {
+    fn test_client_for_file_falls_back_to_default() {
         let temp_dir = TempDir::new().unwrap();
         let test_file = temp_dir.path().join("unknown.xyz");
         fs::write(&test_file, "content").unwrap();
@@ -495,7 +495,7 @@ mod tests {
 
         let translator = Translator::new().with_extensions(extension_map);
 
-        let result = translator.get_client_for_file(&test_file, ToolKind::Hover);
+        let result = translator.client_for_file(&test_file, ToolKind::Hover);
 
         assert!(result.is_err());
         if let Err(Error::NoServerForLanguage(lang)) = result {
@@ -506,7 +506,7 @@ mod tests {
     }
 
     #[test]
-    fn test_get_client_for_file_routes_tsx_to_typescript_server() {
+    fn test_client_for_file_routes_tsx_to_typescript_server() {
         let temp_dir = TempDir::new().unwrap();
         let test_file = temp_dir.path().join("component.tsx");
         fs::write(&test_file, "export const Component = () => <div />").unwrap();
@@ -526,13 +526,13 @@ mod tests {
         );
 
         let (_id, client) = translator
-            .get_client_for_file(&test_file, ToolKind::Hover)
+            .client_for_file(&test_file, ToolKind::Hover)
             .unwrap();
         assert_eq!(client.language_id(), "typescript");
     }
 
     #[test]
-    fn test_get_client_for_file_prefers_exact_react_server() {
+    fn test_client_for_file_prefers_exact_react_server() {
         let temp_dir = TempDir::new().unwrap();
         let test_file = temp_dir.path().join("component.tsx");
         fs::write(&test_file, "export const Component = () => <div />").unwrap();
@@ -573,7 +573,7 @@ mod tests {
         );
 
         let (_id, client) = translator
-            .get_client_for_file(&test_file, ToolKind::Hover)
+            .client_for_file(&test_file, ToolKind::Hover)
             .unwrap();
         assert_eq!(client.language_id(), "typescriptreact");
     }
@@ -597,7 +597,7 @@ mod tests {
             .with_extensions(extension_map)
             .with_router(ToolRouter::catch_all([(id.clone(), "rust".to_string())]));
         // Deliberately no `register_client`/`register_server`: this must not
-        // require a live registration, unlike `get_client_for_file`.
+        // require a live registration, unlike `client_for_file`.
 
         assert_eq!(
             translator.diagnostics_route_id_for_path(&test_file),
@@ -619,7 +619,7 @@ mod tests {
     }
 
     #[test]
-    fn test_get_client_for_file_routes_jsx_to_javascript_server() {
+    fn test_client_for_file_routes_jsx_to_javascript_server() {
         let temp_dir = TempDir::new().unwrap();
         let test_file = temp_dir.path().join("component.jsx");
         fs::write(&test_file, "export const Component = () => <div />").unwrap();
@@ -649,7 +649,7 @@ mod tests {
         translator.register_client("javascript".to_string(), LspClient::new(javascript_config));
 
         let (_id, client) = translator
-            .get_client_for_file(&test_file, ToolKind::Hover)
+            .client_for_file(&test_file, ToolKind::Hover)
             .unwrap();
         assert_eq!(client.language_id(), "javascript");
     }
@@ -1172,7 +1172,7 @@ mod tests {
         ));
     }
 
-    /// `handle_incoming_calls` resolves its server via `get_client_for_file`
+    /// `handle_incoming_calls` resolves its server via `client_for_file`
     /// directly (not `prepare_document`), a separate code path from the other
     /// gated handlers -- exercise it explicitly.
     #[tokio::test]

--- a/crates/mcpls-core/src/bridge/translator/symbols.rs
+++ b/crates/mcpls-core/src/bridge/translator/symbols.rs
@@ -174,7 +174,7 @@ impl Translator {
                 // covers a server that is configured but has not finished
                 // spawning yet -- check `expected_servers` (unavailable to
                 // `ToolRouter` itself) to tell the two apart, mirroring
-                // `get_client_for_file`'s `ServerInitializing` check below.
+                // `client_for_file`'s `ServerInitializing` check below.
                 NoServerReason::NothingRegistered => {
                     if lock_std(&self.expected_servers).is_empty() {
                         Error::NoServerConfigured

--- a/crates/mcpls-core/src/lib.rs
+++ b/crates/mcpls-core/src/lib.rs
@@ -2053,7 +2053,7 @@ mod tests {
                     tokio::task::yield_now().await;
                     let found = {
                         let guard = cache.lock().await;
-                        guard.get_diagnostics(uri.as_ref()).is_some()
+                        guard.diagnostics(uri.as_ref()).is_some()
                     };
                     if found {
                         return true;
@@ -2137,7 +2137,7 @@ mod tests {
                 loop {
                     {
                         let guard = cache.lock().await;
-                        if guard.get_diagnostics(inside_uri.as_ref()).is_some() {
+                        if guard.diagnostics(inside_uri.as_ref()).is_some() {
                             return;
                         }
                     }
@@ -2150,7 +2150,7 @@ mod tests {
             let found_outside = cache
                 .lock()
                 .await
-                .get_diagnostics(outside_uri.as_ref())
+                .diagnostics(outside_uri.as_ref())
                 .is_some();
             assert!(
                 !found_outside,
@@ -2273,7 +2273,7 @@ mod tests {
                 loop {
                     {
                         let guard = cache.lock().await;
-                        if guard.get_diagnostics(uri.as_ref()).is_some() {
+                        if guard.diagnostics(uri.as_ref()).is_some() {
                             return;
                         }
                     }

--- a/crates/mcpls-core/src/mcp/server.rs
+++ b/crates/mcpls-core/src/mcp/server.rs
@@ -665,7 +665,7 @@ impl McplsServer {
                         let push_degraded = route_id
                             .as_ref()
                             .is_some_and(|id| cache.is_push_degraded(id));
-                        (cache.get_diagnostics(&uri).cloned(), owner, push_degraded)
+                        (cache.diagnostics(&uri).cloned(), owner, push_degraded)
                     };
                     let encoding = owner.map_or(PositionEncoding::Utf16, |server_id| {
                         self.context.translator.position_encoding_for(&server_id)
@@ -907,7 +907,7 @@ impl ServerHandler for McplsServer {
                 .is_some_and(|id| cache.is_push_degraded(id));
             build_resource_diagnostics_response(
                 self.context.translator.is_document_open(&validated_path),
-                cache.get_diagnostics(lsp_uri.as_ref()),
+                cache.diagnostics(lsp_uri.as_ref()),
                 push_degraded,
             )
         };
@@ -962,7 +962,7 @@ impl ServerHandler for McplsServer {
             .map_err(|e| McpError::invalid_params(e.to_string(), None))?;
         let has_cached_diagnostics = {
             let cache = self.context.notification_cache.lock().await;
-            cache.get_diagnostics(lsp_uri.as_ref()).is_some()
+            cache.diagnostics(lsp_uri.as_ref()).is_some()
         };
 
         if has_cached_diagnostics


### PR DESCRIPTION
## Summary
- Renames `NotificationCache::get_diagnostics` to `diagnostics` (`bridge/notifications.rs`) and `Translator::get_client_for_file` to `client_for_file` (`bridge/translator/routing.rs`), per Rust API guidelines (C-GETTER): the `get_` prefix is reserved for rare disambiguation cases, not plain internal accessors.
- Both are internal (non-trait, non-MCP-tool) methods; `McplsServer::get_hover`/`get_definition`/`get_diagnostics` and other wire-facing MCP tool identifiers set by the `#[tool(...)]` macro are untouched, as they are exempt.
- All call sites updated across 8 files in `mcpls-core`; 8 test function identifiers that embedded the old method names were also renamed for consistency.
- Adds a `CHANGELOG.md` entry noting this is a breaking rename for embedders (`NotificationCache::get_diagnostics` was `pub`) and that it revisits the rationale in a previous entry (#293) that had left `get_diagnostics` unchanged.

## Note on naming
During review, a minor naming inconsistency was flagged: `diagnostics(uri)` returns `Option<&DiagnosticInfo>` (a wrapper), which breaks the "name matches the thing returned" pattern followed by the sibling `diagnostics_owner`/`diagnostics_count` methods (an alternative like `diagnostics_entry` would satisfy C-GETTER while preserving that pattern). This PR keeps `diagnostics` as specified in #384's own before/after code block; flagging here in case a follow-up rename is preferred.

Closes #384

Test plan
- `cargo +nightly fmt --all -- --check`
- `cargo clippy --all-targets --all-features --workspace -- -D warnings`
- `cargo nextest run --workspace --all-features` (818 passed / 40 skipped)
- `cargo test --doc --all-features --workspace`
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`

https://claude.ai/code/session_01TxTfgVHmNTLn8FUcyUZ4Sy