### PR TITLE
docs: document issue-claiming convention in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,6 +39,16 @@ This project follows the [Rust Code of Conduct](https://www.rust-lang.org/polici
 
 ## Development Workflow
 
+### Claiming an Issue
+
+Before starting work on an issue:
+
+1. Check the issue's `assignee` field — if already assigned to someone else, please ask in a comment before opening a competing pull request.
+2. For non-trivial issues, leave a comment stating your intent to work on it. This allows maintainers to coordinate effort and catch duplicate work early.
+3. If a maintainer-authored fix is already in progress on the issue, their work takes precedence — coordinate with the maintainer before submitting an alternative solution.
+
+This helps prevent duplicate effort and keeps the project organized as it grows.
+
 ### Branch Naming
 
 - `feature/description` - New features


### PR DESCRIPTION
## Summary

- Add a "Claiming an Issue" section to CONTRIBUTING.md, placed at the start of the Development Workflow section.
- Covers checking the issue's assignee before starting work, leaving an intent comment on non-trivial issues, and deferring to a maintainer-authored fix already in progress.

This prevents uncoordinated duplicate PRs like the one observed between issue #382 and PR #385.

Closes #388

## Test plan

- [x] Reviewed diff for consistency with existing CONTRIBUTING.md tone and formatting
- [x] Confirmed no other sections were modified
- [x] Documentation-only change; no build/test suite impact