### PR TITLE
fix(lsp): retry ContentModified (-32801) responses for safe methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- LSP `-32801` (`ContentModified`) error responses are now retried automatically for read-only/idempotent tool calls (hover, references, diagnostics, etc.), using the same attempt budget and backoff already applied to `-32802` (`ServerCancelled`); mutating requests (rename, formatting, code actions) are excluded. Also corrected a doc comment that mislabeled `-32802` as "content modified". (#382)
+- LSP `-32801` (`ContentModified`) error responses are now retried automatically for read-only/idempotent tool calls (hover, references, diagnostics, etc.), using the same attempt budget and backoff already applied to `-32802` (`ServerCancelled`); mutating requests (rename, formatting, code actions) are excluded. Also corrected a doc comment that mislabeled `-32802` as "content modified". (#390)
 - `NotificationCache` now derives the diagnostics cache fair-share budget automatically from the number of publishing servers when `set_diagnostics_route_count` is never called, instead of silently defaulting to an unpartitioned budget. (#379)
 - Cache eviction now prefers evicting empty ("file is clean") diagnostics entries over real ones, including across servers sharing the same eviction victim, so a stream of clean-file notifications can no longer displace actual diagnostics from the cache. (#379)
 - Diagnostics push notifications no longer silently vanish after an LSP server respawn; `get_cached_diagnostics`/resource reads now flag when they're degraded. (#363)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- LSP `-32801` (`ContentModified`) error responses are now retried automatically for read-only/idempotent tool calls (hover, references, diagnostics, etc.), using the same attempt budget and backoff already applied to `-32802` (`ServerCancelled`); mutating requests (rename, formatting, code actions) are excluded. Also corrected a doc comment that mislabeled `-32802` as "content modified". (#382)
 - `NotificationCache` now derives the diagnostics cache fair-share budget automatically from the number of publishing servers when `set_diagnostics_route_count` is never called, instead of silently defaulting to an unpartitioned budget. (#379)
 - Cache eviction now prefers evicting empty ("file is clean") diagnostics entries over real ones, including across servers sharing the same eviction victim, so a stream of clean-file notifications can no longer displace actual diagnostics from the cache. (#379)
 - Diagnostics push notifications no longer silently vanish after an LSP server respawn; `get_cached_diagnostics`/resource reads now flag when they're degraded. (#363)

--- a/crates/mcpls-core/src/config/server.rs
+++ b/crates/mcpls-core/src/config/server.rs
@@ -182,10 +182,12 @@ pub struct LspServerConfig {
     /// while translating an MCP tool call (hover, definition, references, etc.).
     ///
     /// This bounds a single request attempt, not a whole tool call: on a
-    /// `-32802` (content modified) response, [`crate::lsp::LspClient::request`]
-    /// retries up to 4 attempts with backoff, so the worst-case latency for one
-    /// tool call is `4 * request_timeout_seconds + 3.5` seconds. Completion
-    /// requests are further capped at 10 seconds regardless of this value; see
+    /// `-32801` (`ContentModified`) or `-32802` (`ServerCancelled`) response,
+    /// [`crate::lsp::LspClient::request`] retries up to 4 attempts with
+    /// backoff (one shared budget across both codes), so the worst-case
+    /// latency for one tool call is `4 * request_timeout_seconds + 3.5`
+    /// seconds. Completion requests are further capped at 10 seconds
+    /// regardless of this value; see
     /// [`crate::lsp::LspClient::completion_timeout`].
     #[serde(default = "default_request_timeout")]
     pub request_timeout_seconds: u64,
@@ -235,9 +237,10 @@ const fn default_request_timeout() -> u64 {
 /// bounds both, since the underlying defect and fix are identical for each.
 ///
 /// Set to 900 (15 minutes), not a rounder 3600 (1 hour): [`LspClient::request`]
-/// retries a request up to 4 times total on a `-32802` (`ServerCancelled`)
-/// response, so the worst-case latency for a single call bounded by this
-/// value is `4 * 900 + 3.5s` ≈ 1 hour, not 4 hours — this constant bounds one
+/// retries a request up to 4 times total on a `-32802` (`ServerCancelled`) or
+/// `-32801` (`ContentModified`) response (one shared budget across both
+/// codes), so the worst-case latency for a single call bounded by this value
+/// is `4 * 900 + 3.5s` ≈ 1 hour, not 4 hours — this constant bounds one
 /// attempt, so it is chosen such that the actually-experienced worst case
 /// (the retried total) stays within about an hour.
 ///

--- a/crates/mcpls-core/src/lsp/client.rs
+++ b/crates/mcpls-core/src/lsp/client.rs
@@ -4,6 +4,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicI64, Ordering};
 
+use lsp_types::LspErrorCodes;
 use serde::Serialize;
 use serde::de::DeserializeOwned;
 use serde_json::Value;
@@ -30,6 +31,45 @@ const SERVER_CANCELLED_MAX_RETRIES: u32 = 3;
 
 /// Initial backoff delay for server-cancelled retries (milliseconds).
 const SERVER_CANCELLED_INITIAL_DELAY_MS: u64 = 500;
+
+/// LSP request methods for which a `-32801` (`ContentModified`) error
+/// response is safe to retry automatically -- also declared to servers via
+/// `general.staleRequestSupport.retryOnContentModified` during initialize
+/// (see [`crate::lsp::LspServer`]'s handshake).
+///
+/// Per the LSP spec, `ContentModified` means the server noticed the document
+/// changed while it was computing a response; the (possibly stale) result may
+/// still be useful, or the client may choose to cancel the request instead.
+/// mcpls chooses to retry, which is safe for a read-only/idempotent request
+/// (hover, references, diagnostics, ...): a stale response is simply
+/// discarded and superseded by a fresh one.
+///
+/// Deliberately excludes every method in
+/// `crate::bridge::translator::edits` (`textDocument/rename`,
+/// `textDocument/formatting`, `textDocument/codeAction`): their result is an
+/// edit the MCP caller applies, and `-32801` means the document changed since
+/// the request was issued, so a retry at the original position could return
+/// an edit for content the caller no longer expects (e.g. renaming a
+/// different symbol than the one originally at that position).
+///
+/// This list only gates `-32801`. `-32802` (`ServerCancelled`) retry is
+/// unaffected and keeps retrying unconditionally for every method, as before.
+pub const CONTENT_MODIFIED_RETRY_METHODS: &[&str] = &[
+    "textDocument/signatureHelp",
+    "textDocument/inlayHint",
+    "textDocument/completion",
+    "textDocument/prepareCallHierarchy",
+    "callHierarchy/incomingCalls",
+    "callHierarchy/outgoingCalls",
+    "textDocument/diagnostic",
+    "textDocument/hover",
+    "textDocument/definition",
+    "textDocument/references",
+    "textDocument/implementation",
+    "textDocument/typeDefinition",
+    "textDocument/documentSymbol",
+    "workspace/symbol",
+];
 
 /// Byte-length threshold for truncating an LSP error message before logging it.
 ///
@@ -227,9 +267,10 @@ impl LspClient {
     ///
     /// This bounds one attempt, not a whole tool call: [`Self::request`]
     /// retries up to `SERVER_CANCELLED_MAX_RETRIES` (3) additional times on a
-    /// `-32802` (`ServerCancelled`) response, so the worst-case latency for a
-    /// single tool call is `4 * request_timeout() + 3.5s` (the sum of the
-    /// retry backoff delays).
+    /// `-32802` (`ServerCancelled`) or `-32801` (`ContentModified`) response,
+    /// sharing one attempt budget between the two codes, so the worst-case
+    /// latency for a single tool call is `4 * request_timeout() + 3.5s` (the
+    /// sum of the retry backoff delays).
     ///
     /// The configured value is clamped to the range from 1 second to
     /// [`MAX_TIMEOUT_SECONDS`]. [`crate::serve`]/[`crate::serve_with`] now
@@ -305,8 +346,11 @@ impl LspClient {
     /// Send request and wait for response with timeout.
     ///
     /// Automatically retries up to 3 times when the server returns error code
-    /// -32802 (`ServerCancelled`) with `data.retriggerRequest == true`, using
-    /// exponential backoff starting at 500 ms.
+    /// -32802 (`ServerCancelled`, any method) or -32801 (`ContentModified`,
+    /// only for methods in `CONTENT_MODIFIED_RETRY_METHODS`) -- gated by
+    /// `data.retriggerRequest` when present -- using exponential backoff
+    /// starting at 500 ms. Both codes share the same attempt budget: a
+    /// request that hits -32801 then -32802 does not get 8 attempts, only 4.
     ///
     /// # Type Parameters
     ///
@@ -336,7 +380,7 @@ impl LspClient {
         for attempt in 0..=SERVER_CANCELLED_MAX_RETRIES {
             if attempt > 0 {
                 debug!(
-                    "Retrying {} after ServerCancelled (attempt {}/{}), backoff={}ms",
+                    "Retrying {} (attempt {}/{}), backoff={}ms",
                     method, attempt, SERVER_CANCELLED_MAX_RETRIES, delay_ms
                 );
                 tokio::time::sleep(Duration::from_millis(delay_ms)).await;
@@ -384,11 +428,11 @@ impl LspClient {
                     code,
                     ref message,
                     ref data,
-                }) if code == SERVER_CANCELLED_CODE && Self::should_retrigger(data.as_ref()) => {
-                    warn!(
-                        "ServerCancelled (-32802) on '{}', will retry: {}",
-                        method, message
-                    );
+                }) if (code == SERVER_CANCELLED_CODE
+                    || (LspErrorCodes::from(code) == LspErrorCodes::ContentModified
+                        && CONTENT_MODIFIED_RETRY_METHODS.contains(&method)))
+                    && Self::should_retrigger(data.as_ref()) =>
+                {
                     if attempt == SERVER_CANCELLED_MAX_RETRIES {
                         return Err(Error::LspServerError {
                             code,
@@ -396,6 +440,13 @@ impl LspClient {
                             data: data.clone(),
                         });
                     }
+                    warn!(
+                        "{:?} ({}) on '{}', will retry: {}",
+                        LspErrorCodes::from(code),
+                        code,
+                        method,
+                        message
+                    );
                     // continue loop for next attempt
                 }
                 Err(e) => return Err(e),
@@ -426,12 +477,19 @@ impl LspClient {
             .await
     }
 
-    /// Returns true when the error data from a `ServerCancelled` (-32802) response
-    /// indicates the server wants the client to retrigger the request.
+    /// Returns true when the error data from a retryable "please retry" LSP
+    /// response (`ServerCancelled` -32802 or `ContentModified` -32801)
+    /// indicates a retry should happen.
     ///
-    /// Per the LSP specification, `data.retriggerRequest == true` is the signal.
-    /// When `data` is absent (older servers), we default to retrying anyway because
-    /// code -32802 is exclusively used for this purpose.
+    /// The LSP spec defines `data.retriggerRequest` only for diagnostic
+    /// requests' `ServerCancelled` responses (`DiagnosticServerCancellationData`)
+    /// -- it is not part of the general `ServerCancelled` or `ContentModified`
+    /// contract for other methods. mcpls checks this field whenever it is
+    /// present regardless of method (harmless for non-diagnostic methods,
+    /// since a compliant server won't send it there) and defaults to
+    /// retrying when the field is absent, since retrying is the more useful
+    /// default for a request that would otherwise surface as a hard error to
+    /// the MCP caller.
     fn should_retrigger(data: Option<&Value>) -> bool {
         data.is_none_or(|v| {
             v.get("retriggerRequest")
@@ -1196,18 +1254,22 @@ mod tests {
             serde_json::from_slice(&buf).unwrap()
         }
 
-        /// Writes a framed JSON-RPC `ServerCancelled` (-32802) error response.
-        async fn write_server_cancelled_response(
+        /// Writes a framed JSON-RPC retryable error response — either
+        /// `ServerCancelled` (-32802) or `ContentModified` (-32801) — with a
+        /// `data.retriggerRequest` flag.
+        async fn write_retryable_error_response(
             stdin: &mut ChildStdin,
             id: &Value,
+            code: i32,
+            message: &str,
             retrigger: bool,
         ) {
             let response = serde_json::json!({
                 "jsonrpc": "2.0",
                 "id": id,
                 "error": {
-                    "code": SERVER_CANCELLED_CODE,
-                    "message": "server cancelled the request",
+                    "code": code,
+                    "message": message,
                     "data": { "retriggerRequest": retrigger },
                 },
             });
@@ -1275,7 +1337,14 @@ mod tests {
             for _ in 0..=SERVER_CANCELLED_MAX_RETRIES {
                 let request = read_framed_message(&mut reader).await;
                 let id = request["id"].clone();
-                write_server_cancelled_response(&mut server.read_half_stdin, &id, true).await;
+                write_retryable_error_response(
+                    &mut server.read_half_stdin,
+                    &id,
+                    SERVER_CANCELLED_CODE,
+                    "server cancelled the request",
+                    true,
+                )
+                .await;
             }
 
             let result = request_task.await.unwrap();
@@ -1314,7 +1383,14 @@ mod tests {
             let mut reader = BufReader::new(&mut server.write_stdout);
             let request = read_framed_message(&mut reader).await;
             let id = request["id"].clone();
-            write_server_cancelled_response(&mut server.read_half_stdin, &id, false).await;
+            write_retryable_error_response(
+                &mut server.read_half_stdin,
+                &id,
+                SERVER_CANCELLED_CODE,
+                "server cancelled the request",
+                false,
+            )
+            .await;
 
             // With `retriggerRequest: false`, `should_retrigger`'s gate on
             // the retry branch must short-circuit the loop: the error
@@ -1361,9 +1437,11 @@ mod tests {
 
             // First attempt is cancelled and must retrigger.
             let first = read_framed_message(&mut reader).await;
-            write_server_cancelled_response(
+            write_retryable_error_response(
                 &mut server.read_half_stdin,
                 &first["id"].clone(),
+                SERVER_CANCELLED_CODE,
+                "server cancelled the request",
                 true,
             )
             .await;
@@ -1385,6 +1463,207 @@ mod tests {
 
             let result = request_task.await.unwrap();
             assert_eq!(result.unwrap(), expected_result);
+        }
+
+        #[tokio::test]
+        async fn test_retry_exhaustion_returns_original_content_modified_error() {
+            let (client, mut server) = fake_lsp_client();
+
+            let request_task = tokio::spawn(async move {
+                client
+                    .request::<_, Value>(
+                        "textDocument/hover",
+                        serde_json::json!({}),
+                        Duration::from_secs(30),
+                    )
+                    .await
+            });
+
+            let mut reader = BufReader::new(&mut server.write_stdout);
+            // Initial attempt plus SERVER_CANCELLED_MAX_RETRIES retries: every
+            // attempt gets ContentModified, so retries must exhaust rather
+            // than loop forever or swallow the error. -32801 shares the same
+            // attempt budget as -32802 (FR-002), not an independent one.
+            for _ in 0..=SERVER_CANCELLED_MAX_RETRIES {
+                let request = read_framed_message(&mut reader).await;
+                let id = request["id"].clone();
+                write_retryable_error_response(
+                    &mut server.read_half_stdin,
+                    &id,
+                    i32::from(LspErrorCodes::ContentModified),
+                    "content modified",
+                    true,
+                )
+                .await;
+            }
+
+            let result = request_task.await.unwrap();
+
+            match result {
+                Err(Error::LspServerError {
+                    code,
+                    message,
+                    data,
+                }) => {
+                    // Assert the exact original error surfaces, not merely
+                    // "some error with this code" -- a freshly constructed
+                    // placeholder error would satisfy a code-only check.
+                    assert_eq!(code, i32::from(LspErrorCodes::ContentModified));
+                    assert_eq!(message, "content modified");
+                    assert_eq!(data, Some(serde_json::json!({ "retriggerRequest": true })));
+                }
+                other => panic!("expected exhausted ContentModified error, got {other:?}"),
+            }
+        }
+
+        #[tokio::test]
+        async fn test_retrigger_false_returns_immediately_without_retry_for_content_modified() {
+            let (client, mut server) = fake_lsp_client();
+
+            let request_task = tokio::spawn(async move {
+                client
+                    .request::<_, Value>(
+                        "textDocument/hover",
+                        serde_json::json!({}),
+                        Duration::from_secs(30),
+                    )
+                    .await
+            });
+
+            let mut reader = BufReader::new(&mut server.write_stdout);
+            let request = read_framed_message(&mut reader).await;
+            let id = request["id"].clone();
+            write_retryable_error_response(
+                &mut server.read_half_stdin,
+                &id,
+                i32::from(LspErrorCodes::ContentModified),
+                "content modified",
+                false,
+            )
+            .await;
+
+            // Same `should_retrigger` gate as -32802: a non-spec-compliant
+            // server sending `retriggerRequest: false` on -32801 must still
+            // be honored (FR-006 resolution), short-circuiting the loop well
+            // under the first 500ms backoff.
+            let result = tokio::time::timeout(Duration::from_millis(200), request_task)
+                .await
+                .unwrap()
+                .unwrap();
+
+            match result {
+                Err(Error::LspServerError { code, .. }) => {
+                    assert_eq!(code, i32::from(LspErrorCodes::ContentModified));
+                }
+                other => panic!("expected immediate ContentModified error, got {other:?}"),
+            }
+
+            let second_request =
+                tokio::time::timeout(Duration::from_millis(200), read_framed_message(&mut reader))
+                    .await;
+            assert!(
+                second_request.is_err(),
+                "no retry should have been sent after retriggerRequest: false"
+            );
+        }
+
+        #[tokio::test]
+        async fn test_retry_succeeds_after_one_content_modified_response() {
+            let (client, mut server) = fake_lsp_client();
+
+            let request_task = tokio::spawn(async move {
+                client
+                    .request::<_, Value>(
+                        "textDocument/hover",
+                        serde_json::json!({}),
+                        Duration::from_secs(30),
+                    )
+                    .await
+            });
+
+            let mut reader = BufReader::new(&mut server.write_stdout);
+
+            // First attempt gets ContentModified and must retrigger.
+            let first = read_framed_message(&mut reader).await;
+            write_retryable_error_response(
+                &mut server.read_half_stdin,
+                &first["id"].clone(),
+                i32::from(LspErrorCodes::ContentModified),
+                "content modified",
+                true,
+            )
+            .await;
+
+            // Second attempt (after backoff) succeeds -- proves the loop
+            // genuinely re-sends the request rather than just counting down.
+            let second = read_framed_message(&mut reader).await;
+            assert_ne!(
+                first["id"], second["id"],
+                "retry must use a fresh request id"
+            );
+            let expected_result = serde_json::json!({ "contents": "resolved on retry" });
+            write_success_response(
+                &mut server.read_half_stdin,
+                &second["id"].clone(),
+                expected_result.clone(),
+            )
+            .await;
+
+            let result = request_task.await.unwrap();
+            assert_eq!(result.unwrap(), expected_result);
+        }
+
+        #[tokio::test]
+        async fn test_content_modified_on_non_allowlisted_method_does_not_retry() {
+            let (client, mut server) = fake_lsp_client();
+
+            // `textDocument/rename` is deliberately excluded from
+            // `CONTENT_MODIFIED_RETRY_METHODS` (its result is an edit the
+            // caller applies at a position that may no longer be valid once
+            // the document changed) -- a -32801 response for it must return
+            // immediately even though `retriggerRequest: true` would pass
+            // `should_retrigger`'s gate on its own.
+            let request_task = tokio::spawn(async move {
+                client
+                    .request::<_, Value>(
+                        "textDocument/rename",
+                        serde_json::json!({}),
+                        Duration::from_secs(30),
+                    )
+                    .await
+            });
+
+            let mut reader = BufReader::new(&mut server.write_stdout);
+            let request = read_framed_message(&mut reader).await;
+            let id = request["id"].clone();
+            write_retryable_error_response(
+                &mut server.read_half_stdin,
+                &id,
+                i32::from(LspErrorCodes::ContentModified),
+                "content modified",
+                true,
+            )
+            .await;
+
+            let result = tokio::time::timeout(Duration::from_millis(200), request_task)
+                .await
+                .unwrap()
+                .unwrap();
+
+            match result {
+                Err(Error::LspServerError { code, .. }) => {
+                    assert_eq!(code, i32::from(LspErrorCodes::ContentModified));
+                }
+                other => panic!("expected immediate ContentModified error, got {other:?}"),
+            }
+
+            let second_request =
+                tokio::time::timeout(Duration::from_millis(200), read_framed_message(&mut reader))
+                    .await;
+            assert!(
+                second_request.is_err(),
+                "no retry should have been sent for a non-allowlisted method"
+            );
         }
 
         /// #313: an oversized, server-controlled error message must be

--- a/crates/mcpls-core/src/lsp/lifecycle.rs
+++ b/crates/mcpls-core/src/lsp/lifecycle.rs
@@ -13,7 +13,8 @@ use std::process::Stdio;
 
 use lsp_types::{
     ClientCapabilities, ClientInfo, GeneralClientCapabilities, InitializeParams, InitializeResult,
-    InitializedParams, PositionEncodingKind, ServerCapabilities, SymbolKind, WorkspaceFolder,
+    InitializedParams, PositionEncodingKind, ServerCapabilities, StaleRequestSupportOptions,
+    SymbolKind, WorkspaceFolder,
 };
 use tokio::process::Command;
 use tokio::sync::mpsc;
@@ -23,6 +24,7 @@ use tracing::{debug, info, warn};
 use crate::bridge::try_path_to_uri;
 use crate::config::{LspServerConfig, ServerId};
 use crate::error::{Error, Result, ServerSpawnFailure};
+use crate::lsp::CONTENT_MODIFIED_RETRY_METHODS;
 use crate::lsp::client::LspClient;
 use crate::lsp::transport::LspTransport;
 use crate::lsp::types::LspNotification;
@@ -446,6 +448,15 @@ impl LspServer {
                     position_encodings: Some(resolve_position_encodings(
                         &config.position_encodings,
                     )),
+                    stale_request_support: Some(StaleRequestSupportOptions {
+                        // mcpls does not implement active in-flight request
+                        // cancellation.
+                        cancel: false,
+                        retry_on_content_modified: CONTENT_MODIFIED_RETRY_METHODS
+                            .iter()
+                            .map(ToString::to_string)
+                            .collect(),
+                    }),
                     ..Default::default()
                 }),
                 text_document: Some(lsp_types::TextDocumentClientCapabilities {
@@ -1841,6 +1852,57 @@ mod tests {
             .await;
 
             // The response written above must let `initialize` complete successfully.
+            init_task.await.unwrap().unwrap();
+        }
+
+        #[tokio::test]
+        async fn test_initialize_advertises_stale_request_support() {
+            let (client, mut server) = fake_lsp_client();
+
+            let config = ServerInitConfig {
+                server_config: LspServerConfig::rust_analyzer(),
+                workspace_roots: vec![],
+                initialization_options: None,
+                position_encodings: vec!["utf-8".to_string(), "utf-16".to_string()],
+                notification_tx: None,
+            };
+
+            let init_task =
+                tokio::spawn(async move { LspServer::initialize(&client, &config).await });
+
+            let mut reader = BufReader::new(&mut server.write_stdout);
+            let request = read_framed_message(&mut reader).await;
+            let params: InitializeParams =
+                serde_json::from_value(request["params"].clone()).unwrap();
+            let stale_request_support = params
+                .capabilities
+                .general
+                .unwrap()
+                .stale_request_support
+                .unwrap();
+
+            assert_eq!(request["method"], "initialize");
+            assert!(
+                !stale_request_support.cancel,
+                "mcpls does not implement active in-flight request cancellation"
+            );
+            assert_eq!(
+                stale_request_support.retry_on_content_modified,
+                CONTENT_MODIFIED_RETRY_METHODS
+                    .iter()
+                    .map(ToString::to_string)
+                    .collect::<Vec<_>>(),
+                "the wire-advertised capability must match the methods LspClient::request \
+                 actually retries -32801 for, not drift from it"
+            );
+
+            write_success_response(
+                &mut server.read_half_stdin,
+                &request["id"].clone(),
+                serde_json::json!({ "capabilities": {} }),
+            )
+            .await;
+
             init_task.await.unwrap().unwrap();
         }
 

--- a/crates/mcpls-core/src/lsp/mod.rs
+++ b/crates/mcpls-core/src/lsp/mod.rs
@@ -8,6 +8,7 @@ mod lifecycle;
 mod transport;
 pub(crate) mod types;
 
+pub(crate) use client::CONTENT_MODIFIED_RETRY_METHODS;
 pub use client::LspClient;
 pub(crate) use lifecycle::SUPPORTED_SYMBOL_KINDS;
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- Retry LSP `-32801` (`ContentModified`) error responses inside `LspClient::request`, sharing the same attempt budget and backoff already applied to `-32802` (`ServerCancelled`)
- Gate `-32801` retry behind a `CONTENT_MODIFIED_RETRY_METHODS` allowlist of read-only/idempotent requests (hover, references, definition, diagnostics, etc.); mutating requests (`textDocument/rename`, `formatting`, `codeAction`) are excluded since a retry at a stale position could apply an edit the caller no longer expects
- Declare `general.staleRequestSupport.retryOnContentModified` during the `initialize` handshake, sourced from the same allowlist (single source of truth, no drift possible)
- Correct a doc comment at `config/server.rs` that mislabeled `-32802` as "content modified" (it is `-32801`)
- Replace hand-rolled error-code handling with `lsp_types::LspErrorCodes`

## Context
Root cause and reproduction: `get_references` (and other tool calls) surfaced a transient `-32801` error immediately after rust-analyzer settled indexing, even though an identical request moments later succeeded. `LspClient::request` already retried `-32802` but had no equivalent handling for `-32801`.

An adversarial critique of the initial fix (unconditional `-32801` retry for every method) found it unsafe for mutating requests: retrying `textDocument/rename` at the original position after the document changed could silently apply a `WorkspaceEdit` renaming a different symbol than the one the caller intended, where the same content-modified condition previously surfaced as a loud error. The final implementation restricts `-32801` retry to a per-method allowlist and declares the corresponding LSP capability.

## Testing
- `cargo +nightly fmt --all -- --check`
- `cargo clippy --all-targets --all-features --workspace -- -D warnings`
- `cargo nextest run --workspace --all-features --lib --bins` (795 passed, 1 skipped)
- `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --all-features --workspace`
- New tests: retry-success and retry-exhaustion for `-32801`, retrigger-gating, allowlist-gate rejection for non-allowlisted methods (e.g. `textDocument/rename`), and wire-format verification that `staleRequestSupport` is sent during `initialize`

Closes #382 