### PR TITLE
docs(specs): add project constitution, modernize legacy spec templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `specs/constitution.md` documenting project-wide principles for the SDD spec package; resolves the `[[constitution]]` wikilink dangling across all specs. (#394)
 - Added end-to-end and TOML parse-error test coverage for `workspace.max_documents`/`max_file_size` resource-limit config. (#376)
 - `[mcp].tool_prefix` config option: prefixes every MCP tool name with `{tool_prefix}_`, letting a client tell apart tools from multiple concurrently running mcpls bridges. (#377)
 
 ### Changed
 
+- Modernized `specs/bridge/003-rwlock-translator` and `specs/mcp/002-mcp-resources-diagnostics` to the current spec template (YAML frontmatter, numbered sections, FR/NFR tables). (#394)
 - **`McpConfig`** — Breaking change: gained a `tool_prefix` field; exhaustive struct-literal construction of `McpConfig` no longer compiles. (#377)
 - Relocated the SDD spec package from `.local/specs/` to repo-root `specs/`, reorganized into functional blocks (config/lsp/mcp/bridge/runtime/testing) with block-scoped numbering, and added retroactive specs for previously undocumented core subsystems (position encoding, config discovery, LSP lifecycle, document tracker sync, MCP tool routing). (#368)
 - **`DocumentTracker::update`** — Breaking change: now `async`, serializing against `ensure_open` for the same path. (#363)

--- a/specs/MOC-specs.md
+++ b/specs/MOC-specs.md
@@ -59,6 +59,10 @@ subsystem.
 |---|------|------|----------|--------|-------|
 | 001 | [[testing/001-e2e-rust-analyzer-testing/spec\|e2e-rust-analyzer-testing]] | enhancement | P2 | implemented (#125, #126, #139, #225) | — |
 
+## Project Foundation
+
+- [[constitution]] — non-negotiable project principles governing all specs
+
 > [!note] Block assignment and numbering rationale
 > Every spec was reassigned to the block its subject matter is *most fundamentally about*, not
 > necessarily where its implementation happens to live in the crate tree. Two calls worth flagging:

--- a/specs/bridge/001-position-encoding-layer/spec.md
+++ b/specs/bridge/001-position-encoding-layer/spec.md
@@ -193,7 +193,7 @@ None — this is a retroactive spec documenting stable, already-shipped, well-te
 
 ## 10. See Also
 
-- [[constitution]] — project principles (not yet created for this project)
+- [[constitution]] — project principles
 - [[MOC-specs]] — all specifications
 - [[lsp/003-lsp-types-unmaintained-migration/spec|spec lsp/003]] — names `bridge/encoding.rs` as the
   critical-path code most sensitive to any `lsp-types`/`ls-types` type-level divergence

--- a/specs/bridge/002-document-tracker-synchronization/spec.md
+++ b/specs/bridge/002-document-tracker-synchronization/spec.md
@@ -207,7 +207,7 @@ None — this is a retroactive spec documenting stable, already-shipped, well-te
 
 ## 10. See Also
 
-- [[constitution]] — project principles (not yet created for this project)
+- [[constitution]] — project principles
 - [[MOC-specs]] — all specifications
 - [[bridge/005-expose-document-tracker-limits/spec|spec bridge/005]] — `ResourceLimits`
   (`max_documents`/`max_file_size`) enforcement, the sibling concern this spec does not duplicate

--- a/specs/bridge/003-rwlock-translator/spec.md
+++ b/specs/bridge/003-rwlock-translator/spec.md
@@ -1,10 +1,30 @@
-# Spec bridge/003: Replace `Arc<Mutex<Translator>>` with `Arc<RwLock<Translator>>`
+---
+aliases:
+  - RwLock Translator
+  - Concurrent read locks
+tags:
+  - sdd
+  - spec
+  - enhancement
+  - bridge
+  - concurrency
+created: 2026-08-01
+status: draft
+related:
+  - "[[constitution]]"
+  - "[[bridge/001-position-encoding-layer/spec]]"
+  - "[[bridge/002-document-tracker-synchronization/spec]]"
+---
 
-**Type**: enhancement
-**Priority**: P2
-**Status**: draft
+# Feature: Replace `Arc<Mutex<Translator>>` with `Arc<RwLock<Translator>>`
 
-## Problem Statement
+> [!info] Metadata
+> **Type**: enhancement
+> **Priority**: P2
+
+## 1. Overview
+
+### Problem Statement
 
 Every one of the 16 MCP tool handlers in `mcpls-core/src/mcp/server.rs` acquires a full exclusive
 `Mutex` lock on the `Translator` before dispatching an LSP request:
@@ -24,42 +44,49 @@ hundreds of milliseconds for a cold rust-analyzer query) serialises all concurre
 This is the root cause described in #104 (notification pump starvation) and the motivation for
 #108 (reduce lock hold time).
 
-## User Stories
+## 2. User Stories
 
-- As an AI agent issuing multiple simultaneous tool calls, I want hover and definition calls to
-  run concurrently rather than queued behind each other.
-- As a developer, I want the notification pump to receive push diagnostics without waiting for
-  a pending hover call to release the lock.
+### US-001: Concurrent read operations
 
-## Functional Requirements
+AS AN AI agent issuing multiple simultaneous tool calls,
+I WANT hover and definition calls to run concurrently rather than queued behind each other,
+SO THAT latency for batched requests is not cumulative.
 
-1. `Arc<Mutex<Translator>>` must be replaced with `Arc<RwLock<Translator>>`.
-2. Read-only tool handlers (hover, definition, references, document_symbols, completions,
-   call_hierarchy, workspace_symbol_search, code_actions, get_cached_diagnostics, get_server_logs,
-   get_server_messages) must acquire a read lock (`read().await`).
-3. Mutating handlers (rename_symbol, format_document, get_diagnostics which triggers didOpen)
-   must acquire a write lock (`write().await`).
-4. The `NotificationCache` must be separated from `Translator` into its own `Arc<RwLock<...>>`
-   (per spec for #104) so the pump can write diagnostics without waiting for a read lock on the
-   full `Translator`.
-5. No deadlocks: no code path may hold a read lock and attempt to acquire a write lock.
+### US-002: Non-blocking notification pump
 
-## Non-Functional Requirements
+AS A developer,
+I WANT the notification pump to receive push diagnostics without waiting for a pending hover call to release the lock,
+SO THAT diagnostics updates are not stalled by unrelated read operations.
 
-- Concurrent read throughput: ≥ 2x improvement on multi-tool batches (hover + definition).
-- No regression on single-tool latency.
-- MSRV compatibility: `tokio::sync::RwLock` is available since tokio 1.0.
+## 3. Functional Requirements
 
-## Alternatives Considered
+| ID | Requirement | Priority |
+|----|-------------|----------|
+| FR-001 | `Arc<Mutex<Translator>>` must be replaced with `Arc<RwLock<Translator>>` | must |
+| FR-002 | Read-only tool handlers (hover, definition, references, document_symbols, completions, call_hierarchy, workspace_symbol_search, code_actions, get_cached_diagnostics, get_server_logs, get_server_messages) must acquire a read lock (`read().await`) | must |
+| FR-003 | Mutating handlers (rename_symbol, format_document, get_diagnostics which triggers didOpen) must acquire a write lock (`write().await`) | must |
+| FR-004 | The `NotificationCache` must be separated from `Translator` into its own `Arc<RwLock<...>>` (per spec #104) so the pump can write diagnostics without waiting for a read lock on the full `Translator` | must |
+| FR-005 | No deadlocks: no code path may hold a read lock and attempt to acquire a write lock | must |
 
-- **arc-swap**: Suitable for config-like data that is atomically replaced wholesale; does not
-  fit `Translator` which is mutated in-place.
+## 4. Non-Functional Requirements
+
+| ID | Category | Requirement |
+|----|----------|-------------|
+| NFR-001 | Performance | Concurrent read throughput: ≥ 2x improvement on multi-tool batches (hover + definition) |
+| NFR-002 | Performance | No regression on single-tool latency |
+| NFR-003 | Compatibility | MSRV compatibility: `tokio::sync::RwLock` is available since tokio 1.0 |
+
+## 5. Alternatives Considered
+
+- **arc-swap**: Suitable for config-like data that is atomically replaced wholesale; does not fit `Translator` which is mutated in-place.
 - **dashmap**: Only applicable to HashMap-shaped state; Translator has richer structure.
-- **message-passing (channel)**: Would require restructuring all 16 handlers significantly;
-  higher complexity than RwLock upgrade.
+- **message-passing (channel)**: Would require restructuring all 16 handlers significantly; higher complexity than RwLock upgrade.
 
-## See Also
+## 6. See Also
 
+- [[constitution]] — project principles
+- [[bridge/001-position-encoding-layer/spec]] — foundational protocol conversion layer
+- [[bridge/002-document-tracker-synchronization/spec]] — document state management
 - #104 — split NotificationCache out of Translator lock
 - #108 — reduce Mutex hold time
 - tokio docs: https://docs.rs/tokio/latest/tokio/sync/struct.RwLock.html

--- a/specs/config/001-config-discovery-and-heuristics/spec.md
+++ b/specs/config/001-config-discovery-and-heuristics/spec.md
@@ -229,7 +229,7 @@ None — this is a retroactive spec documenting stable, already-shipped, well-te
 
 ## 10. See Also
 
-- [[constitution]] — project principles (not yet created for this project)
+- [[constitution]] — project principles
 - [[MOC-specs]] — all specifications
 - [[bridge/005-expose-document-tracker-limits/spec|spec bridge/005]] — `workspace.max_documents`/`max_file_size`,
   fields on the same `WorkspaceConfig` this spec documents

--- a/specs/constitution.md
+++ b/specs/constitution.md
@@ -1,0 +1,137 @@
+---
+aliases:
+  - Project Principles
+tags:
+  - sdd
+  - constitution
+created: 2026-09-06
+status: permanent
+---
+
+# Project Constitution
+
+> [!important]
+> Non-negotiable principles governing ALL development in this project.
+> Every specification, plan, and task MUST comply with this document.
+> Update this file only through explicit team decision.
+
+## I. Architecture
+
+**mcpls** is a bridge between MCP (Model Context Protocol) and LSP (Language Server Protocol):
+
+```
+AI Client (Claude) ←→ [MCP] ←→ mcpls ←→ [LSP] ←→ rust-analyzer / pyright / ...
+```
+
+The codebase is organized into four modules that match the four-block spec numbering scheme in `specs/`:
+
+- **`config/`** — TOML config loading, LSP server discovery with project-marker heuristics (Cargo.toml → rust-analyzer, package.json → typescript-language-server, etc.), auto-generates default config with 30 language mappings on first run
+- **`lsp/`** — LSP client: spawns server processes, manages JSON-RPC 2.0 over stdin/stdout, handles lifecycle (initialize → shutdown)
+- **`mcp/`** — MCP server (via `rmcp` crate): defines 20 tools (hover, definition, references, diagnostics, rename, format, call hierarchy, signature help, implementation/type-definition, inlay hints, etc.), dispatches tool calls to the bridge
+- **`bridge/`** — protocol translation layer:
+  - `translator/` — core MCP→LSP request/response mapping (organized into submodules: diagnostics, navigation, routing, symbols, call_hierarchy, assist, edits, respawn, characterization, clock, dto, encoding_ctx)
+  - `state.rs` — lazy document state tracking (textDocument/didOpen sent on first access)
+  - `encoding.rs` — position conversion: MCP uses 1-based lines/columns, LSP uses 0-based
+  - `notifications.rs` — caches push-based LSP notifications (diagnostics, log messages) for polling via MCP tools
+
+Cross-cutting concerns (CLI argument parsing, signal handling, transport-level shutdown) live in `mcpls-cli` and `mcpls-core`'s top-level modules under the `runtime` block.
+
+**Non-negotiable design constraints:**
+
+- Position encoding mismatch: MCP is 1-based, LSP is 0-based — all conversions go through `bridge/encoding.rs` (critical path; every tool depends on this)
+- Diagnostics are push-based in LSP but poll-based in MCP — `notifications.rs` caches them for safe querying
+- Multiple LSP servers run concurrently; one failing must not affect others (graceful degradation — a design principle, not a feature)
+- `deny(unsafe_code)` enforced workspace-wide via `unsafe_code = "deny"` in `workspace.lints`
+
+## II. Technology Stack
+
+- **Language**: Rust 1.88+ (MSRV enforced in `Cargo.toml` as `rust-version = "1.88"`)
+- **Edition**: 2024 edition
+- **Primary dependencies**:
+  - `tokio` 1.53+ — async runtime
+  - `rmcp` 3.2.0 — MCP server framework
+  - `lsp-types` (gen-lsp-types) 0.11.0 — LSP type definitions (fixed version to ensure stable protocol surface)
+  - `serde` 1.0 — serialization
+  - `anyhow` 1.0 — error handling
+  - `clap` 4.6 — CLI argument parsing
+  - `toml` 1.1 — configuration file parsing
+  - `tracing` 0.1 — structured logging
+
+No in-memory database; no external services required for core functionality (LSP servers are spawned as child processes, not external services).
+
+## III. Testing (NON-NEGOTIABLE)
+
+All features must have tests that pass before merge. Testing standards:
+
+- **Framework**: `cargo nextest` for parallel test execution; `rstest` for parametrized tests
+- **Minimum coverage**: All new public APIs and bridge translation logic require tests
+- **Integration testing**: End-to-end stack tests preferred over mocks for critical paths (position encoding, document tracking, notification caching)
+- **Pre-commit checklist**: All of the following must pass:
+  ```bash
+  cargo +nightly fmt --all -- --check
+  cargo clippy --all-targets --all-features --workspace -- -D warnings
+  cargo nextest run --workspace --all-features --lib --bins
+  RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features
+  ```
+
+## IV. Code Style
+
+- Follow existing patterns in the codebase (refer to `crates/mcpls-core/src/` subdirectories for established idioms)
+- All public APIs (`pub fn`, `pub struct`, `pub trait`, etc.) must have doc comments (`///`) with `# Examples` for non-trivial APIs
+- Doc comments must explain WHAT and WHY, not restate the signature
+- Avoid `unwrap()` and `expect()` in production code — use proper error handling (`Result`, `anyhow::Context`, or explicit fallback)
+- No hand-written UTF-8/UTF-16/UTF-32 encoding logic outside `bridge/encoding.rs` — reuse the conversion helpers
+- Follow the lock-ordering discipline documented in `crates/mcpls-core/src/bridge/translator/diagnostics.rs` comments around `NotificationCache` access
+
+## V. Security
+
+- Never commit secrets, keys, credentials, or API tokens
+- All user input (file paths, LSP server responses, MCP client requests) must be validated at system boundaries
+- File path handling must use `dunce` for UNC path normalization and validate against symlink escapes where applicable
+- Unsafe code blocks must have a safety comment explaining the invariant and why it cannot panic
+- Dependency security: maintain `cargo deny` checks in CI (no unaudited or yanked versions)
+
+## VI. Performance
+
+No hard latency targets — performance is secondary to correctness and simplicity. However:
+
+- Position encoding / document tracking / notification caching are on every critical path; optimization here is justified
+- Merge/dedup logic for diagnostics must be O(n) or O(n log n) in the number of diagnostics for a file (typically single/low double digits)
+- No additional LSP round-trips added to existing tool flows (e.g., don't spawn a new diagnostic request just to fix an incomplete result)
+
+## VII. Simplicity
+
+- Prefer standard library and framework features over third-party alternatives
+- New dependencies require justification (document in CHANGELOG.md and PR description)
+- Avoid multiple approaches to the same problem — establish one pattern and reuse it (example: position encoding logic is centralized in `bridge/encoding.rs`, not scattered across tool handlers)
+- Remove obsolete code paths entirely rather than deprecating or gating them behind flags
+- Module-level documentation (`//!`) must explain responsibility and fit into the architecture
+
+## VIII. Git Workflow
+
+**Branch naming:**
+- Features: `feat/m{N}/{issue-number}-{feature-slug}` (e.g., `feat/m3/42-auth-module`)
+- Bug fixes: `fix/{issue-number}-{short-slug}` (e.g., `fix/58-null-pointer`)
+- Hotfixes: `hotfix/{issue-number}-{short-slug}`
+- If no issue, omit the number: `feat/{feature-slug}` or `fix/{short-slug}`
+
+**Commit messages:** Follow Conventional Commits 1.0.0 format:
+```
+<type>[optional scope]: <description>
+
+[optional body]
+
+[optional footer(s)]
+```
+
+Allowed types: `feat`, `fix`, `docs`, `style`, `refactor`, `test`, `build`, `ci`, `perf`, `chore`, `release`. Each maps to semver as specified in `.claude/rules/commits-and-issues.md`.
+
+**Anti-patterns:**
+- Do not use past tense ("added feature" → use "add feature")
+- Do not mention AI tools, co-authors, or code generation
+- Do not use emoji
+- No session links in commit messages
+
+**Before creating a PR:** Run the full pre-commit check suite listed in Section III (Testing) — local checks must match CI exactly.
+
+**Issue filing:** All issues must have a priority label (P0–P4) as an actual label, plus a category (`bug`, `enhancement`, `research`). See `.claude/rules/commits-and-issues.md` for severity definitions and issue templates.

--- a/specs/lsp/001-lsp-server-lifecycle-and-respawn/spec.md
+++ b/specs/lsp/001-lsp-server-lifecycle-and-respawn/spec.md
@@ -242,7 +242,7 @@ None — this is a retroactive spec documenting stable, already-shipped, well-te
 
 ## 10. See Also
 
-- [[constitution]] — project principles (not yet created for this project)
+- [[constitution]] — project principles
 - [[MOC-specs]] — all specifications
 - [[runtime/002-sigterm-stdin-blocking-pool-hang/spec|spec runtime/002]] — the OS-process-exit half of shutdown
   this spec's `Translator::shutdown_servers`/`LspServer::shutdown` step feeds into

--- a/specs/lsp/003-lsp-types-unmaintained-migration/spec.md
+++ b/specs/lsp/003-lsp-types-unmaintained-migration/spec.md
@@ -323,7 +323,7 @@ All four questions below are now resolved by the completed migration (2026-09-05
 
 ## 10. See Also
 
-- [[constitution]] — project principles (not yet created for this project)
+- [[constitution]] — project principles
 - [[MOC-specs]] — all specifications
 - [gluon-lang/lsp-types](https://github.com/gluon-lang/lsp-types) — current upstream dependency, unmaintained since 2024-06-04
 - [tower-lsp-community/ls-types](https://github.com/tower-lsp-community/ls-types) — proposed replacement, maintained fork

--- a/specs/lsp/004-lsp-318-draft-gaps/spec.md
+++ b/specs/lsp/004-lsp-318-draft-gaps/spec.md
@@ -214,5 +214,5 @@ Not applicable — no code changes result from this spec.
 - [[lsp/002-lsp317-missing-tools/spec|spec lsp/002]] / issue #116 — existing tracked gap of unimplemented LSP 3.17-era tools (`get_signature_help`, `go_to_implementation`, `go_to_type_definition`, `get_inlay_hints`, `prepare_type_hierarchy`)
 - issue #290 — negotiated LSP position encoding not consumed by position conversion (P2, open)
 - [[lsp/003-lsp-types-unmaintained-migration/spec|spec lsp/003]] — companion finding on the unmaintained `lsp-types` dependency; prerequisite for adopting any 3.18 draft type
-- [[constitution]] — project principles (not yet created for this project)
+- [[constitution]] — project principles
 - [[MOC-specs]] — all specifications

--- a/specs/mcp/001-mcp-tool-surface-and-routing/spec.md
+++ b/specs/mcp/001-mcp-tool-surface-and-routing/spec.md
@@ -223,7 +223,7 @@ None — this is a retroactive spec documenting stable, already-shipped, well-te
 
 ## 10. See Also
 
-- [[constitution]] — project principles (not yet created for this project)
+- [[constitution]] — project principles
 - [[MOC-specs]] — all specifications
 - [[mcp/002-mcp-resources-diagnostics/spec|spec mcp/002]] — the `resources/*` MCP surface, a sibling
   concern this spec does not duplicate

--- a/specs/mcp/002-mcp-resources-diagnostics/spec.md
+++ b/specs/mcp/002-mcp-resources-diagnostics/spec.md
@@ -1,10 +1,30 @@
-# Spec mcp/002: Expose LSP Diagnostics as MCP Resources with Subscriptions
+---
+aliases:
+  - MCP resources diagnostics
+  - Diagnostics subscriptions
+tags:
+  - sdd
+  - spec
+  - enhancement
+  - mcp
+  - resources
+  - diagnostics
+created: 2026-07-30
+status: draft
+related:
+  - "[[constitution]]"
+  - "[[bridge/004-get-diagnostics-flycheck-gap/spec]]"
+---
 
-**Type**: enhancement
-**Priority**: P3
-**Status**: draft
+# Feature: Expose LSP Diagnostics as MCP Resources with Subscriptions
 
-## Problem Statement
+> [!info] Metadata
+> **Type**: enhancement
+> **Priority**: P3
+
+## 1. Overview
+
+### Problem Statement
 
 mcpls currently exposes LSP diagnostics only as polling tools (`get_diagnostics`,
 `get_cached_diagnostics`). The MCP 2025-11-25 specification introduces first-class
@@ -19,33 +39,41 @@ mcpls's current diagnostics model is a pull-based cache (`NotificationCache`) po
 the LSP push pump. This is already the right data structure — the gap is surfacing it through
 the MCP resource/subscription interface instead of (or in addition to) tool calls.
 
-## User Stories
+## 2. User Stories
 
-- As an AI agent editing a file, I want to receive a notification when new diagnostics arrive
-  rather than polling `get_diagnostics` repeatedly.
-- As an MCP client, I want to subscribe to `lsp-diagnostics://path/to/file` and receive
-  updates without issuing repeated tool calls.
+### US-001: Push notifications for diagnostics changes
 
-## Functional Requirements
+AS AN AI agent editing a file,
+I WANT to receive a notification when new diagnostics arrive rather than polling `get_diagnostics` repeatedly,
+SO THAT I can respond to errors and warnings in real time.
 
-1. mcpls must declare `resources` capability with `subscribe: true` in its `ServerInfo`.
-2. mcpls must implement `resources/list` returning URIs of the form
-   `lsp-diagnostics://<absolute-path>` for each open document.
-3. mcpls must implement `resources/read` for `lsp-diagnostics://` URIs, returning the current
-   `NotificationCache` contents for that path as JSON.
-4. mcpls must implement `resources/subscribe` — when a client subscribes, the notification
-   pump must emit `notifications/resources/updated` whenever the diagnostics cache for that
-   path changes.
-5. Existing `get_cached_diagnostics` tool must remain for clients that do not support resources.
+### US-002: Subscribe to diagnostics resources
 
-## Non-Functional Requirements
+AS AN MCP client,
+I WANT to subscribe to `lsp-diagnostics://path/to/file` and receive updates without issuing repeated tool calls,
+SO THAT my implementation can be event-driven rather than polling-based.
 
-- Zero extra LSP round-trips: use the existing notification pump output.
-- rmcp crate must expose resource registration and `notifications/resources/updated` send API
-  — verify before implementation (rmcp 1.5.0 currently used).
+## 3. Functional Requirements
 
-## See Also
+| ID | Requirement | Priority |
+|----|------------|----------|
+| FR-001 | mcpls must declare `resources` capability with `subscribe: true` in its `ServerInfo` | must |
+| FR-002 | mcpls must implement `resources/list` returning URIs of the form `lsp-diagnostics://<absolute-path>` for each open document | must |
+| FR-003 | mcpls must implement `resources/read` for `lsp-diagnostics://` URIs, returning the current `NotificationCache` contents for that path as JSON | must |
+| FR-004 | mcpls must implement `resources/subscribe` — when a client subscribes, the notification pump must emit `notifications/resources/updated` whenever the diagnostics cache for that path changes | must |
+| FR-005 | Existing `get_cached_diagnostics` tool must remain for clients that do not support resources | must |
 
+## 4. Non-Functional Requirements
+
+| ID | Category | Requirement |
+|----|----------|-------------|
+| NFR-001 | Performance | Zero extra LSP round-trips: use the existing notification pump output |
+| NFR-002 | Compatibility | rmcp crate must expose resource registration and `notifications/resources/updated` send API — verify before implementation (rmcp 3.2.0 currently used) |
+
+## 5. See Also
+
+- [[constitution]] — project principles
+- [[bridge/004-get-diagnostics-flycheck-gap/spec]] — uses and extends the `NotificationCache` design from this spec
 - MCP 2025-11-25 resources spec: https://modelcontextprotocol.io/specification/2025-11-25/server/resources
 - Tritlo/lsp-mcp: https://github.com/Tritlo/lsp-mcp
 - mcpls NotificationCache: `crates/mcpls-core/src/bridge/notifications.rs`

--- a/specs/runtime/001-log-json-bool-env-parsing/spec.md
+++ b/specs/runtime/001-log-json-bool-env-parsing/spec.md
@@ -217,7 +217,7 @@ No new domain entities. This is a parsing-behavior change on two existing CLI/en
 
 ## 10. See Also
 
-- [[constitution]] — project principles (not yet created for this project)
+- [[constitution]] — project principles
 - [[MOC-specs]] — all specifications
 - PR #285 (commit c25d756) — introduced `MCPLS_LOG_JSON` wiring into `logging::init`, source of the regression
 - Issue #279 — original request for `--log-json` support

--- a/specs/runtime/002-sigterm-stdin-blocking-pool-hang/spec.md
+++ b/specs/runtime/002-sigterm-stdin-blocking-pool-hang/spec.md
@@ -159,7 +159,7 @@ No new domain entities — this is a process-lifecycle/shutdown-sequencing fix.
 
 ## 10. See Also
 
-- [[constitution]] — project principles (not yet created for this project)
+- [[constitution]] — project principles
 - [[MOC-specs]] — all specifications
 - PR #270 (commit ec67fa4) — added the signal handling this bug affects, closed #241
 - Issue #241 — original "no SIGINT/SIGTERM handling" issue

--- a/specs/testing/001-e2e-rust-analyzer-testing/spec.md
+++ b/specs/testing/001-e2e-rust-analyzer-testing/spec.md
@@ -236,7 +236,7 @@ Not a data-model feature — the relevant "entities" are test-harness constructs
 ## 10. See Also
 
 - [[plan|plan.md]] — architecture and rollout of this suite, adapted from the original Rev 2 design doc
-- [[constitution]] — project principles (not yet created for this project)
+- [[constitution]] — project principles
 - [[MOC-specs]] — all specifications
 - [[mcp/002-mcp-resources-diagnostics/spec|spec mcp/002]] — MCP resources design this suite's `sc_list_resources`/`sc_read_resource`/`sc_subscribe_unsubscribe_resource` sub-cases exercise
 - [[lsp/002-lsp317-missing-tools/spec|spec lsp/002]] — LSP 3.17 tools this suite's `sc_get_signature_help`/`sc_go_to_implementation`/`sc_go_to_type_definition`/`sc_get_inlay_hints` sub-cases exercise


### PR DESCRIPTION
## Summary

- Adds `specs/constitution.md`, documenting the project's non-negotiable principles (architecture, tech stack, testing, code style, security, performance, simplicity, git workflow), grounded in `.claude/CLAUDE.md`, `Cargo.toml`, and `.claude/rules/`. This resolves the dangling `[[constitution]]` wikilink referenced by every spec's `related:` frontmatter.
- Strips the now-false `(not yet created for this project)` parenthetical from the 10 specs that referenced `[[constitution]]` before it existed, and adds a `## Project Foundation` section to `specs/MOC-specs.md` per the SDD skill's own MOC template convention.
- Modernizes `specs/bridge/003-rwlock-translator/spec.md` and `specs/mcp/002-mcp-resources-diagnostics/spec.md` to the template used from spec `004` onward: YAML frontmatter (`aliases`/`tags`/`created`/`status`/`related`), an `[!info] Metadata` callout, numbered sections, and FR/NFR tables — converting existing content losslessly, without inventing new requirements, edge cases, or acceptance criteria the legacy specs never had. Both remain `status: draft` (verified against current code: `Arc<Mutex<Translator>>` and no MCP `resources/subscribe` capability are still in place, i.e. neither is implemented yet).
- `specs/lsp/002-lsp317-missing-tools/spec.md` — originally named in #370's scope — was already modernized on `main` by `e4e75ba` (#372, closing #369), so it is untouched here; #370's remaining scope was just `bridge/003` and `mcp/002`.

Closes #371
Closes #370

## Test plan

- [x] All new/modified YAML frontmatter validated with `fy parse -q`
- [x] `grep -rn "\[\[constitution\]\]" specs/` confirms all wikilinks now resolve to `specs/constitution.md`
- [x] `grep -rln "not yet created for this project" specs/` returns 0 hits
- [x] Verified `constitution.md` claims against current code where cited (crate layout, `translator/` submodule split, `deny(unsafe_code)`, dependency versions in `Cargo.toml`)
- [x] Verified `bridge/003`/`mcp/002` status remains accurate against current code (still unimplemented)
- No source code changed — no `cargo build`/`clippy`/`nextest`/`doc` run required