### PR TITLE
feat(mcp): add structured tool output for 4 high-value tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `specs/constitution.md` documenting project-wide principles for the SDD spec package; resolves the `[[constitution]]` wikilink dangling across all specs. (#394)
 - Added end-to-end and TOML parse-error test coverage for `workspace.max_documents`/`max_file_size` resource-limit config. (#376)
 - `[mcp].tool_prefix` config option: prefixes every MCP tool name with `{tool_prefix}_`, letting a client tell apart tools from multiple concurrently running mcpls bridges. (#377)
+- Structured tool output (`outputSchema` + `structuredContent`) for `get_diagnostics`, `get_definition`, `get_references`, and `get_document_symbols`. (#PR_NUMBER)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `specs/constitution.md` documenting project-wide principles for the SDD spec package; resolves the `[[constitution]]` wikilink dangling across all specs. (#394)
 - Added end-to-end and TOML parse-error test coverage for `workspace.max_documents`/`max_file_size` resource-limit config. (#376)
 - `[mcp].tool_prefix` config option: prefixes every MCP tool name with `{tool_prefix}_`, letting a client tell apart tools from multiple concurrently running mcpls bridges. (#377)
-- Structured tool output (`outputSchema` + `structuredContent`) for `get_diagnostics`, `get_definition`, `get_references`, and `get_document_symbols`. (#PR_NUMBER)
+- Structured tool output (`outputSchema` + `structuredContent`) for `get_diagnostics`, `get_definition`, `get_references`, and `get_document_symbols`. (#397)
 
 ### Changed
 

--- a/crates/mcpls-core/src/bridge/translator/dto.rs
+++ b/crates/mcpls-core/src/bridge/translator/dto.rs
@@ -1,10 +1,11 @@
 //! Public MCP-facing result/data-transfer types returned by the tool-call
 //! handlers in the sibling domain modules.
 
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 /// Position in a document (1-based for MCP).
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 pub struct Position2D {
     /// Line number (1-based).
     pub line: u32,
@@ -29,7 +30,7 @@ pub struct Position {
 }
 
 /// Range in a document (1-based for MCP).
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 pub struct Range {
     /// Start position.
     pub start: Position2D,
@@ -38,7 +39,7 @@ pub struct Range {
 }
 
 /// Location in a document.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct Location {
     /// URI of the document.
     pub uri: String,
@@ -56,21 +57,21 @@ pub struct HoverResult {
 }
 
 /// Result of a definition request.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct DefinitionResult {
     /// Locations of the definition.
     pub locations: Vec<Location>,
 }
 
 /// Result of a references request.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct ReferencesResult {
     /// Locations of all references.
     pub locations: Vec<Location>,
 }
 
 /// Diagnostic severity.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "lowercase")]
 pub enum DiagnosticSeverity {
     /// Error diagnostic.
@@ -84,7 +85,7 @@ pub enum DiagnosticSeverity {
 }
 
 /// A single diagnostic.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 pub struct Diagnostic {
     /// Range where the diagnostic applies.
     pub range: Range,
@@ -97,7 +98,7 @@ pub struct Diagnostic {
 }
 
 /// Result of a diagnostics request.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct DiagnosticsResult {
     /// List of diagnostics for the document.
     pub diagnostics: Vec<Diagnostic>,
@@ -149,7 +150,7 @@ pub struct CompletionsResult {
 }
 
 /// A document symbol.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct Symbol {
     /// Name of the symbol.
     pub name: String,
@@ -165,7 +166,7 @@ pub struct Symbol {
 }
 
 /// Result of a document symbols request.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct DocumentSymbolsResult {
     /// List of symbols in the document.
     pub symbols: Vec<Symbol>,

--- a/crates/mcpls-core/src/mcp/server.rs
+++ b/crates/mcpls-core/src/mcp/server.rs
@@ -8,7 +8,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use rmcp::handler::server::router::tool::ToolRouter;
-use rmcp::handler::server::wrapper::Parameters;
+use rmcp::handler::server::wrapper::{Json, Parameters};
 use rmcp::model::{
     Implementation, ListResourcesResult, ReadResourceRequestParams, ReadResourceResponse,
     ReadResourceResult, Resource, ResourceContents, ResourceUpdatedNotificationParam,
@@ -16,6 +16,8 @@ use rmcp::model::{
     UnsubscribeRequestParams,
 };
 use rmcp::{ErrorData as McpError, RoleServer, ServerHandler, tool, tool_handler, tool_router};
+use schemars::JsonSchema;
+use serde::Serialize;
 use tokio::sync::Mutex;
 
 use super::handlers::BridgeContext;
@@ -27,8 +29,9 @@ use super::tools::{
 };
 use crate::bridge::resources::{make_uri, parse_uri};
 use crate::bridge::{
-    DiagnosticInfo, DiagnosticsResult, NotificationCache, Position, PositionEncoding,
-    ResourceSubscriptions, Translator, validate_path_against_roots,
+    DefinitionResult, DiagnosticInfo, DiagnosticsResult, DocumentSymbolsResult, NotificationCache,
+    Position, PositionEncoding, ReferencesResult, ResourceSubscriptions, Translator,
+    validate_path_against_roots,
 };
 use crate::config::{McpConfig, ToolPrefix};
 
@@ -140,6 +143,21 @@ fn to_tool_result<T: serde::Serialize>(
     match result {
         Ok(value) => serde_json::to_string(&value)
             .map_err(|e| McpError::internal_error(format!("Serialization error: {e}"), None)),
+        Err(e) => Err(McpError::internal_error(e.to_string(), None)),
+    }
+}
+
+/// Map a bridge-layer result to a structured MCP tool response (`structuredContent` plus the
+/// legacy `content` text block, per the MCP spec's backwards-compat shape).
+///
+/// The handler's own return type -- not this helper's -- is what the `#[tool]` macro reads to
+/// derive `outputSchema`; it must spell `Result<Json<T>, McpError>` literally (no alias) for the
+/// macro to detect it. See `Json<T>`'s `IntoCallToolResult` impl, which this helper relies on.
+fn to_structured_tool_result<T: Serialize + JsonSchema>(
+    result: crate::error::Result<T>,
+) -> Result<Json<T>, McpError> {
+    match result {
+        Ok(value) => Ok(Json(value)),
         Err(e) => Err(McpError::internal_error(e.to_string(), None)),
     }
 }
@@ -381,8 +399,8 @@ impl McplsServer {
             line,
             character,
         }): Parameters<PositionParams>,
-    ) -> Result<String, McpError> {
-        to_tool_result(
+    ) -> Result<Json<DefinitionResult>, McpError> {
+        to_structured_tool_result(
             self.context
                 .translator
                 .handle_definition(file_path, Position { line, character })
@@ -406,8 +424,8 @@ impl McplsServer {
                 },
             include_declaration,
         }): Parameters<ReferencesParams>,
-    ) -> Result<String, McpError> {
-        to_tool_result(
+    ) -> Result<Json<ReferencesResult>, McpError> {
+        to_structured_tool_result(
             self.context
                 .translator
                 .handle_references(file_path, Position { line, character }, include_declaration)
@@ -423,11 +441,11 @@ impl McplsServer {
     async fn get_diagnostics(
         &self,
         Parameters(DiagnosticsParams { file_path }): Parameters<DiagnosticsParams>,
-    ) -> Result<String, McpError> {
+    ) -> Result<Json<DiagnosticsResult>, McpError> {
         // Merging push-model (flycheck/clippy) diagnostics into the pull
         // result, including the pull-error-but-cache-has-data fallback, is
         // handled inside handle_diagnostics itself -- see its doc comment.
-        to_tool_result(
+        to_structured_tool_result(
             self.context
                 .translator
                 .handle_diagnostics(file_path, &self.context.notification_cache)
@@ -495,8 +513,8 @@ impl McplsServer {
     async fn get_document_symbols(
         &self,
         Parameters(DocumentSymbolsParams { file_path }): Parameters<DocumentSymbolsParams>,
-    ) -> Result<String, McpError> {
-        to_tool_result(
+    ) -> Result<Json<DocumentSymbolsResult>, McpError> {
+        to_structured_tool_result(
             self.context
                 .translator
                 .handle_document_symbols(file_path)
@@ -2510,6 +2528,34 @@ sleep 0.3
         );
     }
 
+    /// Structured output (`outputSchema`) is advertised for exactly the tools migrated to
+    /// `Result<Json<T>, McpError>` handler signatures, and only those. Driven off a literal
+    /// expected-name set (not derived from the router) so both a future migration and an
+    /// accidental scope change fail loudly here instead of only showing up as an opaque diff in
+    /// `test_tool_surface_matches_golden_snapshot`.
+    #[test]
+    fn test_output_schema_present_only_for_structured_tools() {
+        const STRUCTURED_TOOLS: &[&str] = &[
+            "get_diagnostics",
+            "get_definition",
+            "get_references",
+            "get_document_symbols",
+        ];
+
+        let tools = McplsServer::build_tool_router(None).list_all();
+        assert!(!tools.is_empty(), "no tools registered");
+
+        for tool in &tools {
+            let expects_schema = STRUCTURED_TOOLS.contains(&tool.name.as_ref());
+            assert_eq!(
+                tool.output_schema.is_some(),
+                expects_schema,
+                "tool `{}`: expected output_schema.is_some() == {expects_schema}",
+                tool.name
+            );
+        }
+    }
+
     // ------------------------------------------------------------------
     // tool_prefix tests
     // ------------------------------------------------------------------
@@ -2553,8 +2599,9 @@ sleep 0.3
     }
 
     /// A configured prefix rewrites only `name` -- every other field
-    /// (description, title, annotations, input schema) stays identical to
-    /// the unprefixed golden snapshot, and no route is gained or lost.
+    /// (description, title, annotations, input schema, output schema) stays
+    /// identical to the unprefixed golden snapshot, and no route is gained
+    /// or lost.
     #[test]
     fn test_build_tool_router_with_prefix_renames_only_name() {
         let prefix: ToolPrefix = "optics".parse().unwrap();
@@ -2568,6 +2615,7 @@ sleep 0.3
             assert_eq!(after.title, before.title);
             assert_eq!(after.annotations, before.annotations);
             assert_eq!(after.input_schema, before.input_schema);
+            assert_eq!(after.output_schema, before.output_schema);
         }
     }
 

--- a/crates/mcpls-core/src/mcp/tool_surface.json
+++ b/crates/mcpls-core/src/mcp/tool_surface.json
@@ -194,6 +194,82 @@
       ],
       "type": "object"
     },
+    "outputSchema": {
+      "$defs": {
+        "Location": {
+          "description": "Location in a document.",
+          "properties": {
+            "range": {
+              "$ref": "#/$defs/Range",
+              "description": "Range within the document."
+            },
+            "uri": {
+              "description": "URI of the document.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "uri",
+            "range"
+          ],
+          "type": "object"
+        },
+        "Position2D": {
+          "description": "Position in a document (1-based for MCP).",
+          "properties": {
+            "character": {
+              "description": "Character offset (1-based).",
+              "format": "uint32",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "line": {
+              "description": "Line number (1-based).",
+              "format": "uint32",
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          "required": [
+            "line",
+            "character"
+          ],
+          "type": "object"
+        },
+        "Range": {
+          "description": "Range in a document (1-based for MCP).",
+          "properties": {
+            "end": {
+              "$ref": "#/$defs/Position2D",
+              "description": "End position."
+            },
+            "start": {
+              "$ref": "#/$defs/Position2D",
+              "description": "Start position."
+            }
+          },
+          "required": [
+            "start",
+            "end"
+          ],
+          "type": "object"
+        }
+      },
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "properties": {
+        "locations": {
+          "description": "Locations of the definition.",
+          "items": {
+            "$ref": "#/$defs/Location"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "locations"
+      ],
+      "type": "object"
+    },
     "annotations": {
       "title": "Go to Definition",
       "readOnlyHint": true,
@@ -218,6 +294,119 @@
       ],
       "type": "object"
     },
+    "outputSchema": {
+      "$defs": {
+        "Diagnostic": {
+          "description": "A single diagnostic.",
+          "properties": {
+            "code": {
+              "description": "Optional diagnostic code.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "message": {
+              "description": "Diagnostic message.",
+              "type": "string"
+            },
+            "range": {
+              "$ref": "#/$defs/Range",
+              "description": "Range where the diagnostic applies."
+            },
+            "severity": {
+              "$ref": "#/$defs/DiagnosticSeverity",
+              "description": "Severity of the diagnostic."
+            }
+          },
+          "required": [
+            "range",
+            "severity",
+            "message"
+          ],
+          "type": "object"
+        },
+        "DiagnosticSeverity": {
+          "description": "Diagnostic severity.",
+          "oneOf": [
+            {
+              "const": "error",
+              "description": "Error diagnostic.",
+              "type": "string"
+            },
+            {
+              "const": "warning",
+              "description": "Warning diagnostic.",
+              "type": "string"
+            },
+            {
+              "const": "information",
+              "description": "Informational diagnostic.",
+              "type": "string"
+            },
+            {
+              "const": "hint",
+              "description": "Hint diagnostic.",
+              "type": "string"
+            }
+          ]
+        },
+        "Position2D": {
+          "description": "Position in a document (1-based for MCP).",
+          "properties": {
+            "character": {
+              "description": "Character offset (1-based).",
+              "format": "uint32",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "line": {
+              "description": "Line number (1-based).",
+              "format": "uint32",
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          "required": [
+            "line",
+            "character"
+          ],
+          "type": "object"
+        },
+        "Range": {
+          "description": "Range in a document (1-based for MCP).",
+          "properties": {
+            "end": {
+              "$ref": "#/$defs/Position2D",
+              "description": "End position."
+            },
+            "start": {
+              "$ref": "#/$defs/Position2D",
+              "description": "Start position."
+            }
+          },
+          "required": [
+            "start",
+            "end"
+          ],
+          "type": "object"
+        }
+      },
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "properties": {
+        "diagnostics": {
+          "description": "List of diagnostics for the document.",
+          "items": {
+            "$ref": "#/$defs/Diagnostic"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "diagnostics"
+      ],
+      "type": "object"
+    },
     "annotations": {
       "title": "Diagnostics",
       "readOnlyHint": true,
@@ -239,6 +428,102 @@
       },
       "required": [
         "file_path"
+      ],
+      "type": "object"
+    },
+    "outputSchema": {
+      "$defs": {
+        "Position2D": {
+          "description": "Position in a document (1-based for MCP).",
+          "properties": {
+            "character": {
+              "description": "Character offset (1-based).",
+              "format": "uint32",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "line": {
+              "description": "Line number (1-based).",
+              "format": "uint32",
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          "required": [
+            "line",
+            "character"
+          ],
+          "type": "object"
+        },
+        "Range": {
+          "description": "Range in a document (1-based for MCP).",
+          "properties": {
+            "end": {
+              "$ref": "#/$defs/Position2D",
+              "description": "End position."
+            },
+            "start": {
+              "$ref": "#/$defs/Position2D",
+              "description": "Start position."
+            }
+          },
+          "required": [
+            "start",
+            "end"
+          ],
+          "type": "object"
+        },
+        "Symbol": {
+          "description": "A document symbol.",
+          "properties": {
+            "children": {
+              "description": "Child symbols.",
+              "items": {
+                "$ref": "#/$defs/Symbol"
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "kind": {
+              "description": "Kind of symbol.",
+              "type": "string"
+            },
+            "name": {
+              "description": "Name of the symbol.",
+              "type": "string"
+            },
+            "range": {
+              "$ref": "#/$defs/Range",
+              "description": "Range of the symbol."
+            },
+            "selection_range": {
+              "$ref": "#/$defs/Range",
+              "description": "Selection range (identifier location)."
+            }
+          },
+          "required": [
+            "name",
+            "kind",
+            "range",
+            "selection_range"
+          ],
+          "type": "object"
+        }
+      },
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "properties": {
+        "symbols": {
+          "description": "List of symbols in the document.",
+          "items": {
+            "$ref": "#/$defs/Symbol"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "symbols"
       ],
       "type": "object"
     },
@@ -418,6 +703,82 @@
         "file_path",
         "line",
         "character"
+      ],
+      "type": "object"
+    },
+    "outputSchema": {
+      "$defs": {
+        "Location": {
+          "description": "Location in a document.",
+          "properties": {
+            "range": {
+              "$ref": "#/$defs/Range",
+              "description": "Range within the document."
+            },
+            "uri": {
+              "description": "URI of the document.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "uri",
+            "range"
+          ],
+          "type": "object"
+        },
+        "Position2D": {
+          "description": "Position in a document (1-based for MCP).",
+          "properties": {
+            "character": {
+              "description": "Character offset (1-based).",
+              "format": "uint32",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "line": {
+              "description": "Line number (1-based).",
+              "format": "uint32",
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          "required": [
+            "line",
+            "character"
+          ],
+          "type": "object"
+        },
+        "Range": {
+          "description": "Range in a document (1-based for MCP).",
+          "properties": {
+            "end": {
+              "$ref": "#/$defs/Position2D",
+              "description": "End position."
+            },
+            "start": {
+              "$ref": "#/$defs/Position2D",
+              "description": "Start position."
+            }
+          },
+          "required": [
+            "start",
+            "end"
+          ],
+          "type": "object"
+        }
+      },
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "properties": {
+        "locations": {
+          "description": "Locations of all references.",
+          "items": {
+            "$ref": "#/$defs/Location"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "locations"
       ],
       "type": "object"
     },


### PR DESCRIPTION
## Summary

- Adds MCP 2025-11-25 structured tool output (`outputSchema` + `structuredContent`) to `get_diagnostics`, `get_definition`, `get_references`, and `get_document_symbols`.
- These 4 handlers now return `Result<Json<T>, McpError>` instead of `Result<String, McpError>`. The rmcp `#[tool]` macro derives `outputSchema` from the literal return type; `CallToolResult::structured` populates both the existing text `content` block and the new `structuredContent` field from the same DTO, so the text response stays backwards compatible.
- Adds `schemars::JsonSchema` derives to the 10 DTO types in the transitive closure of these 4 tools' results (`bridge/translator/dto.rs`).
- Adds a shared `to_structured_tool_result` helper alongside the existing `to_tool_result`.
- Adds a test asserting `outputSchema` is present for exactly these 4 tools and absent for the other 16, driven off a literal expected-name set so a future scope change fails loudly rather than silently.
- Regenerates `mcp/tool_surface.json` (purely additive: 4 new `outputSchema` blocks).

## Design notes

This PR originally also covered issue #119 (MCP tasks/call for long-running requests), grouped with #137 for subsystem cohesion (both touch `crates/mcpls-core/src/mcp/`). Architecture review found #119's design non-conformant with SEP-2663 when enabled (rmcp 3.2.0 has no per-call task opt-in, so the server can't distinguish a client that requested async execution from one that didn't) and providing no value when disabled by default. #119 was descoped from this PR; it stays open and will get a tracking spec describing why implementation is deferred until rmcp adds per-call opt-in support or a latency-triggered hybrid dispatch mode is designed.

## Tradeoffs

- Response payload for these 4 tools grows roughly 1.9x (measured), since `CallToolResult::structured` emits the same data as both text and structured JSON. This is the MCP spec's intended backwards-compat shape. It lands on two of mcpls's highest-volume tools (`get_references`, `get_diagnostics`); worth watching for context-window cost in AI-agent use cases. No mitigation implemented — MCP has no capability negotiation for a client to signal it only wants structured output.
- `get_document_symbols`'s outputSchema (and the other 3, due to shared types like `Range`/`Location`) contains `$defs`/`$ref` due to schemars' handling of the recursive `Symbol` type and shared nested types. Valid, self-contained draft-2020-12 JSON Schema.
- The remaining 16 tools' outputSchema support is left as a follow-up (issue to be filed) to keep this PR's wire-contract change bounded.

## Test plan

- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features --workspace -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --lib --bins` (796 passed, 1 skipped)
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`
- [x] New test verifies `outputSchema` presence/absence across all 20 registered tools by name
- [x] Golden snapshot test regenerated and passing with the 4 new `outputSchema` blocks

Closes #137