### PR TITLE
fix: honor CARGO_TARGET_DIR in e2e binary lookup; document HTTP transport auth gap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- README now documents that the HTTP transport (`--listen`) has no built-in authentication and requires a reverse proxy for non-loopback binding. (#391)
+- README now documents that the HTTP transport (`--listen`) has no built-in authentication and requires a reverse proxy for non-loopback binding. (#400)
 - Modernized `specs/bridge/003-rwlock-translator` and `specs/mcp/002-mcp-resources-diagnostics` to the current spec template (YAML frontmatter, numbered sections, FR/NFR tables). (#394)
 - **`McpConfig`** — Breaking change: gained a `tool_prefix` field; exhaustive struct-literal construction of `McpConfig` no longer compiles. (#377)
 - Relocated the SDD spec package from `.local/specs/` to repo-root `specs/`, reorganized into functional blocks (config/lsp/mcp/bridge/runtime/testing) with block-scoped numbering, and added retroactive specs for previously undocumented core subsystems (position encoding, config discovery, LSP lifecycle, document tracker sync, MCP tool routing). (#368)
@@ -44,7 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- E2E test harness (`McpClient::spawn_with_args`) now honors `CARGO_TARGET_DIR`/`CARGO_BUILD_TARGET_DIR` when locating the built `mcpls` binary, instead of hardcoding `target/debug/mcpls`; spawn failures now report the resolved path. (#393)
+- E2E test harness (`McpClient::spawn_with_args`) now honors `CARGO_TARGET_DIR`/`CARGO_BUILD_TARGET_DIR` when locating the built `mcpls` binary, instead of hardcoding `target/debug/mcpls`; spawn failures now report the resolved path. (#400)
 - LSP `-32801` (`ContentModified`) error responses are now retried automatically for read-only/idempotent tool calls (hover, references, diagnostics, etc.), using the same attempt budget and backoff already applied to `-32802` (`ServerCancelled`); mutating requests (rename, formatting, code actions) are excluded. Also corrected a doc comment that mislabeled `-32802` as "content modified". (#390)
 - `NotificationCache` now derives the diagnostics cache fair-share budget automatically from the number of publishing servers when `set_diagnostics_route_count` is never called, instead of silently defaulting to an unpartitioned budget. (#379)
 - Cache eviction now prefers evicting empty ("file is clean") diagnostics entries over real ones, including across servers sharing the same eviction victim, so a stream of clean-file notifications can no longer displace actual diagnostics from the cache. (#379)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- README now documents that the HTTP transport (`--listen`) has no built-in authentication and requires a reverse proxy for non-loopback binding. (#391)
 - Modernized `specs/bridge/003-rwlock-translator` and `specs/mcp/002-mcp-resources-diagnostics` to the current spec template (YAML frontmatter, numbered sections, FR/NFR tables). (#394)
 - **`McpConfig`** — Breaking change: gained a `tool_prefix` field; exhaustive struct-literal construction of `McpConfig` no longer compiles. (#377)
 - Relocated the SDD spec package from `.local/specs/` to repo-root `specs/`, reorganized into functional blocks (config/lsp/mcp/bridge/runtime/testing) with block-scoped numbering, and added retroactive specs for previously undocumented core subsystems (position encoding, config discovery, LSP lifecycle, document tracker sync, MCP tool routing). (#368)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- E2E test harness (`McpClient::spawn_with_args`) now honors `CARGO_TARGET_DIR`/`CARGO_BUILD_TARGET_DIR` when locating the built `mcpls` binary, instead of hardcoding `target/debug/mcpls`; spawn failures now report the resolved path. (#393)
 - LSP `-32801` (`ContentModified`) error responses are now retried automatically for read-only/idempotent tool calls (hover, references, diagnostics, etc.), using the same attempt budget and backoff already applied to `-32802` (`ServerCancelled`); mutating requests (rename, formatting, code actions) are excluded. Also corrected a doc comment that mislabeled `-32802` as "content modified". (#390)
 - `NotificationCache` now derives the diagnostics cache fair-share budget automatically from the number of publishing servers when `set_diagnostics_route_count` is never called, instead of silently defaulting to an unpartitioned budget. (#379)
 - Cache eviction now prefers evicting empty ("file is clean") diagnostics entries over real ones, including across servers sharing the same eviction victim, so a stream of clean-file notifications can no longer displace actual diagnostics from the cache. (#379)

--- a/README.md
+++ b/README.md
@@ -308,6 +308,31 @@ See [Configuration Reference](docs/user-guide/configuration.md) for all options.
 
 </details>
 
+<details>
+<summary><strong>HTTP Transport</strong></summary>
+
+By default, mcpls communicates over stdin/stdout. You can expose it as an HTTP server using the `--listen` flag:
+
+```bash
+mcpls --listen 127.0.0.1:8080
+```
+
+> [!WARNING]
+> mcpls performs **no authentication** on any transport, including HTTP. When binding to a non-loopback address (e.g., `0.0.0.0:8080`), you **must** place mcpls behind a reverse proxy that:
+> - Enforces authentication before forwarding requests
+> - Rewrites the `Host` header (rmcp's host validation only allows `localhost`, `127.0.0.1`, or `::1` by default)
+
+**Example (nginx):**
+```nginx
+location / {
+    auth_request /auth;
+    proxy_pass http://localhost:8080;
+    proxy_set_header Host localhost;
+}
+```
+
+</details>
+
 ## Supported Language Servers
 
 mcpls works with any LSP 3.17 compliant server. Battle-tested with:

--- a/crates/mcpls-core/tests/e2e/mcp_client.rs
+++ b/crates/mcpls-core/tests/e2e/mcp_client.rs
@@ -65,31 +65,45 @@ impl McpClient {
     /// - The mcpls binary cannot be found or spawned
     /// - stdin or stdout cannot be captured
     pub fn spawn_with_args(args: &[&str]) -> Result<Self> {
-        // Get binary path from cargo test environment
+        // Get binary path from cargo test environment.
         // CARGO_BIN_EXE_mcpls is only set for tests in the mcpls-cli crate.
         // For tests in mcpls-core, compute workspace root from CARGO_MANIFEST_DIR.
-        let binary_path = std::env::var("CARGO_BIN_EXE_mcpls")
-            .ok()
-            .or_else(|| {
+        // Path::join discards the base when the joined component is absolute, so
+        // an absolute CARGO_TARGET_DIR/CARGO_BUILD_TARGET_DIR is honored automatically.
+        // A *relative* value is resolved here against the workspace root rather than
+        // the original `cargo` invocation's working directory (unlike real cargo) —
+        // the invocation directory isn't recoverable at test runtime, so this is a
+        // best-effort approximation.
+        let target_dir = std::env::var_os("CARGO_TARGET_DIR")
+            .or_else(|| std::env::var_os("CARGO_BUILD_TARGET_DIR"))
+            .unwrap_or_else(|| "target".into());
+
+        let binary_path: std::path::PathBuf = std::env::var_os("CARGO_BIN_EXE_mcpls").map_or_else(
+            || {
                 let manifest_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
                 manifest_dir
                     .ancestors()
                     .nth(2) // mcpls-core -> crates -> workspace
-                    .map(|root| {
-                        root.join("target/debug/mcpls")
-                            .to_string_lossy()
-                            .into_owned()
-                    })
-            })
-            .unwrap_or_else(|| "target/debug/mcpls".to_string());
+                    .unwrap_or(manifest_dir)
+                    .join(&target_dir)
+                    .join("debug/mcpls")
+            },
+            std::path::PathBuf::from,
+        );
 
-        let mut process = Command::new(binary_path)
+        let mut process = Command::new(&binary_path)
             .args(args)
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::inherit())
             .spawn()
-            .context("failed to spawn mcpls binary")?;
+            .with_context(|| {
+                format!(
+                    "failed to spawn mcpls binary at {} \
+                     (set CARGO_TARGET_DIR or CARGO_BUILD_TARGET_DIR if the build used a non-default target dir)",
+                    binary_path.display()
+                )
+            })?;
 
         let stdin = process
             .stdin


### PR DESCRIPTION
## Summary

- Fixes #393: `McpClient::spawn_with_args` (e2e test harness) now honors `CARGO_TARGET_DIR` and `CARGO_BUILD_TARGET_DIR`, matching cargo's own precedence, instead of hardcoding `target/debug/mcpls`. Spawn failures now include the resolved path for diagnosability. A relative target-dir value is resolved against the workspace root here rather than the original cargo invocation CWD (documented as a known, deliberate limitation — that CWD is unrecoverable at test runtime).
- Fixes #391: README now documents that the HTTP transport (`--listen`, `transport-http` feature) has no built-in authentication and that binding to a non-loopback address requires a reverse proxy that authenticates requests and rewrites the Host header.

## Test plan

- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features --workspace -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --lib --bins` (799 passed, 1 skipped)
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`
- [x] Manually verified the ignored e2e suite spawns the binary correctly under `CARGO_TARGET_DIR` and `CARGO_BUILD_TARGET_DIR` independently, matching the baseline result with the default target dir
- [x] Verified the spawn-failure error message includes the resolved path

Closes #393
Closes #391
