### PR TITLE
fix(lsp): log retried transient errors at warn, not error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - E2E test harness (`McpClient::spawn_with_args`) now honors `CARGO_TARGET_DIR`/`CARGO_BUILD_TARGET_DIR` when locating the built `mcpls` binary, instead of hardcoding `target/debug/mcpls`; spawn failures now report the resolved path. (#400)
+- Retried transient LSP errors (`-32802` `ServerCancelled`, allowlisted `-32801` `ContentModified`) no longer log at `error!` before the retry succeeds, avoiding false-positive alerts in log-based monitoring; `error!` is now reserved for errors actually surfaced to the caller. (#392)
 - LSP `-32801` (`ContentModified`) error responses are now retried automatically for read-only/idempotent tool calls (hover, references, diagnostics, etc.), using the same attempt budget and backoff already applied to `-32802` (`ServerCancelled`); mutating requests (rename, formatting, code actions) are excluded. Also corrected a doc comment that mislabeled `-32802` as "content modified". (#390)
 - `NotificationCache` now derives the diagnostics cache fair-share budget automatically from the number of publishing servers when `set_diagnostics_route_count` is never called, instead of silently defaulting to an unpartitioned budget. (#379)
 - Cache eviction now prefers evicting empty ("file is clean") diagnostics entries over real ones, including across servers sharing the same eviction victim, so a stream of clean-file notifications can no longer displace actual diagnostics from the cache. (#379)

--- a/crates/mcpls-core/src/bridge/notifications.rs
+++ b/crates/mcpls-core/src/bridge/notifications.rs
@@ -1068,6 +1068,7 @@ mod tests {
     use lsp_types::{Position, Range};
 
     use super::*;
+    use crate::test_lsp::CapturedLogs;
 
     /// Every test in this module that doesn't exercise multi-server
     /// fairness routes through one implicit server, so `set_diagnostics_route_count`
@@ -1290,36 +1291,6 @@ mod tests {
         );
     }
 
-    /// Captures `tracing` events emitted while a closure runs, mirroring
-    /// `transport::tests::http_tests::CapturedMessages` -- there is no
-    /// shared `tracing_test`-style helper in this codebase to reuse.
-    #[derive(Clone, Default)]
-    struct CapturedMessages(std::sync::Arc<std::sync::Mutex<Vec<String>>>);
-
-    impl<S: tracing::Subscriber> tracing_subscriber::Layer<S> for CapturedMessages {
-        fn on_event(
-            &self,
-            event: &tracing::Event<'_>,
-            _ctx: tracing_subscriber::layer::Context<'_, S>,
-        ) {
-            struct MessageVisitor(String);
-            impl tracing::field::Visit for MessageVisitor {
-                fn record_debug(
-                    &mut self,
-                    field: &tracing::field::Field,
-                    value: &dyn std::fmt::Debug,
-                ) {
-                    if field.name() == "message" {
-                        self.0 = format!("{value:?}");
-                    }
-                }
-            }
-            let mut visitor = MessageVisitor(String::new());
-            event.record(&mut visitor);
-            self.0.lock().unwrap().push(visitor.0);
-        }
-    }
-
     /// #311 S7 / M7: truncating the diagnostics list must not be silent --
     /// a caller with no visibility into this cache would otherwise have no
     /// way to know a `get_cached_diagnostics` result is incomplete.
@@ -1333,13 +1304,13 @@ mod tests {
             .map(|i| minimal_diagnostic(format!("diagnostic {i}: {}", "x".repeat(250))))
             .collect();
 
-        let captured = CapturedMessages::default();
+        let captured = CapturedLogs::default();
         let subscriber = tracing_subscriber::registry().with(captured.clone());
         let guard = tracing::subscriber::set_default(subscriber);
         cache.store_diagnostics(&test_server(), &uri, Some(1), diagnostics);
         drop(guard);
 
-        let messages = captured.0.lock().unwrap().clone();
+        let messages = captured.messages();
         assert!(
             messages
                 .iter()
@@ -1362,13 +1333,13 @@ mod tests {
             "blob": "x".repeat(MAX_DIAGNOSTICS_ENTRY_BYTES + 1000),
         }));
 
-        let captured = CapturedMessages::default();
+        let captured = CapturedLogs::default();
         let subscriber = tracing_subscriber::registry().with(captured.clone());
         let guard = tracing::subscriber::set_default(subscriber);
         cache.store_diagnostics(&test_server(), &uri, Some(1), vec![diagnostic]);
         drop(guard);
 
-        let messages = captured.0.lock().unwrap().clone();
+        let messages = captured.messages();
         assert!(
             messages.iter().any(|m| m.contains("code-action")),
             "expected a warning noting the code-action quick-fix impact, got: {messages:?}"

--- a/crates/mcpls-core/src/lib.rs
+++ b/crates/mcpls-core/src/lib.rs
@@ -1929,11 +1929,13 @@ mod tests {
         async fn test_await_lsp_init_handle_logs_panic() {
             use tracing_subscriber::layer::SubscriberExt as _;
 
+            use crate::test_lsp::CapturedLogs;
+
             let handle = tokio::spawn(async {
                 panic!("simulated background LSP init panic");
             });
 
-            let captured = CapturedMessages::default();
+            let captured = CapturedLogs::default();
             let subscriber = tracing_subscriber::registry().with(captured.clone());
             let guard = tracing::subscriber::set_default(subscriber);
 
@@ -1941,44 +1943,13 @@ mod tests {
 
             drop(guard);
 
-            let messages = captured.0.lock().unwrap().clone();
+            let messages = captured.messages();
             assert!(
                 messages
                     .iter()
                     .any(|m| m.contains("Background LSP initialization task failed")),
                 "expected an error! log for the panicking background init task, got: {messages:?}"
             );
-        }
-
-        /// Captures `tracing` events emitted while a closure runs. Mirrors
-        /// `transport::tests::http_tests::CapturedMessages` — duplicated
-        /// rather than shared since this crate has no common test-support
-        /// module and the two live in separate, non-`pub` test submodules.
-        #[derive(Clone, Default)]
-        struct CapturedMessages(Arc<std::sync::Mutex<Vec<String>>>);
-
-        impl<S: tracing::Subscriber> tracing_subscriber::Layer<S> for CapturedMessages {
-            fn on_event(
-                &self,
-                event: &tracing::Event<'_>,
-                _ctx: tracing_subscriber::layer::Context<'_, S>,
-            ) {
-                struct MessageVisitor(String);
-                impl tracing::field::Visit for MessageVisitor {
-                    fn record_debug(
-                        &mut self,
-                        field: &tracing::field::Field,
-                        value: &dyn std::fmt::Debug,
-                    ) {
-                        if field.name() == "message" {
-                            self.0 = format!("{value:?}");
-                        }
-                    }
-                }
-                let mut visitor = MessageVisitor(String::new());
-                event.record(&mut visitor);
-                self.0.lock().unwrap().push(visitor.0);
-            }
         }
     }
 

--- a/crates/mcpls-core/src/lsp/client.rs
+++ b/crates/mcpls-core/src/lsp/client.rs
@@ -73,8 +73,10 @@ pub const CONTENT_MODIFIED_RETRY_METHODS: &[&str] = &[
 
 /// Byte-length threshold for truncating an LSP error message before logging it.
 ///
-/// Kept short since this feeds a single `tracing::error!` log line, not the
-/// MCP caller -- see `MAX_ERROR_MESSAGE_CALLER_BYTES` for that budget.
+/// Kept short since this feeds a single log line in [`LspClient::request`]
+/// -- `warn!` while a transient error is being retried, `error!` once it is
+/// actually surfaced to the caller -- not the MCP caller itself; see
+/// `MAX_ERROR_MESSAGE_CALLER_BYTES` for that budget.
 const MAX_ERROR_MESSAGE_LOG_BYTES: usize = 200;
 
 /// Byte-length threshold for the LSP error message forwarded to the MCP
@@ -352,6 +354,13 @@ impl LspClient {
     /// starting at 500 ms. Both codes share the same attempt budget: a
     /// request that hits -32801 then -32802 does not get 8 attempts, only 4.
     ///
+    /// This method owns the severity of LSP error-response logging (#392):
+    /// a transient error about to be retried logs at `warn!`, while `error!`
+    /// is reserved for an error actually surfaced to the caller -- retry
+    /// exhaustion or a non-retryable code/method combination. This is
+    /// deliberately not decided in `message_loop_inner`, which parses the
+    /// response before knowing whether a retry will follow.
+    ///
     /// # Type Parameters
     ///
     /// * `P` - The type of the request parameters (must be serializable)
@@ -426,28 +435,57 @@ impl LspClient {
                 }
                 Err(Error::LspServerError {
                     code,
-                    ref message,
-                    ref data,
+                    message,
+                    data,
                 }) if (code == SERVER_CANCELLED_CODE
                     || (LspErrorCodes::from(code) == LspErrorCodes::ContentModified
                         && CONTENT_MODIFIED_RETRY_METHODS.contains(&method)))
                     && Self::should_retrigger(data.as_ref()) =>
                 {
                     if attempt == SERVER_CANCELLED_MAX_RETRIES {
+                        // Same "LSP error response: ..." prefix as the
+                        // non-retryable branch below -- a log-grep alert on
+                        // that prefix must catch every error actually
+                        // surfaced to the caller, retry exhaustion included.
+                        error!(
+                            "LSP error response: {} (code {}) on '{}' (id={:?}), retries exhausted",
+                            Self::truncate_error_message_for_log(&message),
+                            code,
+                            method,
+                            id
+                        );
                         return Err(Error::LspServerError {
                             code,
-                            message: message.clone(),
-                            data: data.clone(),
+                            message,
+                            data,
                         });
                     }
                     warn!(
-                        "{:?} ({}) on '{}', will retry: {}",
-                        LspErrorCodes::from(code),
+                        "LSP error response: {} (code {}) on '{}' (id={:?}), will retry",
+                        Self::truncate_error_message_for_log(&message),
                         code,
                         method,
-                        message
+                        id
                     );
                     // continue loop for next attempt
+                }
+                Err(Error::LspServerError {
+                    code,
+                    message,
+                    data,
+                }) => {
+                    error!(
+                        "LSP error response: {} (code {}) on '{}' (id={:?})",
+                        Self::truncate_error_message_for_log(&message),
+                        code,
+                        method,
+                        id
+                    );
+                    return Err(Error::LspServerError {
+                        code,
+                        message,
+                        data,
+                    });
                 }
                 Err(e) => return Err(e),
             }
@@ -647,8 +685,21 @@ impl LspClient {
 
                             if let Some(sender) = sender {
                                 if let Some(error) = response.error {
-                                    let log_message = Self::truncate_error_message_for_log(&error.message);
-                                    error!("LSP error response: {} (code {})", log_message, error.code);
+                                    // Deliberately not logged at `error!` here: this fires
+                                    // for every attempt, before `LspClient::request`'s retry
+                                    // loop knows whether the error is transient and about to
+                                    // be retried (-32802, or -32801 for an allowlisted
+                                    // method). Logging unconditionally at this point would
+                                    // emit a spurious ERROR line for errors that are retried
+                                    // and succeed. `request` logs at `warn!` on retry and
+                                    // `error!` once the error is actually surfaced to the
+                                    // caller (retry exhaustion or a non-retryable error);
+                                    // the response id is already traced above.
+                                    trace!(
+                                        "LSP error response: {} (code {})",
+                                        Self::truncate_error_message_for_log(&error.message),
+                                        error.code
+                                    );
                                     // Truncated separately from the log line, to the larger
                                     // MAX_ERROR_MESSAGE_CALLER_BYTES -- the raw message is
                                     // unbounded and attacker-influenceable (#313), but a
@@ -1189,7 +1240,7 @@ mod tests {
 
         use super::*;
         use crate::test_lsp::{
-            fake_lsp_client, read_framed_message, write_error_response,
+            CapturedLogs, fake_lsp_client, read_framed_message, write_error_response,
             write_response as write_success_response,
         };
 
@@ -1226,9 +1277,20 @@ mod tests {
         // Not `start_paused`: the retry loop's real backoff sleeps
         // interleave with real async I/O on the duplex pipes below, and
         // paused virtual time does not reliably auto-advance across both.
+        //
+        // Also captures tracing output (#392): retry exhaustion is the one
+        // scenario where every attempt but the last logs `warn!` and only
+        // the last logs `error!`, so this doubles as that regression test
+        // rather than duplicating the same ~3.5s wire choreography in a
+        // second test just to assert on log severity.
         #[tokio::test]
         async fn test_retry_exhaustion_returns_original_server_cancelled_error() {
+            use tracing_subscriber::layer::SubscriberExt as _;
+
             let (client, mut server) = fake_lsp_client();
+            let captured = CapturedLogs::default();
+            let subscriber = tracing_subscriber::registry().with(captured.clone());
+            let guard = tracing::subscriber::set_default(subscriber);
 
             let request_task = tokio::spawn(async move {
                 client
@@ -1274,6 +1336,33 @@ mod tests {
                 }
                 other => panic!("expected exhausted ServerCancelled error, got {other:?}"),
             }
+
+            drop(guard);
+            let logs = captured.entries();
+            assert_eq!(
+                logs.iter()
+                    .filter(|(level, _)| *level == tracing::Level::ERROR)
+                    .count(),
+                1,
+                "exactly the final exhausted attempt must log at ERROR, got: {logs:?}"
+            );
+            assert!(
+                logs.iter()
+                    .any(|(level, msg)| *level == tracing::Level::ERROR
+                        && msg.contains("LSP error response")
+                        && msg.contains("retries exhausted")),
+                "expected an ERROR log sharing the 'LSP error response' prefix and naming \
+                 retry exhaustion, got: {logs:?}"
+            );
+            assert_eq!(
+                logs.iter()
+                    .filter(
+                        |(level, msg)| *level == tracing::Level::WARN && msg.contains("will retry")
+                    )
+                    .count(),
+                usize::try_from(SERVER_CANCELLED_MAX_RETRIES).unwrap(),
+                "every attempt before the last must log a WARN 'will retry' line, got: {logs:?}"
+            );
         }
 
         #[tokio::test]
@@ -1657,6 +1746,117 @@ mod tests {
                 }
                 other => panic!("expected untruncated LspServerError, got {other:?}"),
             }
+        }
+
+        /// #392: a `-32802`/`-32801` error that gets retried and then
+        /// succeeds must not log at `error!` -- only a `warn!` "will retry"
+        /// line -- so log-based monitoring does not false-positive on a
+        /// transient error the retry loop silently recovers from.
+        #[tokio::test]
+        async fn test_retried_error_that_recovers_does_not_log_error_level() {
+            use tracing_subscriber::layer::SubscriberExt as _;
+
+            let (client, mut server) = fake_lsp_client();
+            let captured = CapturedLogs::default();
+            let subscriber = tracing_subscriber::registry().with(captured.clone());
+            let guard = tracing::subscriber::set_default(subscriber);
+
+            let request_task = tokio::spawn(async move {
+                client
+                    .request::<_, Value>(
+                        "textDocument/hover",
+                        serde_json::json!({}),
+                        Duration::from_secs(30),
+                    )
+                    .await
+            });
+
+            let mut reader = BufReader::new(&mut server.write_stdout);
+
+            let first = read_framed_message(&mut reader).await;
+            write_retryable_error_response(
+                &mut server.read_half_stdin,
+                &first["id"].clone(),
+                SERVER_CANCELLED_CODE,
+                "server cancelled the request",
+                true,
+            )
+            .await;
+
+            let second = read_framed_message(&mut reader).await;
+            write_success_response(
+                &mut server.read_half_stdin,
+                &second["id"].clone(),
+                serde_json::json!({ "contents": "resolved on retry" }),
+            )
+            .await;
+
+            let result = request_task.await.unwrap();
+            assert!(result.is_ok(), "expected retry to recover, got {result:?}");
+
+            drop(guard);
+            let logs = captured.entries();
+            assert!(
+                !logs
+                    .iter()
+                    .any(|(level, _)| *level == tracing::Level::ERROR),
+                "a retried-and-recovered error must not log at ERROR, got: {logs:?}"
+            );
+            assert!(
+                logs.iter().any(
+                    |(level, msg)| *level == tracing::Level::WARN && msg.contains("will retry")
+                ),
+                "expected a WARN 'will retry' log line, got: {logs:?}"
+            );
+        }
+
+        /// #392: a `-32801` (`ContentModified`) error for a method outside
+        /// `CONTENT_MODIFIED_RETRY_METHODS` is never retried, so it must
+        /// still surface at `error!` on the very first attempt.
+        #[tokio::test]
+        async fn test_non_retryable_error_logs_error_level() {
+            use tracing_subscriber::layer::SubscriberExt as _;
+
+            let (client, mut server) = fake_lsp_client();
+            let captured = CapturedLogs::default();
+            let subscriber = tracing_subscriber::registry().with(captured.clone());
+            let guard = tracing::subscriber::set_default(subscriber);
+
+            let request_task = tokio::spawn(async move {
+                client
+                    .request::<_, Value>(
+                        "textDocument/rename",
+                        serde_json::json!({}),
+                        Duration::from_secs(30),
+                    )
+                    .await
+            });
+
+            let mut reader = BufReader::new(&mut server.write_stdout);
+            let request = read_framed_message(&mut reader).await;
+            let id = request["id"].clone();
+            write_retryable_error_response(
+                &mut server.read_half_stdin,
+                &id,
+                i32::from(LspErrorCodes::ContentModified),
+                "content modified",
+                true,
+            )
+            .await;
+
+            let result = request_task.await.unwrap();
+            assert!(result.is_err(), "expected a non-retryable error");
+
+            drop(guard);
+            let logs = captured.entries();
+            assert!(
+                logs.iter()
+                    .any(|(level, msg)| *level == tracing::Level::ERROR
+                        && msg.contains("LSP error response")
+                        && msg.contains("content modified")),
+                "a non-retryable error must still surface an ERROR log sharing the \
+                 'LSP error response' prefix, got: {logs:?}"
+            );
         }
     }
 }

--- a/crates/mcpls-core/src/test_lsp.rs
+++ b/crates/mcpls-core/src/test_lsp.rs
@@ -175,3 +175,56 @@ async fn write_framed(writer: &mut DuplexStream, message: &Value) {
     writer.write_all(content.as_bytes()).await.unwrap();
     writer.flush().await.unwrap();
 }
+
+/// Captures `(level, message)` pairs for `tracing` events emitted while a
+/// closure runs, as a `tracing_subscriber::Layer`.
+///
+/// Shared here rather than duplicated per-module: `transport.rs`, `lib.rs`
+/// and `bridge/notifications.rs` each used to carry their own
+/// message-only `CapturedMessages` copy. This is a strict superset (it
+/// also records the event's [`tracing::Level`], needed to assert that a
+/// log line is or is not at `error!` severity, not just that it contains
+/// certain text) so it replaces all of them.
+#[derive(Clone, Default)]
+pub struct CapturedLogs(std::sync::Arc<std::sync::Mutex<Vec<(tracing::Level, String)>>>);
+
+impl CapturedLogs {
+    /// Snapshot of everything captured so far, as `(level, message)` pairs.
+    pub fn entries(&self) -> Vec<(tracing::Level, String)> {
+        self.0.lock().unwrap().clone()
+    }
+
+    /// Snapshot of captured message text only, for callers that don't care
+    /// about severity.
+    pub fn messages(&self) -> Vec<String> {
+        self.0
+            .lock()
+            .unwrap()
+            .iter()
+            .map(|(_, message)| message.clone())
+            .collect()
+    }
+}
+
+impl<S: tracing::Subscriber> tracing_subscriber::Layer<S> for CapturedLogs {
+    fn on_event(
+        &self,
+        event: &tracing::Event<'_>,
+        _ctx: tracing_subscriber::layer::Context<'_, S>,
+    ) {
+        struct MessageVisitor(String);
+        impl tracing::field::Visit for MessageVisitor {
+            fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
+                if field.name() == "message" {
+                    self.0 = format!("{value:?}");
+                }
+            }
+        }
+        let mut visitor = MessageVisitor(String::new());
+        event.record(&mut visitor);
+        self.0
+            .lock()
+            .unwrap()
+            .push((*event.metadata().level(), visitor.0));
+    }
+}

--- a/crates/mcpls-core/src/transport.rs
+++ b/crates/mcpls-core/src/transport.rs
@@ -861,6 +861,7 @@ mod tests {
         use std::net::SocketAddr;
 
         use super::super::{HttpConfig, Transport};
+        use crate::test_lsp::CapturedLogs;
 
         #[test]
         fn test_http_config_fields() {
@@ -1433,37 +1434,6 @@ mod tests {
             server_task.abort();
         }
 
-        /// Captures `tracing` events emitted while a closure runs, since this
-        /// codebase has no existing `tracing_test`-style capture helper to
-        /// reuse (only `mcpls-cli/src/logging.rs` sets up a real/global
-        /// subscriber, which isn't suitable for assertions).
-        #[derive(Clone, Default)]
-        struct CapturedMessages(std::sync::Arc<std::sync::Mutex<Vec<String>>>);
-
-        impl<S: tracing::Subscriber> tracing_subscriber::Layer<S> for CapturedMessages {
-            fn on_event(
-                &self,
-                event: &tracing::Event<'_>,
-                _ctx: tracing_subscriber::layer::Context<'_, S>,
-            ) {
-                struct MessageVisitor(String);
-                impl tracing::field::Visit for MessageVisitor {
-                    fn record_debug(
-                        &mut self,
-                        field: &tracing::field::Field,
-                        value: &dyn std::fmt::Debug,
-                    ) {
-                        if field.name() == "message" {
-                            self.0 = format!("{value:?}");
-                        }
-                    }
-                }
-                let mut visitor = MessageVisitor(String::new());
-                event.record(&mut visitor);
-                self.0.lock().unwrap().push(visitor.0);
-            }
-        }
-
         /// #233: binding to a non-loopback address must log a warning that
         /// tells operators to put the endpoint behind a reverse proxy that
         /// *enforces* authentication (not the inverted "ensure no
@@ -1475,7 +1445,7 @@ mod tests {
             let addr: SocketAddr = "0.0.0.0:0".parse().unwrap();
             let cfg = HttpConfig::new(addr, "/mcp");
 
-            let captured = CapturedMessages::default();
+            let captured = CapturedLogs::default();
             let subscriber = tracing_subscriber::registry().with(captured.clone());
             let guard = tracing::subscriber::set_default(subscriber);
 
@@ -1490,7 +1460,7 @@ mod tests {
 
             drop(guard);
 
-            let messages = captured.0.lock().unwrap().clone();
+            let messages = captured.messages();
             assert!(
                 messages.iter().any(|m| m.contains(
                     "place this endpoint behind a reverse proxy that enforces authentication"


### PR DESCRIPTION
## Summary
- `message_loop_inner` logged every LSP JSON-RPC error response at `error!` unconditionally, before `LspClient::request`'s retry logic decided whether `-32802` (ServerCancelled) or an allowlisted `-32801` (ContentModified) would be retried. A request that was retried and then succeeded still emitted a spurious ERROR line, causing false-positive alerts in log-based monitoring.
- The severity decision now lives in `request()`, the only place that knows whether a retry will follow: `warn!` on each retry attempt, `error!` only on retry exhaustion or a non-retryable error/method. All caller-visible `error!` lines share one consistent `"LSP error response: ..."` prefix, so log-grep monitoring keeps working for exhaustion cases too.
- Promoted the level-aware tracing capture test helper into the shared `test_lsp` module, replacing three message-only duplicates in `transport.rs`, `lib.rs`, and `bridge/notifications.rs`.

Closes #392

## Test plan
- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features --workspace -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --lib --bins` (798 passed, 1 skipped)
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`
- [x] New regression tests: retried-and-recovered error does not log ERROR; retry exhaustion logs exactly one ERROR sharing the shared prefix; non-retryable error still logs ERROR on first attempt