### PR TITLE
release: v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-09-06
+
 ### Added
 
 - `specs/constitution.md` documenting project-wide principles for the SDD spec package; resolves the `[[constitution]]` wikilink dangling across all specs. (#394)
@@ -21,16 +23,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`McpConfig`** — Breaking change: gained a `tool_prefix` field; exhaustive struct-literal construction of `McpConfig` no longer compiles. (#377)
 - Relocated the SDD spec package from `.local/specs/` to repo-root `specs/`, reorganized into functional blocks (config/lsp/mcp/bridge/runtime/testing) with block-scoped numbering, and added retroactive specs for previously undocumented core subsystems (position encoding, config discovery, LSP lifecycle, document tracker sync, MCP tool routing). (#368)
 - **`DocumentTracker::update`** — Breaking change: now `async`, serializing against `ensure_open` for the same path. (#363)
-- Bump rmcp from 3.1.4 to 3.2.0; an `initialize` request naming `protocolVersion: 2026-07-28` now receives the server's negotiated legacy version in response instead of an echo of the requested version (rmcp behavior change) (#364)
-- Reorder `mcpls-core` `Cargo.toml` dependencies into alphabetical order (#364)
-- **`ToolKind`/`NoServerReason`** — Breaking change: both marked `#[non_exhaustive]`; `ToolKind::ALL` is now `&[ToolKind]` instead of a fixed-size array. (#366)
-- **`WorkspaceConfig::get_language_for_extension`** — Breaking change: renamed to `language_for_extension`. (#366)
+- Bump rmcp from 3.1.4 to 3.2.0 (an `initialize` request naming `protocolVersion: 2026-07-28` now receives the server's negotiated legacy version in response instead of an echo of the requested version — rmcp behavior change) and reorder `mcpls-core` `Cargo.toml` dependencies into alphabetical order. (#364)
+- **`ToolKind`/`NoServerReason`** — Breaking change: both marked `#[non_exhaustive]`; `ToolKind::ALL` is now `&[ToolKind]` instead of a fixed-size array. **`WorkspaceConfig::get_language_for_extension`** — Breaking change: renamed to `language_for_extension`. (#366)
 - **`Translator::handle_*` position-based methods** — Breaking change: now take a `Position { line, character }` struct instead of two adjacent bare `u32` arguments, so a call site can no longer swap `line`/`character` without a compile error. (#367)
-- Replace unmaintained `lsp-types` (gluon-lang) dependency with `gen-lsp-types` 0.11.0 (pinned); `lsp_types::` import paths are unchanged. (#375)
-- **`Uri` parsing** — Breaking change: `Uri` no longer validates its input, so a malformed MCP-supplied URI in `get_incoming_calls`/`get_outgoing_calls` now surfaces as a file-not-found error instead of an invalid-parameter error. (#375)
-- **`search_workspace_symbols`**/**`rename_symbol`** — Breaking change: symbols without a location range are now dropped instead of given a fabricated placeholder range, and LSP-3.18 snippet-shaped rename edits are now dropped instead of their literal placeholder syntax (e.g. `${1:name}`) being written into the file. (#375)
-- `workspace/symbol` `kind_filter` validation now derives its accepted names from `SUPPORTED_SYMBOL_KINDS`, the same single source of truth used by the `initialize` handshake, instead of a separately hand-maintained string list. (#383)
-- Replaced the hand-rolled `DiagnosticRequestParams` workaround with upstream `lsp_types::DocumentDiagnosticParams` directly; wire format is unchanged. (#383)
+- Replace unmaintained `lsp-types` (gluon-lang) dependency with `gen-lsp-types` 0.11.0 (pinned); `lsp_types::` import paths are unchanged. **`Uri` parsing** — Breaking change: `Uri` no longer validates its input, so a malformed MCP-supplied URI in `get_incoming_calls`/`get_outgoing_calls` now surfaces as a file-not-found error instead of an invalid-parameter error. **`search_workspace_symbols`**/**`rename_symbol`** — Breaking change: symbols without a location range are now dropped instead of given a fabricated placeholder range, and LSP-3.18 snippet-shaped rename edits are now dropped instead of their literal placeholder syntax (e.g. `${1:name}`) being written into the file. (#375)
+- `workspace/symbol` `kind_filter` validation now derives its accepted names from `SUPPORTED_SYMBOL_KINDS`, the same single source of truth used by the `initialize` handshake, instead of a separately hand-maintained string list. Replaced the hand-rolled `DiagnosticRequestParams` workaround with upstream `lsp_types::DocumentDiagnosticParams` directly; wire format is unchanged. (#383)
 - Consolidated the duplicated `handle_definition`/`handle_implementation`/`handle_type_definition` go-to-X handlers and their response-flattening helpers in `bridge::translator::navigation` behind a shared generic path; behavior is unchanged. (#386)
 - **`NotificationCache::get_diagnostics`/`Translator::get_client_for_file` renamed to `diagnostics`/`client_for_file`** — Breaking change: drops the redundant `get_` prefix per Rust API guidelines C-GETTER, revisiting a previous entry in this changelog (#293) that had left `get_diagnostics` unchanged as a keyed lookup rather than a plain accessor. (#387)
 - **`LspTransport::new`** — now accepts any `AsyncWrite`/`AsyncRead` pair instead of only `ChildStdin`/`ChildStdout` (source-compatible for every existing caller), so tests can wire it to an in-memory `tokio::io::duplex` pipe instead of a real subprocess; `LspTransport`'s `Debug` output changed from a derived field dump to a fixed `LspTransport { .. }`. (#396)
@@ -45,14 +42,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - E2E test harness (`McpClient::spawn_with_args`) now honors `CARGO_TARGET_DIR`/`CARGO_BUILD_TARGET_DIR` when locating the built `mcpls` binary, instead of hardcoding `target/debug/mcpls`; spawn failures now report the resolved path. (#400)
-- Retried transient LSP errors (`-32802` `ServerCancelled`, allowlisted `-32801` `ContentModified`) no longer log at `error!` before the retry succeeds, avoiding false-positive alerts in log-based monitoring; `error!` is now reserved for errors actually surfaced to the caller. (#392)
+- Retried transient LSP errors (`-32802` `ServerCancelled`, allowlisted `-32801` `ContentModified`) no longer log at `error!` before the retry succeeds, avoiding false-positive alerts in log-based monitoring; `error!` is now reserved for errors actually surfaced to the caller. (#401)
 - LSP `-32801` (`ContentModified`) error responses are now retried automatically for read-only/idempotent tool calls (hover, references, diagnostics, etc.), using the same attempt budget and backoff already applied to `-32802` (`ServerCancelled`); mutating requests (rename, formatting, code actions) are excluded. Also corrected a doc comment that mislabeled `-32802` as "content modified". (#390)
-- `NotificationCache` now derives the diagnostics cache fair-share budget automatically from the number of publishing servers when `set_diagnostics_route_count` is never called, instead of silently defaulting to an unpartitioned budget. (#379)
-- Cache eviction now prefers evicting empty ("file is clean") diagnostics entries over real ones, including across servers sharing the same eviction victim, so a stream of clean-file notifications can no longer displace actual diagnostics from the cache. (#379)
+- `NotificationCache` now derives the diagnostics cache fair-share budget automatically from the number of publishing servers when `set_diagnostics_route_count` is never called, instead of silently defaulting to an unpartitioned budget. Cache eviction now prefers evicting empty ("file is clean") diagnostics entries over real ones, including across servers sharing the same eviction victim, so a stream of clean-file notifications can no longer displace actual diagnostics from the cache. (#379)
 - Diagnostics push notifications no longer silently vanish after an LSP server respawn; `get_cached_diagnostics`/resource reads now flag when they're degraded. (#363)
-- `document_symbols` no longer redundantly recomputes the same range twice for flat (`SymbolInformation`) responses. (#365)
-- HTTP transport now catches a repeat shutdown signal received during the connection-drain window and cuts the drain short instead of waiting out the full timeout. (#365)
-- Corrected a broken assertion in the ignored `test_diagnostics_with_error` integration test (test-only; no production behavior change). (#365)
+- `document_symbols` no longer redundantly recomputes the same range twice for flat (`SymbolInformation`) responses. HTTP transport now catches a repeat shutdown signal received during the connection-drain window and cuts the drain short instead of waiting out the full timeout. Corrected a broken assertion in the ignored `test_diagnostics_with_error` integration test (test-only; no production behavior change). (#365)
 - Capped nextest concurrency for `fake_lsp_client()` subprocess-mock tests (`bridge::translator`, `bridge::state`, `lsp::client`, `lsp::lifecycle`) to reduce, though not eliminate, a rare 120s hard timeout / spurious test failure caused by OS process contention under full parallel load (test-only; no production behavior change). (#380)
 - Replaced the `cat`/`echo` subprocess loopback mock LSP transport, duplicated near-verbatim across `bridge::translator`, `bridge::state`, `lsp::client`, and `lsp::lifecycle`, with a single shared `tokio::io::duplex`-based harness (`crate::test_lsp`); `LspServer`'s test-only fixtures (`new_for_test`, `new_for_test_with_encoding`, `fake_lsp_server`) no longer spawn a placeholder child process either (`LspServer`'s internal `child` field is now `Option<tokio::process::Child>`), so no subprocess spawn remains anywhere in this mock path. The shared harness's `read_framed_message` also gained an EOF guard and a 30s read timeout, so a stuck or mismatched test fails fast with a clear panic instead of spinning until an external 120s test-runner kill. An initial version of this change (subprocess loopback removed, but the placeholder child spawn and the EOF/timeout guard still missing) reproduced the same 120s hang / spurious-assertion family the nextest cap was mitigating (3/25 uncapped, 1/25 capped full-suite stress runs) with a live-hang sample showing a lost wakeup/deadlock rather than spawn contention; after the placeholder-spawn removal and the read guard above, stress testing at up to 4x that sample size reproduced zero failures across 630 runs. Removed the `subprocess-mock-pipe` nextest test-group added in #380 accordingly — it was never addressing this flake's actual cause. (test-only; no production behavior change) (#396)
 
@@ -738,7 +732,8 @@ Add to `~/.claude/mcp.json`:
 - Workspace auto-discovery
 - LSP server auto-detection and installation
 
-[Unreleased]: https://github.com/bug-ops/mcpls/compare/v0.4.0...HEAD
+[Unreleased]: https://github.com/bug-ops/mcpls/compare/v0.5.0...HEAD
+[0.5.0]: https://github.com/bug-ops/mcpls/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/bug-ops/mcpls/compare/v0.3.9...v0.4.0
 [0.3.9]: https://github.com/bug-ops/mcpls/compare/v0.3.8...v0.3.9
 [0.3.8]: https://github.com/bug-ops/mcpls/compare/v0.3.7...v0.3.8

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -946,7 +946,7 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "mcpls"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -961,7 +961,7 @@ dependencies = [
 
 [[package]]
 name = "mcpls-core"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.0"
+version = "0.5.0"
 edition = "2024"
 rust-version = "1.88"
 authors = ["Andrei G. <k05h31@gmail.com>"]
@@ -26,7 +26,7 @@ dunce = "1.0.5"
 futures = "0.3"
 ignore = "0.4"
 lsp-types = { package = "gen-lsp-types", version = "=0.11.0" }
-mcpls-core = { path = "crates/mcpls-core", version = "0.4.0" }
+mcpls-core = { path = "crates/mcpls-core", version = "0.5.0" }
 predicates = "3.1"
 rmcp = "3.2.0"
 rstest = "0.26"

--- a/README.md
+++ b/README.md
@@ -148,6 +148,10 @@ Claude: [get_references] Found 4 matches:
 Names below are the defaults; if the bridge is configured with `mcp.tool_prefix`, every tool
 name gains that prefix (`{tool_prefix}_{tool}`).
 
+`get_diagnostics`, `get_definition`, `get_references`, and `get_document_symbols` also publish a
+structured `outputSchema`, so MCP clients that support structured tool output get typed
+`structuredContent` alongside the text response.
+
 <details>
 <summary><strong>Code Intelligence</strong></summary>
 

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -629,6 +629,20 @@ export MCPLS_LISTEN=127.0.0.1:3000
 mcpls
 ```
 
+> [!WARNING]
+> **Authentication requirement**: mcpls performs **no authentication** on any transport, including HTTP. When binding to a non-loopback address (e.g., `0.0.0.0:3000`), you **must** place mcpls behind a reverse proxy that enforces authentication before forwarding requests.
+>
+> The reverse proxy should also rewrite the `Host` header, as rmcp's host validation only allows `localhost`, `127.0.0.1`, or `::1` by default.
+>
+> **Example (nginx):**
+> ```nginx
+> location /mcp/ {
+>     auth_request /auth;
+>     proxy_pass http://localhost:3000;
+>     proxy_set_header Host localhost;
+> }
+> ```
+
 ### `MCPLS_HTTP_PATH` (transport-http feature)
 
 URL prefix the MCP service is mounted at.

--- a/specs/MOC-specs.md
+++ b/specs/MOC-specs.md
@@ -37,7 +37,7 @@ rather than one subsystem). Numbering restarts at 001 within each block.
 |---|------|------|----------|--------|-------|
 | 001 | [[bridge/001-position-encoding-layer/spec\|position-encoding-layer]] | enhancement | P1 | implemented (retroactive) | — |
 | 002 | [[bridge/002-document-tracker-synchronization/spec\|document-tracker-synchronization]] | enhancement | P1 | implemented (retroactive) | — |
-| 003 | [[bridge/003-rwlock-translator/spec\|rwlock-translator]] | enhancement | P2 | draft | #114 |
+| 003 | [[bridge/003-rwlock-translator/spec\|rwlock-translator]] | enhancement | P2 | superseded | #114 |
 | 004 | [[bridge/004-get-diagnostics-flycheck-gap/spec\|get-diagnostics-flycheck-gap]] | bug | P1 | draft | — |
 | 005 | [[bridge/005-expose-document-tracker-limits/spec\|expose-document-tracker-limits]] | enhancement | P2 | implemented (#324) | — |
 

--- a/specs/bridge/001-position-encoding-layer/spec.md
+++ b/specs/bridge/001-position-encoding-layer/spec.md
@@ -160,6 +160,7 @@ THEN the raw (unconverted) value is used as a fallback rather than erroring the 
 | `line_text` is `None` (file unreadable) | Falls back to the raw value (`test_mcp_to_lsp_position_missing_line_text_falls_back`) |
 | MCP position `(0, 0)` | Clamped to `(0, 0)` via `saturating_sub`, no underflow (`test_saturating_sub_zero`) |
 | CRLF-terminated source line | No column shift — `line_text` never includes the terminator (`test_mcp_to_lsp_position_utf8_negotiated_crlf_line_text`) |
+| rust-analyzer itself rejects a position as out-of-range (its own internal `"Invalid offset LineCol { .. }"` error, distinct from this module's own conversion fallbacks) | Sanitized to a clean `"position out of range for this document"` message by `Error::LspServerError`'s `Display` impl (`crates/mcpls-core/src/error.rs`, #399) before reaching the MCP caller — out of this module's scope (it never sees LSP server-reported errors), but worth cross-referencing since both concern "position out of range" |
 
 ## 7. Success Criteria
 

--- a/specs/bridge/003-rwlock-translator/spec.md
+++ b/specs/bridge/003-rwlock-translator/spec.md
@@ -9,7 +9,7 @@ tags:
   - bridge
   - concurrency
 created: 2026-08-01
-status: draft
+status: superseded
 related:
   - "[[constitution]]"
   - "[[bridge/001-position-encoding-layer/spec]]"
@@ -21,6 +21,22 @@ related:
 > [!info] Metadata
 > **Type**: enhancement
 > **Priority**: P2
+
+> [!warning] Superseded
+> The shipped design (since PR #326, `refactor(bridge): split translator.rs into submodules,
+> inject Clock seam`, well before v0.4.0) did not adopt either alternative proposed below. Instead,
+> `Translator` is now shared as a plain `Arc<Translator>` with no outer `Mutex`/`RwLock` at all —
+> every field that needs synchronization (`lsp_clients`, `lsp_servers`, `document_tracker`,
+> `router`, `respawn_locks`, etc.) carries its own independent lock, scoped to the narrowest
+> critical section that field actually needs (see the field-level doc comments in
+> `crates/mcpls-core/src/bridge/translator/mod.rs`). This achieves the same goal as FR-001/FR-002
+> (concurrent reads not serialized behind one global lock) more granularly than a single
+> `RwLock<Translator>` would, and sidesteps FR-005's deadlock concern entirely for most fields since
+> there is no single lock two call paths could acquire in conflicting order. `NotificationCache`
+> (FR-004) is likewise its own independently-locked structure, not nested inside `Translator`. The
+> `mcp/server.rs` tool count referenced in the Problem Statement below is also stale — the surface
+> is now 20 tools (see `specs/constitution.md`), not 16. Kept for historical context; do not use
+> this spec's FR/NFR table as a description of the current locking architecture.
 
 ## 1. Overview
 

--- a/specs/bridge/004-get-diagnostics-flycheck-gap/spec.md
+++ b/specs/bridge/004-get-diagnostics-flycheck-gap/spec.md
@@ -10,6 +10,7 @@ tags:
 created: 2026-07-25
 status: draft
 related:
+  - "[[constitution]]"
   - "[[MOC-specs]]"
   - "[[mcp/002-mcp-resources-diagnostics/spec]]"
 ---
@@ -191,6 +192,7 @@ No new entities. The fix operates on two existing shapes:
 
 ## 10. See Also
 
+- [[constitution]] — project principles
 - [[MOC-specs]] — all specifications
 - [[bridge/003-rwlock-translator/spec|Spec bridge/003]] — `NotificationCache` / `Translator` lock-ordering discipline this fix must respect
 - [[mcp/002-mcp-resources-diagnostics/spec|Spec mcp/002]] — the `NotificationCache` / `get_cached_diagnostics` / resources design this fix reuses

--- a/specs/bridge/005-expose-document-tracker-limits/spec.md
+++ b/specs/bridge/005-expose-document-tracker-limits/spec.md
@@ -42,6 +42,11 @@ related:
 > first time. Neither change was anticipated in Section 1 (Overview) or Section 8 (Agent
 > Boundaries, "Never: ... without explicit instruction") of this spec; they were bundled into the
 > same PR rather than filed separately.
+>
+> **Follow-up (#376)**: end-to-end and TOML parse-error test coverage for
+> `workspace.max_documents`/`max_file_size` was added, closing the remaining gap in SC-003; the
+> dead `mock_lsp` test module was also removed as part of the same PR (unrelated to this spec's
+> functional requirements).
 
 ## 1. Overview
 

--- a/specs/lsp/001-lsp-server-lifecycle-and-respawn/spec.md
+++ b/specs/lsp/001-lsp-server-lifecycle-and-respawn/spec.md
@@ -33,6 +33,14 @@ related:
 > request/response with retry), `crates/mcpls-core/src/lsp/transport.rs` (stdio framing), and
 > `crates/mcpls-core/src/bridge/translator/respawn.rs` (dead-server detection and
 > backoff-bounded respawn) already implement everything described below.
+>
+> **Post-v0.4.0 additions**: `-32801` (`ContentModified`) retry (FR-013) was extended to read-only/
+> idempotent tool calls under the same attempt budget as `-32802` (`ServerCancelled`) (#390); the
+> `warn!`/`error!` log-level split for retried-vs-surfaced errors (FR-014) was corrected so a
+> successful retry no longer logs a false-positive `error!` (#401). `LspTransport::new` also now
+> accepts any `AsyncWrite`/`AsyncRead` pair rather than only `ChildStdin`/`ChildStdout` (#396,
+> already reflected in `transport.rs`'s own doc comment cited above) — source-compatible for every
+> production caller, so no FR change was needed for it here.
 
 ## 1. Overview
 
@@ -168,6 +176,8 @@ THEN it sends `shutdown`+`exit`, waits up to a fixed grace period for the child 
 | FR-010 | WHEN the diagnostics-route server for a language is respawned THE SYSTEM SHALL mark that language's cached diagnostics as push-degraded (`NotificationCache::mark_push_degraded`) rather than silently continuing to serve stale cached diagnostics as current | must |
 | FR-011 | WHEN shutting down a server THE SYSTEM SHALL send the LSP `shutdown` request, then the `exit` notification, then wait up to a fixed grace period (3s) for the child process to exit on its own, falling back to `kill_on_drop` (SIGKILL on drop) if it does not | must |
 | FR-012 | THE SYSTEM SHALL perform the graceful-shutdown sequence (FR-011) even if the `shutdown`/`exit` handshake itself fails or times out — the child process must still be torn down (killed if necessary) regardless of handshake outcome | must |
+| FR-013 | WHEN an in-flight LSP request receives a `-32802` (`ServerCancelled`) response, or a `-32801` (`ContentModified`) response for a read-only/idempotent method THE SYSTEM SHALL retry it, sharing one combined attempt budget across both error codes (e.g. a request that hits `-32801` then `-32802` does not get separate budgets, only one shared one); mutating requests (rename, formatting, code actions) are excluded from the `-32801` retry allowlist | must |
+| FR-014 | WHEN a transient error (`-32802`/allowlisted `-32801`) is about to be retried THE SYSTEM SHALL log it at `warn!`, and reserve `error!` for the case where retries are exhausted and the error actually surfaces to the caller — a request that is retried and then succeeds must never log at `error!` | must |
 
 ## 4. Non-Functional Requirements
 
@@ -177,7 +187,7 @@ THEN it sends `shutdown`+`exit`, waits up to a fixed grace period for the child 
 | NFR-002 | Performance | A crash-looping server must not cost more than the bounded backoff window per tool call once backed off — never a repeated full `timeout_seconds` wait per call (FR-007) |
 | NFR-003 | Security | A spawned LSP server must not inherit mcpls's full process environment by default — only the explicit allowlist plus configured overrides (FR-001); configured `env` keys/values are never logged, only an allowlist-presence count and an override count (secret-bearing env var names like `AWS_SECRET_ACCESS_KEY` must not leak via debug logs) |
 | NFR-004 | Correctness | A respawned server must never be treated as having synced state (open documents) it never actually saw (FR-009) |
-| NFR-005 | Observability | A respawn (successful or failed), a crash-loop backoff, and a diagnostics-degradation event must each be logged (`tracing::warn!`) with enough context (server id, language, backoff duration) to diagnose from logs alone |
+| NFR-005 | Observability | A respawn (successful or failed), a crash-loop backoff, and a diagnostics-degradation event must each be logged (`tracing::warn!`) with enough context (server id, language, backoff duration) to diagnose from logs alone. `error!` is reserved for errors actually surfaced to the caller, never for a transient error that a retry (FR-013/FR-014) still has attempts left to recover from — a monitoring setup alerting on `error!` logs must not false-positive on a successful retry |
 
 ## 5. Data Model
 
@@ -203,6 +213,10 @@ THEN it sends `shutdown`+`exit`, waits up to a fixed grace period for the child 
 | Child does not exit within the grace period after `exit` | `kill_on_drop` (SIGKILL) fires when the `Child` handle drops |
 | A respawned server is the diagnostics-route server for its language | That language's cached diagnostics are marked push-degraded; a healthy sibling server's own language's diagnostics are unaffected (scoped by per-server ownership, not a blanket cache clear) |
 | A respawned server is *not* the diagnostics-route server | No diagnostics-cache side effect — only document-sync history (FR-009) is cleared |
+| A read-only request (hover, references, diagnostics, etc.) receives `-32801` (`ContentModified`) | Retried under the same attempt budget/backoff as `-32802`, per FR-013 |
+| A mutating request (rename, formatting, code actions) receives `-32801` (`ContentModified`) | Not retried — `-32801` retry is allowlisted to read-only/idempotent methods only |
+| A retried request eventually succeeds | Only `warn!` is logged for the retried attempt(s); no `error!` is logged (FR-014) |
+| A retried request exhausts its attempt budget | The final failure is logged at `error!`, since it is now surfaced to the caller (FR-014) |
 
 ## 7. Success Criteria
 

--- a/specs/lsp/002-lsp317-missing-tools/spec.md
+++ b/specs/lsp/002-lsp317-missing-tools/spec.md
@@ -10,6 +10,7 @@ tags:
 created: 2026-08-05
 status: implemented
 related:
+  - "[[constitution]]"
   - "[[testing/001-e2e-rust-analyzer-testing/spec]]"
   - "[[lsp/004-lsp-318-draft-gaps/spec]]"
 ---
@@ -85,6 +86,7 @@ requested by users of similar tools (see isaacphi/mcp-language-server issues).
 
 ## See Also
 
+- [[constitution]] — project principles
 - LSP 3.17 spec: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/
 - lsp-types 0.97: https://docs.rs/lsp-types/0.97.0/lsp_types/
 - Existing tool pattern: `crates/mcpls-core/src/mcp/server.rs`, `crates/mcpls-core/src/bridge/translator.rs`

--- a/specs/mcp/001-mcp-tool-surface-and-routing/spec.md
+++ b/specs/mcp/001-mcp-tool-surface-and-routing/spec.md
@@ -38,7 +38,7 @@ related:
 > This is a retroactive spec: `crates/mcpls-core/src/mcp/server.rs` (20 `#[tool]` handlers plus
 > the `resources/*` handlers), `crates/mcpls-core/src/mcp/tools.rs` (parameter schemas),
 > `crates/mcpls-core/src/config/routing.rs` (`ToolRouter`, `ServerId`, `ToolKind`), and
-> `crates/mcpls-core/src/bridge/translator/routing.rs` (`get_client_for_file`,
+> `crates/mcpls-core/src/bridge/translator/routing.rs` (`client_for_file`,
 > `resolve_client_for_file`, path validation) already implement everything described below.
 > [[mcp/002-mcp-resources-diagnostics/spec|spec mcp/002]] already covers the `resources/*` MCP surface in
 > detail; this spec covers the *tool* surface (the 20 `#[tool]` handlers) and the request-routing
@@ -152,6 +152,8 @@ THEN the request is rejected with the same PathOutsideWorkspace error regardless
 | FR-008 | THE SYSTEM SHALL map every bridge-layer `Result<T, Error>` to the MCP tool response shape via one shared function, so error formatting stays consistent across all 20 tool handlers | must |
 | FR-009 | THE SYSTEM SHALL classify all 20 tools as read-only (`ToolAnnotations`) at the router level, once, rather than repeating an identical annotation block on every `#[tool]` attribute, since every mcpls tool is a query or a proposed-edit generator that never itself writes to disk | must |
 | FR-010 | WHEN a tool call resolves to a server whose process has died THE SYSTEM SHALL attempt to respawn it (per [[lsp/001-lsp-server-lifecycle-and-respawn/spec|spec lsp/001]]) before the request is treated as failed | must |
+| FR-011 | THE SYSTEM SHALL advertise `outputSchema` and return `structuredContent` (via `to_structured_tool_result`/`Json<T>` handler signatures) for `get_diagnostics`, `get_definition`, `get_references`, and `get_document_symbols`, while every other tool continues to return a plain serialized-string response via `to_tool_result` | must |
+| FR-012 | WHEN the optional `[mcp].tool_prefix` config value is set THE SYSTEM SHALL prefix every tool's registered name with `{tool_prefix}_` at `build_tool_router` time, so a client can tell apart tools exposed by multiple concurrently running mcpls bridges; omitting it SHALL leave tool names unprefixed | must |
 
 ## 4. Non-Functional Requirements
 
@@ -166,11 +168,12 @@ THEN the request is rejected with the same PathOutsideWorkspace error regardless
 
 | Entity | Description | Key Attributes |
 |--------|-------------|-----------------|
-| `ToolKind` | Every routable MCP tool (excludes cache-only tools that never reach a specific server: `get_cached_diagnostics`, `get_server_logs`, `get_server_messages`) | 15 variants, `ALL: [Self; 15]`, `as_str()` snake_case name |
+| `ToolKind` | Every routable MCP tool (excludes cache-only tools that never reach a specific server: `get_cached_diagnostics`, `get_server_logs`, `get_server_messages`) | 15 variants, `#[non_exhaustive]`, `ALL: &[Self]` (slice, not a fixed-size array — #366), `as_str()` snake_case name |
 | `ServerId` | Unique routing identity of a configured server within a workspace | Wraps `String`; a server's explicit `name` if set, else its `language_id` |
 | `ToolRouter` | Resolves `(language, tool)` → `ServerId` | Built via `from_configs` (post-heuristics applicable configs), rebound via `rebind_to_registered` (post-spawn registered set) |
-| `NoServerReason` | Why `resolve_any` found no server for a workspace-wide tool | `NothingRegistered`, `NoClaimant` |
+| `NoServerReason` | Why `resolve_any` found no server for a workspace-wide tool | `NothingRegistered`, `NoClaimant`, `#[non_exhaustive]` (#366) |
 | `BridgeContext` (`mcp/handlers.rs`) | Shared state every `#[tool]` handler dispatches through | `translator`, `notification_cache`, `workspace_roots`, `subscriptions`, `project_config_ignored`, `mcp` (presentation overrides) |
+| `McpConfig` (`config/mod.rs`) | `[mcp]` TOML section carrying MCP-surface presentation/naming overrides | `title`, `description`, `instructions`, `tool_prefix: Option<ToolPrefix>` — `#[serde(deny_unknown_fields)]`, not `#[non_exhaustive]` (exhaustive struct-literal construction breaks whenever a field is added, e.g. `tool_prefix` in #377) |
 
 ## 6. Edge Cases and Error Handling
 
@@ -237,7 +240,10 @@ None — this is a retroactive spec documenting stable, already-shipped, well-te
   `declared_tool_router`
 - `crates/mcpls-core/src/mcp/tools.rs` — MCP tool parameter schemas
 - `crates/mcpls-core/src/mcp/handlers.rs` — `BridgeContext`
-- `crates/mcpls-core/src/config/routing.rs` — `ToolRouter`, `ServerId`, `ToolKind`,
-  `NoServerReason`
-- `crates/mcpls-core/src/bridge/translator/routing.rs` — `get_client_for_file`,
+- `crates/mcpls-core/src/config/routing.rs` — `ToolRouter`, `ServerId`, `ToolKind`
+  (`#[non_exhaustive]`), `NoServerReason` (`#[non_exhaustive]`)
+- `crates/mcpls-core/src/bridge/translator/routing.rs` — `client_for_file`,
   `resolve_client_for_file`, `validate_path_against_roots`
+- `crates/mcpls-core/src/config/mod.rs` — `McpConfig`, `ToolPrefix` (FR-012)
+- `to_tool_result`/`to_structured_tool_result` in `mcp/server.rs` — the plain-string vs.
+  structured (`outputSchema`/`structuredContent`) response-mapping split (FR-011)

--- a/specs/mcp/003-mcp-2026-stateless-adoption/spec.md
+++ b/specs/mcp/003-mcp-2026-stateless-adoption/spec.md
@@ -9,6 +9,7 @@ tags:
 created: 2026-08-05
 status: draft
 related:
+  - "[[constitution]]"
   - "[[MOC-specs]]"
 ---
 
@@ -34,7 +35,7 @@ every request must instead carry protocol version and client capabilities via
 `_meta` fields.
 
 mcpls's MCP server surface (`crates/mcpls-core/src/mcp/`, built on the `rmcp`
-crate, currently pinned to `rmcp = "3.0.0"` in the workspace
+crate, currently pinned to `rmcp = "3.2.0"` in the workspace
 `Cargo.toml`) implements `get_info()` / `ServerCapabilities` on top of rmcp's
 current stateful `initialize` model. If the removal of `initialize` becomes a
 hard protocol requirement, mcpls's MCP-facing capability negotiation surface
@@ -60,6 +61,17 @@ phased, Tier-based rollout, not a finished implementation. mcpls therefore
 cannot adopt the new model yet; this spec exists to **track** the change and
 define what mcpls will need to do once `rmcp` reaches conformance, not to
 implement it now.
+
+mcpls bumped `rmcp` again, to 3.2.0 (PR #364; see
+[[mcp/004-mcp-tasks-sep2663-adoption/spec|spec mcp/004]] for a separate Tasks-primitive
+audit against this same version). That bump surfaced one more observable data point for
+FR-001: an `initialize` request naming
+`protocolVersion: 2026-07-28` now receives rmcp's negotiated *legacy* version in the
+response instead of an echo of the requested version, whereas 3.1.4 echoed it back
+unchanged. This is still `initialize`-based negotiation, not the stateless per-request
+`_meta` model this spec tracks — it does not change this spec's "not yet safe to adopt"
+conclusion, but it is worth noting as incremental upstream movement the next FR-001
+re-review should account for.
 
 ### Goal
 
@@ -166,7 +178,7 @@ that mcpls's MCP layer will eventually need to represent:
 |----------|-------------------|
 | `rmcp` ships a version that supports 2026-07-28 as opt-in alongside legacy `initialize` | mcpls should stay on the legacy path until this spec is revisited and superseded by an implementation spec |
 | `rmcp` ships a version that drops legacy `initialize` support entirely (breaking) | mcpls's `Cargo.toml` `rmcp` version pin acts as the safety net — do not bump past that version until the migration described here is actually implemented |
-| A future MCP client sends 2026-07-28-style per-request `_meta` fields to a pre-migration mcpls server | Current `rmcp = "3.0.0"`-based server does not understand these fields; behavior depends on `rmcp`'s own backward-compatibility handling, not mcpls code — `[NEEDS CLARIFICATION: does rmcp 3.0.0 reject or silently ignore unrecognized _meta fields from newer clients?]` |
+| A future MCP client sends 2026-07-28-style per-request `_meta` fields to a pre-migration mcpls server | Current `rmcp = "3.2.0"`-based server does not understand these fields; behavior depends on `rmcp`'s own backward-compatibility handling, not mcpls code — `[NEEDS CLARIFICATION: does rmcp 3.2.0 reject or silently ignore unrecognized _meta fields from newer clients?]` |
 | Position-encoding negotiation (`bc95b89`, LSP-side) is mistaken for MCP-side handshake work in a future PR | Reviewers should point to this spec's Overview callout distinguishing the two handshakes |
 
 ## 7. Success Criteria
@@ -199,15 +211,17 @@ that mcpls's MCP layer will eventually need to represent:
 
 - [NEEDS CLARIFICATION: What is mcpls's actual timeline trigger for revisiting this — a specific `rmcp` version, a calendar date, or "when issue #119/#122 work resumes"?]
 - [NEEDS CLARIFICATION: Does mcpls currently use MCP Roots or Logging features (`crates/mcpls-core/src/mcp/`), which are formally deprecated in 2026-07-28 with a 12-month window?]
-- [NEEDS CLARIFICATION: Does `rmcp` 3.0.0 (mcpls's current pin) reject or silently ignore unrecognized 2026-07-28-style `_meta` fields sent by a forward-compatible client?]
+- [NEEDS CLARIFICATION: Does `rmcp` 3.2.0 (mcpls's current pin) reject or silently ignore unrecognized 2026-07-28-style `_meta` fields sent by a forward-compatible client?]
 - [NEEDS CLARIFICATION: Should this spec be re-filed as a GitHub issue (P3, `research` label) per the project's issue-filing protocol, or does the spec artifact alone satisfy tracking for now?]
 
 ## 10. See Also
 
+- [[constitution]] — project principles
 - [[MOC-specs]] — all specifications
 - [MCP Specification 2026-07-28 changelog](https://modelcontextprotocol.io/specification/2026-07-28/changelog)
 - [MCP 2026-07-28 release candidate announcement](https://blog.modelcontextprotocol.io/posts/2026-07-28-release-candidate/)
 - [rmcp v3.1.0 release notes](https://github.com/modelcontextprotocol/rust-sdk/releases/tag/rmcp-v3.1.0)
+- [rmcp v3.2.0 release notes](https://github.com/modelcontextprotocol/rust-sdk/releases/tag/rmcp-v3.2.0) — mcpls's current pin (PR #364); see the `initialize` `protocolVersion` negotiation-echo change noted above
 - [MCP Specification 2025-11-25](https://modelcontextprotocol.io/specification/2025-11-25/) — mcpls's current cited reference in `.claude/rules/continuous-improvement.md`, superseded by 2026-07-28 above
 - [GitHub issue bug-ops/mcpls#119](https://github.com/bug-ops/mcpls/issues/119) — "support MCP 2025-11-25 tasks/call" (P4), directly affected by the Tasks extension redesign in 2026-07-28
 - [GitHub issue bug-ops/mcpls#122](https://github.com/bug-ops/mcpls/issues/122) — competitive-parity playbook / Streamable HTTP transport, affected by session-header removal in 2026-07-28


### PR DESCRIPTION
## Summary

- Bump version from 0.4.0 to 0.5.0 across the workspace
- Consolidate CHANGELOG.md `[Unreleased]` entries into the `[0.5.0]` section, merging duplicate per-PR bullets and correcting a stale PR reference (#392 -> #401)
- Update specs/ to reflect code shipped since v0.4.0 (structured tool output, tool_prefix, ContentModified retry, LspTransport signature, non_exhaustive enums, rmcp 3.2.0), fix missing constitution wikilinks, mark bridge/003 as superseded
- Document the HTTP transport authentication gap in docs/user-guide/configuration.md
- Note structured tool output for 4 MCP tools in README.md

## Checklist

- [x] Version updated in all manifests (workspace.package.version + internal mcpls-core dependency version)
- [x] CHANGELOG.md has release section with date
- [x] README reflects new version
- [x] All CI checks pass locally (fmt, clippy, nextest, rustdoc)
- [ ] Ready for tagging after merge