### PR TITLE
fix(lsp): omit params on shutdown and exit instead of sending null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `shutdown` and `exit` are now sent without a `params` key instead of `"params": null`. tsgo rejects the null form with `-32602 expected empty, got: null` and never exits, so every mcpls shutdown against tsgo fell through to the 3s kill-on-timeout path. (#PRNUM)
+
 ## [0.5.0] - 2026-09-06
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- `shutdown` and `exit` are now sent without a `params` key instead of `"params": null`. tsgo rejects the null form with `-32602 expected empty, got: null` and never exits, so every mcpls shutdown against tsgo fell through to the 3s kill-on-timeout path. (#PRNUM)
+- `shutdown` and `exit` are now sent without a `params` key instead of `"params": null`. tsgo rejects the null form with `-32602 expected empty, got: null` and never exits, so every mcpls shutdown against tsgo fell through to the 3s kill-on-timeout path. (#404)
 
 ## [0.5.0] - 2026-09-06
 

--- a/crates/mcpls-core/src/lsp/client.rs
+++ b/crates/mcpls-core/src/lsp/client.rs
@@ -17,7 +17,8 @@ use crate::config::LspServerConfig;
 use crate::error::{Error, Result};
 use crate::lsp::transport::LspTransport;
 use crate::lsp::types::{
-    InboundMessage, JsonRpcError, JsonRpcRequest, JsonRpcResponse, LspNotification, RequestId,
+    InboundMessage, JsonRpcError, JsonRpcNotification, JsonRpcRequest, JsonRpcResponse,
+    LspNotification, RequestId,
 };
 
 /// JSON-RPC protocol version.
@@ -383,7 +384,7 @@ impl LspClient {
         P: Serialize,
         R: DeserializeOwned,
     {
-        let params_value = serde_json::to_value(params)?;
+        let params_value = Self::omit_null_params(serde_json::to_value(params)?);
         let mut delay_ms = SERVER_CANCELLED_INITIAL_DELAY_MS;
 
         for attempt in 0..=SERVER_CANCELLED_MAX_RETRIES {
@@ -402,7 +403,7 @@ impl LspClient {
                 jsonrpc: JSONRPC_VERSION.to_string(),
                 id: id.clone(),
                 method: method.to_string(),
-                params: Some(params_value.clone()),
+                params: params_value.clone(),
             };
 
             debug!("Sending request: {} (id={:?})", method, id);
@@ -559,14 +560,14 @@ impl LspClient {
     where
         P: Serialize,
     {
-        let params_value = serde_json::to_value(params)?;
+        let params_value = Self::omit_null_params(serde_json::to_value(params)?);
 
         debug!("Sending notification: {}", method);
 
         self.command_tx
             .send(ClientCommand::SendNotification {
                 method: method.to_string(),
-                params: Some(params_value),
+                params: params_value,
             })
             .await
             .map_err(|_| Error::ServerTerminated)?;
@@ -624,6 +625,13 @@ impl LspClient {
         result
     }
 
+    /// Maps a `null` params value to an omitted `params` field. LSP methods
+    /// with `params: void` (`shutdown`, `exit`) must go out without the key:
+    /// tsgo rejects `"params": null` with `-32602 expected empty, got: null`.
+    fn omit_null_params(params: Value) -> Option<Value> {
+        if params.is_null() { None } else { Some(params) }
+    }
+
     /// Truncate an LSP server's error message for the `tracing::error!` log
     /// line, bounding it to at most [`MAX_ERROR_MESSAGE_LOG_BYTES`] bytes
     /// (the full formatted string is slightly longer).
@@ -655,11 +663,11 @@ impl LspClient {
                             transport.send(&value).await?;
                         }
                         ClientCommand::SendNotification { method, params } => {
-                            let notification = serde_json::json!({
-                                "jsonrpc": "2.0",
-                                "method": method,
-                                "params": params,
-                            });
+                            let notification = serde_json::to_value(JsonRpcNotification {
+                                jsonrpc: JSONRPC_VERSION.to_string(),
+                                method,
+                                params,
+                            })?;
                             transport.send(&notification).await?;
                         }
                         ClientCommand::Shutdown => {
@@ -1233,6 +1241,76 @@ mod tests {
         assert!(LspClient::should_retrigger(Some(&serde_json::json!({
             "retriggerRequest": true
         }))));
+    }
+
+    /// Wire-level checks that `params: void` LSP methods go out without a
+    /// `params` key. tsgo rejects `"params": null` on `shutdown` with
+    /// `-32602 expected empty, got: null` and then ignores the `exit` that
+    /// follows, so mcpls fell through to the kill-on-timeout path.
+    mod void_params_wire {
+        use tokio::io::BufReader;
+
+        use super::*;
+        use crate::test_lsp::{fake_lsp_client, read_framed_message, write_response};
+
+        #[tokio::test]
+        async fn test_request_with_null_params_omits_params_key() {
+            let (client, mut server) = fake_lsp_client();
+
+            let request_task = tokio::spawn(async move {
+                client
+                    .request::<_, Value>("shutdown", Value::Null, Duration::from_secs(5))
+                    .await
+            });
+
+            let mut reader = BufReader::new(&mut server.write_stdout);
+            let request = read_framed_message(&mut reader).await;
+
+            assert_eq!(request["method"], "shutdown");
+            assert!(
+                request.get("params").is_none(),
+                "null params must be omitted, got: {request}"
+            );
+
+            write_response(&mut server.read_half_stdin, &request["id"], Value::Null).await;
+            request_task.await.unwrap().unwrap();
+        }
+
+        #[tokio::test]
+        async fn test_notify_with_null_params_omits_params_key() {
+            let (client, mut server) = fake_lsp_client();
+
+            client.notify("exit", Value::Null).await.unwrap();
+
+            let mut reader = BufReader::new(&mut server.write_stdout);
+            let notification = read_framed_message(&mut reader).await;
+
+            assert_eq!(notification["method"], "exit");
+            assert!(
+                notification.get("params").is_none(),
+                "null params must be omitted, got: {notification}"
+            );
+        }
+
+        #[tokio::test]
+        async fn test_notify_with_empty_object_params_keeps_params_key() {
+            let (client, mut server) = fake_lsp_client();
+
+            client
+                .notify("initialized", lsp_types::InitializedParams {})
+                .await
+                .unwrap();
+
+            let mut reader = BufReader::new(&mut server.write_stdout);
+            let notification = read_framed_message(&mut reader).await;
+
+            assert_eq!(notification["method"], "initialized");
+            assert_eq!(
+                notification["params"],
+                serde_json::json!({}),
+                "non-null params must still be sent"
+            );
+        }
     }
 
     mod retry_behavior {


### PR DESCRIPTION
## Problem

Every mcpls shutdown against tsgo waits the full 3s `CHILD_EXIT_GRACE` and kills the child. Closes #403.

## Root cause

`LspClient::request`/`notify` always emit `Some(params)`, so the `Value::Null` passed by `LspServer::shutdown` serializes as `"params": null`. tsgo rejects that on `shutdown` with `-32602 expected empty, got: null` and ignores the following `exit`.

## Fix

`request` and `notify` map `Value::Null` to `None`; the notification send path now serializes through `JsonRpcNotification` so `skip_serializing_if` drops the key. Non-null params are unchanged. Fixed in the client rather than the two call sites so any future `params: void` method is covered. Changelog entry under Unreleased.

## Validation

- `cargo +nightly fmt --check`
- `cargo clippy --all-targets --all-features --workspace -- -D warnings` (stable 1.98.1)
- `cargo nextest run --workspace`: 812 passed
- New tests in `client.rs::tests::void_params_wire`: request with null params omits the key, notify with null params omits the key, notify with `{}` params keeps it
- Live: release build against tsgo 7.0.0-dev.20260611.2, `shutdown` returns `result: null` and the child exits in under 10ms with `LSP server shut down successfully`, versus the 3s kill fallback on v0.5.0
